### PR TITLE
[BE] CORS를 임시로 허용한다.

### DIFF
--- a/backend/src/main/java/com/woowacourse/f12/config/WebConfig.java
+++ b/backend/src/main/java/com/woowacourse/f12/config/WebConfig.java
@@ -3,16 +3,27 @@ package com.woowacourse.f12.config;
 import com.woowacourse.f12.presentation.CustomPageableHandlerArgumentResolver;
 import java.util.List;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
+
+    private static final String CORS_ALLOWED_METHODS = "GET,POST,HEAD,PUT,PATCH,DELETE,TRACE,OPTIONS";
 
     @Override
     public void addArgumentResolvers(final List<HandlerMethodArgumentResolver> resolvers) {
         CustomPageableHandlerArgumentResolver customPageableHandlerArgumentResolver = new CustomPageableHandlerArgumentResolver();
         customPageableHandlerArgumentResolver.setMaxPageSize(150);
         resolvers.add(customPageableHandlerArgumentResolver);
+    }
+
+    @Override
+    public void addCorsMappings(final CorsRegistry registry) {
+        registry.addMapping("/api/**")
+                .allowedMethods(CORS_ALLOWED_METHODS.split(","))
+                .exposedHeaders(HttpHeaders.LOCATION);
     }
 }

--- a/backend/src/test/java/com/woowacourse/f12/config/WebConfigTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/config/WebConfigTest.java
@@ -1,0 +1,37 @@
+package com.woowacourse.f12.config;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class WebConfigTest {
+
+    private static final String CORS_ALLOWED_METHODS = "GET,POST,HEAD,PUT,PATCH,DELETE,TRACE,OPTIONS";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void CORS가_허용되어있다() throws Exception {
+        mockMvc.perform(
+                        options("/api/v1/keyboards")
+                                .header(HttpHeaders.ORIGIN, "http://localhost:8080")
+                                .header(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, "GET")
+                )
+                .andExpect(status().isOk())
+                .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "*"))
+                .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS, CORS_ALLOWED_METHODS))
+                .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS, HttpHeaders.LOCATION))
+                .andDo(print());
+    }
+}


### PR DESCRIPTION
# issue: #17 

# 작업 내용
- 모든 origin에 대해 CORS를 허용하도록 설정했다.

# 주의 사항
- origin이 확정되고 나면(프론트엔드 배포 이후) 허용된 origin 설정을 반드시 바꿔주어야 한다.