### PR TITLE
[BE] 페이징 요청의 크기가 최대 제한 크기를 넘어갔을 때 예외를 발생시키는 기능 추가

### DIFF
--- a/backend/src/main/java/com/woowacourse/f12/config/CustomPageableHandlerArgumentResolver.java
+++ b/backend/src/main/java/com/woowacourse/f12/config/CustomPageableHandlerArgumentResolver.java
@@ -1,0 +1,29 @@
+package com.woowacourse.f12.config;
+
+import com.woowacourse.f12.exception.InvalidPageSizeException;
+import org.springframework.core.MethodParameter;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+public class CustomPageableHandlerArgumentResolver extends PageableHandlerMethodArgumentResolver {
+
+    private static final int MAX_SIZE = 150;
+
+    @Override
+    public boolean supportsParameter(final MethodParameter parameter) {
+        return super.supportsParameter(parameter);
+    }
+
+    @Override
+    public Pageable resolveArgument(final MethodParameter methodParameter, final ModelAndViewContainer mavContainer,
+                                    final NativeWebRequest webRequest, final WebDataBinderFactory binderFactory) {
+        final int size = Integer.parseInt(webRequest.getParameter("size"));
+        if (size > MAX_SIZE) {
+            throw new InvalidPageSizeException(MAX_SIZE);
+        }
+        return super.resolveArgument(methodParameter, mavContainer, webRequest, binderFactory);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/config/WebConfig.java
+++ b/backend/src/main/java/com/woowacourse/f12/config/WebConfig.java
@@ -1,0 +1,17 @@
+package com.woowacourse.f12.config;
+
+import java.util.List;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addArgumentResolvers(final List<HandlerMethodArgumentResolver> resolvers) {
+        CustomPageableHandlerArgumentResolver customPageableHandlerArgumentResolver = new CustomPageableHandlerArgumentResolver();
+        customPageableHandlerArgumentResolver.setMaxPageSize(150);
+        resolvers.add(customPageableHandlerArgumentResolver);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/config/WebConfig.java
+++ b/backend/src/main/java/com/woowacourse/f12/config/WebConfig.java
@@ -1,5 +1,6 @@
 package com.woowacourse.f12.config;
 
+import com.woowacourse.f12.presentation.CustomPageableHandlerArgumentResolver;
 import java.util.List;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;

--- a/backend/src/main/java/com/woowacourse/f12/exception/InvalidPageSizeException.java
+++ b/backend/src/main/java/com/woowacourse/f12/exception/InvalidPageSizeException.java
@@ -1,0 +1,8 @@
+package com.woowacourse.f12.exception;
+
+public class InvalidPageSizeException extends IllegalArgumentException {
+
+    public InvalidPageSizeException(int maxSize) {
+        super("페이지의 크기는" + maxSize + "이하여야 합니다.");
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/presentation/CustomPageableHandlerArgumentResolver.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/CustomPageableHandlerArgumentResolver.java
@@ -1,4 +1,4 @@
-package com.woowacourse.f12.config;
+package com.woowacourse.f12.presentation;
 
 import com.woowacourse.f12.exception.InvalidPageSizeException;
 import org.springframework.core.MethodParameter;


### PR DESCRIPTION
# issue: closed #14 

# 작업 내용
- PageableHandlerMethodArgumentResolver 를 상속 받아 페이징 요청 크기가 최대 제한 크기를 넘어가면 예외를 발생시켰다.
