### PR TITLE
[BE] 키보드 목록을 페이징하여 조회한다.

### DIFF
--- a/backend/src/main/java/com/woowacourse/f12/application/KeyboardService.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/KeyboardService.java
@@ -2,8 +2,10 @@ package com.woowacourse.f12.application;
 
 import com.woowacourse.f12.domain.Keyboard;
 import com.woowacourse.f12.domain.KeyboardRepository;
+import com.woowacourse.f12.dto.response.KeyboardPageResponse;
 import com.woowacourse.f12.dto.response.KeyboardResponse;
 import com.woowacourse.f12.exception.KeyboardNotFoundException;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,5 +23,9 @@ public class KeyboardService {
         final Keyboard keyboard = keyboardRepository.findById(id)
                 .orElseThrow(KeyboardNotFoundException::new);
         return KeyboardResponse.from(keyboard);
+    }
+
+    public KeyboardPageResponse findPage(final Pageable pageable) {
+        return KeyboardPageResponse.from(keyboardRepository.findPageBy(pageable));
     }
 }

--- a/backend/src/main/java/com/woowacourse/f12/domain/Keyboard.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/Keyboard.java
@@ -26,8 +26,8 @@ public class Keyboard {
     @Formula("(SELECT COUNT(1) FROM review r WHERE r.product_id = id)")
     private int reviewCount;
 
-    @Formula("(SELECT AVG(r.rating) FROM review r WHERE r.product_id = id)")
-    private Double rating;
+    @Formula("(SELECT IFNULL(AVG(r.rating), 0) FROM review r WHERE r.product_id = id)")
+    private double rating;
 
     protected Keyboard() {
     }

--- a/backend/src/main/java/com/woowacourse/f12/domain/Keyboard.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/Keyboard.java
@@ -9,6 +9,7 @@ import javax.persistence.Id;
 import javax.persistence.Table;
 import lombok.Builder;
 import lombok.Getter;
+import org.hibernate.annotations.Formula;
 
 @Entity
 @Table(name = "keyboard")
@@ -21,6 +22,12 @@ public class Keyboard {
 
     @Column(name = "name")
     private String name;
+
+    @Formula("(SELECT COUNT(1) FROM review r WHERE r.product_id = id)")
+    private int reviewCount;
+
+    @Formula("(SELECT AVG(r.rating) FROM review r WHERE r.product_id = id)")
+    private double rating;
 
     protected Keyboard() {
     }

--- a/backend/src/main/java/com/woowacourse/f12/domain/Keyboard.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/Keyboard.java
@@ -27,7 +27,7 @@ public class Keyboard {
     private int reviewCount;
 
     @Formula("(SELECT AVG(r.rating) FROM review r WHERE r.product_id = id)")
-    private double rating;
+    private Double rating;
 
     protected Keyboard() {
     }

--- a/backend/src/main/java/com/woowacourse/f12/domain/KeyboardRepository.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/KeyboardRepository.java
@@ -1,7 +1,10 @@
 package com.woowacourse.f12.domain;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface KeyboardRepository extends JpaRepository<Keyboard, Long> {
 
+    Slice<Keyboard> findPageBy(Pageable pageable);
 }

--- a/backend/src/main/java/com/woowacourse/f12/dto/response/KeyboardPageResponse.java
+++ b/backend/src/main/java/com/woowacourse/f12/dto/response/KeyboardPageResponse.java
@@ -1,0 +1,31 @@
+package com.woowacourse.f12.dto.response;
+
+import com.woowacourse.f12.domain.Keyboard;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.Getter;
+import org.springframework.data.domain.Slice;
+
+@Getter
+public class KeyboardPageResponse {
+
+    private boolean hasNext;
+    private List<KeyboardResponse> keyboards;
+
+    private KeyboardPageResponse() {
+    }
+
+    private KeyboardPageResponse(final boolean hasNext,
+                                 final List<KeyboardResponse> keyboards) {
+        this.hasNext = hasNext;
+        this.keyboards = keyboards;
+    }
+
+    public static KeyboardPageResponse from(final Slice<Keyboard> slice) {
+        final List<KeyboardResponse> keyboards = slice.getContent()
+                .stream()
+                .map(KeyboardResponse::from)
+                .collect(Collectors.toList());
+        return new KeyboardPageResponse(slice.hasNext(), keyboards);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/dto/response/KeyboardResponse.java
+++ b/backend/src/main/java/com/woowacourse/f12/dto/response/KeyboardResponse.java
@@ -8,16 +8,25 @@ public class KeyboardResponse {
 
     private Long id;
     private String name;
+    private int reviewCount;
+    private double rating;
 
     private KeyboardResponse() {
     }
 
-    private KeyboardResponse(final Long id, final String name) {
+    private KeyboardResponse(final Long id, final String name, final int reviewCount, final double rating) {
         this.id = id;
         this.name = name;
+        this.reviewCount = reviewCount;
+        this.rating = rating;
     }
 
     public static KeyboardResponse from(final Keyboard keyboard) {
-        return new KeyboardResponse(keyboard.getId(), keyboard.getName());
+        return new KeyboardResponse(
+                keyboard.getId(),
+                keyboard.getName(),
+                keyboard.getReviewCount(),
+                keyboard.getRating()
+        );
     }
 }

--- a/backend/src/main/java/com/woowacourse/f12/presentation/KeyboardController.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/KeyboardController.java
@@ -1,7 +1,9 @@
 package com.woowacourse.f12.presentation;
 
 import com.woowacourse.f12.application.KeyboardService;
+import com.woowacourse.f12.dto.response.KeyboardPageResponse;
 import com.woowacourse.f12.dto.response.KeyboardResponse;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -16,6 +18,11 @@ public class KeyboardController {
 
     public KeyboardController(final KeyboardService keyboardService) {
         this.keyboardService = keyboardService;
+    }
+
+    @GetMapping
+    public ResponseEntity<KeyboardPageResponse> showPage(final Pageable pageable) {
+        return ResponseEntity.ok().body(keyboardService.findPage(pageable));
     }
 
     @GetMapping("/{id}")

--- a/backend/src/test/java/com/woowacourse/f12/acceptance/KeyboardAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/acceptance/KeyboardAcceptanceTest.java
@@ -1,11 +1,14 @@
 package com.woowacourse.f12.acceptance;
 
 import static com.woowacourse.f12.acceptance.support.RestAssuredRequestUtil.GET_요청을_보낸다;
+import static com.woowacourse.f12.acceptance.support.RestAssuredRequestUtil.POST_요청을_보낸다;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.woowacourse.f12.domain.Keyboard;
 import com.woowacourse.f12.domain.KeyboardRepository;
+import com.woowacourse.f12.dto.request.ReviewRequest;
+import com.woowacourse.f12.dto.response.KeyboardPageResponse;
 import com.woowacourse.f12.dto.response.KeyboardResponse;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
@@ -21,7 +24,7 @@ class KeyboardAcceptanceTest extends AcceptanceTest {
     @Test
     void 키보드_단일_제품_조회한다() {
         // given
-        Keyboard keyboard = 키보드를_저장한다();
+        Keyboard keyboard = 키보드를_저장한다("키보드");
 
         // when
         ExtractableResponse<Response> response = GET_요청을_보낸다("/api/v1/keyboards/" + keyboard.getId());
@@ -34,11 +37,80 @@ class KeyboardAcceptanceTest extends AcceptanceTest {
         );
     }
 
-    private Keyboard 키보드를_저장한다() {
+    @Test
+    void 키보드_목록을_페이징하여_조회한다() {
+        // given
+        Keyboard keyboard = 키보드를_저장한다("키보드1");
+        키보드를_저장한다("키보드2");
+
+        // when
+        ExtractableResponse<Response> response = GET_요청을_보낸다("/api/v1/keyboards?page=0&size=1");
+
+        // then
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(response.as(KeyboardPageResponse.class).getKeyboards())
+                        .extracting("id")
+                        .containsExactly(keyboard.getId()),
+                () -> assertThat(response.as(KeyboardPageResponse.class).isHasNext()).isTrue()
+        );
+    }
+
+    @Test
+    void 키보드_목록을_리뷰가_많은_순서로_페이징하여_조회한다() {
+        // given
+        Keyboard keyboard1 = 키보드를_저장한다("키보드1");
+        Keyboard keyboard2 = 키보드를_저장한다("키보드2");
+        키보드에_대한_리뷰를_작성한다(keyboard1, 5);
+        키보드에_대한_리뷰를_작성한다(keyboard1, 4);
+        키보드에_대한_리뷰를_작성한다(keyboard2, 3);
+
+        // when
+        ExtractableResponse<Response> response = GET_요청을_보낸다("/api/v1/keyboards?page=0&size=1&sort=reviewCount,desc");
+
+        // then
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(response.as(KeyboardPageResponse.class).getKeyboards())
+                        .extracting("id")
+                        .containsExactly(keyboard1.getId()),
+                () -> assertThat(response.as(KeyboardPageResponse.class).isHasNext()).isTrue()
+        );
+    }
+
+    @Test
+    void 키보드_목록을_평점_높은_순서로_페이징하여_조회한다() {
+        // given
+        Keyboard keyboard1 = 키보드를_저장한다("키보드1");
+        Keyboard keyboard2 = 키보드를_저장한다("키보드2");
+        키보드에_대한_리뷰를_작성한다(keyboard1, 5);
+        키보드에_대한_리뷰를_작성한다(keyboard1, 1);
+        키보드에_대한_리뷰를_작성한다(keyboard2, 4);
+
+        // when
+        ExtractableResponse<Response> response = GET_요청을_보낸다("/api/v1/keyboards?page=0&size=1&sort=rating,desc");
+
+        // then
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(response.as(KeyboardPageResponse.class).getKeyboards())
+                        .extracting("id")
+                        .containsExactly(keyboard2.getId()),
+                () -> assertThat(response.as(KeyboardPageResponse.class).isHasNext()).isTrue()
+        );
+    }
+
+    private Keyboard 키보드를_저장한다(String name) {
         Keyboard keyboard = Keyboard.builder()
-                .name("키보드")
+                .name(name)
                 .build();
         keyboardRepository.save(keyboard);
         return keyboard;
+    }
+
+    private ExtractableResponse<Response> 키보드에_대한_리뷰를_작성한다(final Keyboard keyboard, final int rating) {
+        ReviewRequest reviewRequest = new ReviewRequest("리뷰 내용", rating);
+        String url = "/api/v1/keyboards/" + keyboard.getId() + "/reviews";
+        return POST_요청을_보낸다(url, reviewRequest);
     }
 }

--- a/backend/src/test/java/com/woowacourse/f12/application/KeyboardServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/application/KeyboardServiceTest.java
@@ -3,20 +3,26 @@ package com.woowacourse.f12.application;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
 import com.woowacourse.f12.domain.Keyboard;
 import com.woowacourse.f12.domain.KeyboardRepository;
+import com.woowacourse.f12.dto.response.KeyboardPageResponse;
 import com.woowacourse.f12.dto.response.KeyboardResponse;
 import com.woowacourse.f12.exception.KeyboardNotFoundException;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.SliceImpl;
 
 @ExtendWith(MockitoExtension.class)
 class KeyboardServiceTest {
@@ -30,10 +36,7 @@ class KeyboardServiceTest {
     @Test
     void id_값으로_키보드를_조회한다() {
         // given
-        Keyboard keyboard = Keyboard.builder()
-                .id(1L)
-                .name("키보드")
-                .build();
+        Keyboard keyboard = 키보드_생성();
 
         given(keyboardRepository.findById(anyLong()))
                 .willReturn(Optional.ofNullable(keyboard));
@@ -59,5 +62,32 @@ class KeyboardServiceTest {
                         .isExactlyInstanceOf(KeyboardNotFoundException.class),
                 () -> verify(keyboardRepository).findById(1L)
         );
+    }
+
+    @Test
+    void 전체_키보드_목록을_조회한다() {
+        // given
+        Pageable pageable = PageRequest.of(0, 1);
+        given(keyboardRepository.findPageBy(any(Pageable.class)))
+                .willReturn(new SliceImpl<>(List.of(
+                        키보드_생성()
+                ), pageable, false));
+
+        // when
+        KeyboardPageResponse keyboardPageResponse = keyboardService.findPage(pageable);
+
+        // then
+        assertAll(
+                () -> verify(keyboardRepository).findPageBy(any(Pageable.class)),
+                () -> assertThat(keyboardPageResponse.isHasNext()).isFalse(),
+                () -> assertThat(keyboardPageResponse.getKeyboards()).hasSize(1)
+        );
+    }
+
+    private Keyboard 키보드_생성() {
+        return Keyboard.builder()
+                .id(1L)
+                .name("키보드")
+                .build();
     }
 }

--- a/backend/src/test/java/com/woowacourse/f12/application/ReviewServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/application/ReviewServiceTest.java
@@ -60,7 +60,7 @@ class ReviewServiceTest {
         Long productId = 1L;
         Pageable pageable = PageRequest.of(0, 1, Sort.by(Order.desc("createdAt")));
         Slice<Review> slice = new SliceImpl<>(List.of(
-                리뷰_저장(2L, productId, "내용", 5)
+                리뷰_생성(2L, productId, "내용", 5)
         ), pageable, true);
 
         given(reviewRepository.findPageByProductId(productId, pageable))
@@ -86,8 +86,8 @@ class ReviewServiceTest {
         Long product2Id = 2L;
         Pageable pageable = PageRequest.of(0, 2, Sort.by(Order.desc("createdAt")));
         Slice<Review> slice = new SliceImpl<>(List.of(
-                리뷰_저장(3L, product2Id, "내용", 5),
-                리뷰_저장(2L, product1Id, "내용", 5)
+                리뷰_생성(3L, product2Id, "내용", 5),
+                리뷰_생성(2L, product1Id, "내용", 5)
         ), pageable, true);
 
         given(reviewRepository.findPageBy(pageable))
@@ -106,7 +106,7 @@ class ReviewServiceTest {
         );
     }
 
-    private Review 리뷰_저장(Long id, Long productId, String content, int rating) {
+    private Review 리뷰_생성(Long id, Long productId, String content, int rating) {
         return Review.builder()
                 .id(id)
                 .productId(productId)

--- a/backend/src/test/java/com/woowacourse/f12/domain/KeyboardRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/domain/KeyboardRepositoryTest.java
@@ -1,0 +1,103 @@
+package com.woowacourse.f12.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.woowacourse.f12.config.JpaConfig;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Order;
+
+@DataJpaTest
+@Import(JpaConfig.class)
+class KeyboardRepositoryTest {
+
+    @Autowired
+    private KeyboardRepository keyboardRepository;
+
+    @Autowired
+    private ReviewRepository reviewRepository;
+
+    @Test
+    void 키보드_전체_목록을_페이징하여_조회한다() {
+        // given
+        Keyboard keyboard1 = 키보드_저장("키보드1");
+        Keyboard keyboard2 = 키보드_저장("키보드2");
+        Pageable pageable = PageRequest.of(0, 1);
+
+        // when
+        Slice<Keyboard> slice = keyboardRepository.findPageBy(pageable);
+
+        // then
+        assertAll(
+                () -> assertThat(slice.hasNext()).isTrue(),
+                () -> assertThat(slice.getContent()).containsExactly(keyboard1)
+        );
+    }
+
+    @Test
+    void 키보드_전체_목록을_리뷰_많은_순으로_페이징하여_조회한다() {
+        // given
+        Keyboard keyboard1 = 키보드_저장("키보드1");
+        Keyboard keyboard2 = 키보드_저장("키보드2");
+
+        리뷰_저장(keyboard1.getId(), "내용", 5);
+        리뷰_저장(keyboard2.getId(), "내용", 5);
+        리뷰_저장(keyboard2.getId(), "내용", 5);
+
+        Pageable pageable = PageRequest.of(0, 1, Sort.by(Order.desc("reviewCount")));
+
+        // when
+        Slice<Keyboard> slice = keyboardRepository.findPageBy(pageable);
+
+        // then
+        assertAll(
+                () -> assertThat(slice.hasNext()).isTrue(),
+                () -> assertThat(slice.getContent()).containsExactly(keyboard2)
+        );
+    }
+
+    @Test
+    void 키보드_전체_목록을_평균_평점_순으로_페이징하여_조회한다() {
+        // given
+        Keyboard keyboard1 = 키보드_저장("키보드1");
+        Keyboard keyboard2 = 키보드_저장("키보드2");
+
+        리뷰_저장(keyboard1.getId(), "내용", 2);
+        리뷰_저장(keyboard1.getId(), "내용", 1);
+        리뷰_저장(keyboard2.getId(), "내용", 5);
+        리뷰_저장(keyboard2.getId(), "내용", 4);
+
+        Pageable pageable = PageRequest.of(0, 1, Sort.by(Order.desc("rating")));
+
+        // when
+        Slice<Keyboard> slice = keyboardRepository.findPageBy(pageable);
+
+        // then
+        assertAll(
+                () -> assertThat(slice.hasNext()).isTrue(),
+                () -> assertThat(slice.getContent()).containsExactly(keyboard2)
+        );
+    }
+
+    private Keyboard 키보드_저장(String name) {
+        return keyboardRepository.save(Keyboard.builder()
+                .name(name)
+                .build()
+        );
+    }
+
+    private Review 리뷰_저장(Long productId, String content, int rating) {
+        return reviewRepository.save(Review.builder()
+                .productId(productId)
+                .content(content)
+                .rating(rating)
+                .build());
+    }
+}

--- a/backend/src/test/java/com/woowacourse/f12/domain/KeyboardRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/domain/KeyboardRepositoryTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.woowacourse.f12.config.JpaConfig;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -23,6 +25,29 @@ class KeyboardRepositoryTest {
 
     @Autowired
     private ReviewRepository reviewRepository;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Test
+    void 키보드를_단일_조회_한다() {
+        // given
+        Keyboard keyboard = 키보드_저장("키보드");
+        리뷰_저장(keyboard.getId(), "리뷰내용", 4);
+        리뷰_저장(keyboard.getId(), "리뷰내용", 5);
+        entityManager.flush();
+        entityManager.refresh(keyboard);
+
+        // when
+        Keyboard savedKeyboard = keyboardRepository.findById(keyboard.getId())
+                .orElseThrow(IllegalArgumentException::new);
+
+        // then
+        assertAll(
+                () -> assertThat(savedKeyboard.getRating()).isEqualTo(4.5),
+                () -> assertThat(savedKeyboard.getReviewCount()).isEqualTo(2)
+        );
+    }
 
     @Test
     void 키보드_전체_목록을_페이징하여_조회한다() {

--- a/backend/src/test/java/com/woowacourse/f12/domain/ReviewRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/domain/ReviewRepositoryTest.java
@@ -26,8 +26,8 @@ class ReviewRepositoryTest {
         // given
         Long productId = 1L;
         Pageable pageable = PageRequest.of(0, 1, Sort.by(desc("createdAt")));
-        reviewRepository.save(리뷰_저장(1L, "내용1", 5));
-        Review review = reviewRepository.save(리뷰_저장(1L, "내용2", 5));
+        리뷰_저장(productId, "내용1", 5);
+        Review review = 리뷰_저장(productId, "내용2", 5);
 
         // when
         Slice<Review> page = reviewRepository.findPageByProductId(productId, pageable);
@@ -46,8 +46,8 @@ class ReviewRepositoryTest {
         // given
         Long productId = 1L;
         Pageable pageable = PageRequest.of(0, 1, Sort.by(desc("rating")));
-        Review review = reviewRepository.save(리뷰_저장(1L, "내용1", 5));
-        reviewRepository.save(리뷰_저장(1L, "내용2", 4));
+        Review review = 리뷰_저장(productId, "내용1", 5);
+        리뷰_저장(productId, "내용2", 4);
 
         // when
         Slice<Review> page = reviewRepository.findPageByProductId(productId, pageable);
@@ -64,10 +64,9 @@ class ReviewRepositoryTest {
     @Test
     void 리뷰_목록을_최신순으로_페이징하여_조회한다() {
         // given
-        Long productId = 1L;
         Pageable pageable = PageRequest.of(0, 1, Sort.by(desc("createdAt")));
-        reviewRepository.save(리뷰_저장(1L, "내용1", 5));
-        Review review = reviewRepository.save(리뷰_저장(2L, "내용2", 4));
+        리뷰_저장(1L, "내용1", 5);
+        Review review = 리뷰_저장(2L, "내용2", 4);
 
         // when
         Slice<Review> page = reviewRepository.findPageBy(pageable);
@@ -82,10 +81,10 @@ class ReviewRepositoryTest {
     }
 
     private Review 리뷰_저장(Long productId, String content, int rating) {
-        return Review.builder()
+        return reviewRepository.save(Review.builder()
                 .productId(productId)
                 .content(content)
                 .rating(rating)
-                .build();
+                .build());
     }
 }


### PR DESCRIPTION
# issue: closed #19 

# 작업 내용
- 키보드 목록을 Pageable을 사용해서 페이징 처리하여 조회했다.
  - rating 필드의 값을 매핑할 때 `AVG` sql 집계함수 사용으로 null이 반환되는 이슈로 `IFNULL(AVG(r.rating), 0)`을 사용하여 기본 값을 0으로 지정했다.
- 정렬 조건
  - 미정렬
  - 평점 높은 순
  - 리뷰 많은 순
