### PR TITLE
[BE] 페이징 조회 요청에서 size 값 null 체크

### DIFF
--- a/backend/src/main/java/com/woowacourse/f12/presentation/CustomPageableHandlerMethodArgumentResolver.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/CustomPageableHandlerMethodArgumentResolver.java
@@ -1,6 +1,7 @@
 package com.woowacourse.f12.presentation;
 
 import com.woowacourse.f12.exception.InvalidPageSizeException;
+import java.util.Objects;
 import org.springframework.core.MethodParameter;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
@@ -20,10 +21,14 @@ public class CustomPageableHandlerMethodArgumentResolver extends PageableHandler
     @Override
     public Pageable resolveArgument(final MethodParameter methodParameter, final ModelAndViewContainer mavContainer,
                                     final NativeWebRequest webRequest, final WebDataBinderFactory binderFactory) {
-        final int size = Integer.parseInt(webRequest.getParameter("size"));
-        if (size > MAX_SIZE) {
+        final String sizeArgument = webRequest.getParameter("size");
+        validateSize(sizeArgument);
+        return super.resolveArgument(methodParameter, mavContainer, webRequest, binderFactory);
+    }
+
+    private void validateSize(final String sizeArgument) {
+        if (Objects.nonNull(sizeArgument) && Integer.parseInt(sizeArgument) > MAX_SIZE) {
             throw new InvalidPageSizeException(MAX_SIZE);
         }
-        return super.resolveArgument(methodParameter, mavContainer, webRequest, binderFactory);
     }
 }

--- a/backend/src/test/java/com/woowacourse/f12/presentation/CustomPageableHandlerMethodArgumentResolverTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/CustomPageableHandlerMethodArgumentResolverTest.java
@@ -1,0 +1,48 @@
+package com.woowacourse.f12.presentation;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.woowacourse.f12.application.KeyboardService;
+import com.woowacourse.f12.dto.response.KeyboardPageResponse;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.data.domain.Sort;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(KeyboardController.class)
+public class CustomPageableHandlerMethodArgumentResolverTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private KeyboardService keyboardService;
+
+    @Test
+    void 페이징_실패_최대_페이징_크기_초과() throws Exception {
+        // given
+        given(keyboardService.findPage(any(Pageable.class)))
+                .willReturn(KeyboardPageResponse.from(new SliceImpl<>(List.of())));
+
+        // when
+        mockMvc.perform(get("/api/v1/keyboards?page=0&size=151&sort=rating,desc"))
+                .andExpect(status().isBadRequest())
+                .andDo(print());
+
+        // then
+        verify(keyboardService, times(0))
+                .findPage(PageRequest.of(0, 151, Sort.by("rating").descending()));
+    }
+}

--- a/backend/src/test/java/com/woowacourse/f12/presentation/CustomPageableHandlerMethodArgumentResolverTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/CustomPageableHandlerMethodArgumentResolverTest.java
@@ -45,4 +45,20 @@ public class CustomPageableHandlerMethodArgumentResolverTest {
         verify(keyboardService, times(0))
                 .findPage(PageRequest.of(0, 151, Sort.by("rating").descending()));
     }
+
+    @Test
+    void 페이징_성공_페이징_값_지정_안할_경우_기본값으로_페이징() throws Exception {
+        // given
+        given(keyboardService.findPage(any(Pageable.class)))
+                .willReturn(KeyboardPageResponse.from(new SliceImpl<>(List.of())));
+
+        // when
+        mockMvc.perform(get("/api/v1/keyboards"))
+                .andExpect(status().isOk())
+                .andDo(print());
+
+        // then
+        verify(keyboardService, times(0))
+                .findPage(PageRequest.of(0, 151, Sort.by("rating").descending()));
+    }
 }

--- a/backend/src/test/java/com/woowacourse/f12/presentation/CustomPageableHandlerMethodArgumentResolverTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/CustomPageableHandlerMethodArgumentResolverTest.java
@@ -58,7 +58,7 @@ public class CustomPageableHandlerMethodArgumentResolverTest {
                 .andDo(print());
 
         // then
-        verify(keyboardService, times(0))
-                .findPage(PageRequest.of(0, 151, Sort.by("rating").descending()));
+        verify(keyboardService)
+                .findPage(PageRequest.of(0, 20));
     }
 }

--- a/backend/src/test/java/com/woowacourse/f12/presentation/KeyboardControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/KeyboardControllerTest.java
@@ -3,7 +3,6 @@ package com.woowacourse.f12.presentation;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -53,22 +52,6 @@ class KeyboardControllerTest {
 
         // then
         verify(keyboardService).findPage(PageRequest.of(0, 150, Sort.by("rating").descending()));
-    }
-
-    @Test
-    void 키보드_목록_페이지_조회_실패_최대_페이징_크기_초과() throws Exception {
-        // given
-        given(keyboardService.findPage(any(Pageable.class)))
-                .willReturn(KeyboardPageResponse.from(new SliceImpl<>(List.of(KEYBOARD_1))));
-
-        // when
-        mockMvc.perform(get("/api/v1/keyboards?page=0&size=151&sort=rating,desc"))
-                .andExpect(status().isBadRequest())
-                .andDo(print());
-
-        // then
-        verify(keyboardService, times(0))
-                .findPage(PageRequest.of(0, 151, Sort.by("rating").descending()));
     }
 
     @Test


### PR DESCRIPTION
# issue:  #48 

# 작업 내용
- 페이징 조회 요청에서 size 값 null을 체크하고 기본값으로 지정되도록 수정했다.
- 스프링에서 제공하는 기본 값은 page=0, size=20 이다.