### PR TITLE
[BE] 프론트엔드와 연결을 위한 설정 완료

### DIFF
--- a/backend/src/main/java/com/woowacourse/f12/presentation/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/GlobalExceptionHandler.java
@@ -3,11 +3,13 @@ package com.woowacourse.f12.presentation;
 import com.woowacourse.f12.dto.response.ExceptionResponse;
 import com.woowacourse.f12.exception.InvalidValueException;
 import com.woowacourse.f12.exception.NotFoundException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
@@ -15,8 +17,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(NotFoundException.class)
     public ResponseEntity<ExceptionResponse> handleNotFoundException(final NotFoundException e) {
-        return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                .body(ExceptionResponse.from(e));
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ExceptionResponse.from(e));
     }
 
     @ExceptionHandler(InvalidValueException.class)
@@ -25,8 +26,8 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ExceptionResponse> handleUnhandledException() {
-        return ResponseEntity.internalServerError()
-                .body(ExceptionResponse.from(INTERNAL_SERVER_ERROR_MESSAGE));
+    public ResponseEntity<ExceptionResponse> handleUnhandledException(Exception e) {
+        log.error("[ERROR]", e);
+        return ResponseEntity.internalServerError().body(ExceptionResponse.from(INTERNAL_SERVER_ERROR_MESSAGE));
     }
 }

--- a/backend/src/main/java/com/woowacourse/f12/presentation/ReviewController.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/ReviewController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/v1/keyboards")
+@RequestMapping("/api/v1")
 public class ReviewController {
 
     private final ReviewService reviewService;
@@ -23,7 +23,7 @@ public class ReviewController {
         this.reviewService = reviewService;
     }
 
-    @PostMapping("/{productId}/reviews")
+    @PostMapping("/keyboards/{productId}/reviews")
     public ResponseEntity<Void> create(@PathVariable final Long productId,
                                        @RequestBody final ReviewRequest reviewRequest) {
         final Long id = reviewService.save(productId, reviewRequest);
@@ -31,7 +31,7 @@ public class ReviewController {
                 .build();
     }
 
-    @GetMapping("/{productId}/reviews")
+    @GetMapping("/keyboards/{productId}/reviews")
     public ResponseEntity<ReviewPageResponse> showPageByProductId(@PathVariable final Long productId,
                                                                   final Pageable pageable) {
         final ReviewPageResponse reviewPageResponse = reviewService.findPageByProductId(productId, pageable);

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,8 +1,15 @@
 spring:
+  datasource:
+    url: jdbc:h2:tcp://localhost/~/f12;MODE=MySQL
+    username: sa
+    password:
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: none
     show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
   h2:
     console:
       enabled: true

--- a/backend/src/test/java/com/woowacourse/f12/acceptance/ReviewAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/acceptance/ReviewAcceptanceTest.java
@@ -97,7 +97,7 @@ public class ReviewAcceptanceTest extends AcceptanceTest {
 
         // when
         ExtractableResponse<Response> response = GET_요청을_보낸다(
-                "/api/v1/keyboards/reviews?page=0&size=2&sort=createdAt,desc");
+                "/api/v1/reviews?page=0&size=2&sort=createdAt,desc");
 
         // then
         assertAll(

--- a/backend/src/test/java/com/woowacourse/f12/presentation/ReviewControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/ReviewControllerTest.java
@@ -139,7 +139,7 @@ class ReviewControllerTest {
                 .willReturn(ReviewPageResponse.from(new SliceImpl<>(List.of(REVIEW_1))));
 
         // when
-        mockMvc.perform(get("/api/v1/keyboards/reviews?size=150&page=0&sort=rating,desc"))
+        mockMvc.perform(get("/api/v1/reviews?size=150&page=0&sort=rating,desc"))
                 .andExpect(status().isOk())
                 .andDo(print());
 

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -1,0 +1,11 @@
+spring:
+  jpa:
+    hibernate:
+      ddl-auto: create
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+
+server:
+  port: 8080


### PR DESCRIPTION
# issue: #56 

# 작업 내용
- 프론트엔드에서 지정한 API 주소와 다른 URL 수정
- 프로덕션에서 로컬 인메모리 h2 데이터베이스를 사용하도록 설정
- 테스트 설정 분리
  - 임베디드 h2 데이터베이스를 사용하도록 설정
- 예상하지 못한 예외가 발생할 경우 서버에 로그를 남기도록 하는 기능 구현
