### PR TITLE
[BE] 리뷰 도메인과 키보드 도메인 연관관계 추가

### DIFF
--- a/backend/src/main/java/com/woowacourse/f12/application/ReviewService.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/ReviewService.java
@@ -1,5 +1,6 @@
 package com.woowacourse.f12.application;
 
+import com.woowacourse.f12.domain.Keyboard;
 import com.woowacourse.f12.domain.KeyboardRepository;
 import com.woowacourse.f12.domain.Review;
 import com.woowacourse.f12.domain.ReviewRepository;
@@ -25,22 +26,23 @@ public class ReviewService {
 
     @Transactional
     public Long save(final Long productId, final ReviewRequest reviewRequest) {
-        validateKeyboardExists(productId);
-        final Review review = reviewRequest.toReview(productId);
+        final Keyboard keyboard = keyboardRepository.findById(productId)
+                .orElseThrow(KeyboardNotFoundException::new);
+        final Review review = reviewRequest.toReview(keyboard);
         return reviewRepository.save(review)
                 .getId();
-    }
-
-    private void validateKeyboardExists(final Long productId) {
-        if (!keyboardRepository.existsById(productId)) {
-            throw new KeyboardNotFoundException();
-        }
     }
 
     public ReviewPageResponse findPageByProductId(final Long productId, final Pageable pageable) {
         validateKeyboardExists(productId);
         final Slice<Review> page = reviewRepository.findPageByProductId(productId, pageable);
         return ReviewPageResponse.from(page);
+    }
+
+    private void validateKeyboardExists(final Long productId) {
+        if (!keyboardRepository.existsById(productId)) {
+            throw new KeyboardNotFoundException();
+        }
     }
 
     public ReviewPageResponse findPage(final Pageable pageable) {

--- a/backend/src/main/java/com/woowacourse/f12/domain/Review.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/Review.java
@@ -8,9 +8,12 @@ import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EntityListeners;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 import lombok.Builder;
 import lombok.Getter;
@@ -31,14 +34,15 @@ public class Review {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "product_id", nullable = false)
-    private Long productId;
-
     @Column(name = "content", nullable = false, length = MAXIMUM_CONTENT_LENGTH)
     private String content;
 
     @Column(name = "rating", nullable = false)
     private int rating;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id")
+    private Keyboard keyboard;
 
     @CreatedDate
     @Column(name = "created_at", nullable = false, updatable = false)
@@ -48,14 +52,14 @@ public class Review {
     }
 
     @Builder
-    private Review(final Long id, final Long productId, final String content, final int rating,
+    private Review(final Long id, final String content, final int rating, final Keyboard keyboard,
                    final LocalDateTime createdAt) {
         validateContent(content);
         validateRating(rating);
         this.id = id;
-        this.productId = productId;
         this.content = content;
         this.rating = rating;
+        this.keyboard = keyboard;
         this.createdAt = createdAt;
     }
 

--- a/backend/src/main/java/com/woowacourse/f12/domain/ReviewRepository.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/ReviewRepository.java
@@ -3,9 +3,11 @@ package com.woowacourse.f12.domain;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
+    @Query("select r from Review r where r.keyboard.id = :productId")
     Slice<Review> findPageByProductId(Long productId, Pageable pageable);
 
     Slice<Review> findPageBy(Pageable pageable);

--- a/backend/src/main/java/com/woowacourse/f12/dto/request/ReviewRequest.java
+++ b/backend/src/main/java/com/woowacourse/f12/dto/request/ReviewRequest.java
@@ -1,5 +1,6 @@
 package com.woowacourse.f12.dto.request;
 
+import com.woowacourse.f12.domain.Keyboard;
 import com.woowacourse.f12.domain.Review;
 import lombok.Getter;
 
@@ -17,9 +18,9 @@ public class ReviewRequest {
         this.rating = rating;
     }
 
-    public Review toReview(final Long productId) {
+    public Review toReview(final Keyboard keyboard) {
         return Review.builder()
-                .productId(productId)
+                .keyboard(keyboard)
                 .content(this.content)
                 .rating(this.rating)
                 .build();

--- a/backend/src/main/java/com/woowacourse/f12/dto/response/ReviewResponse.java
+++ b/backend/src/main/java/com/woowacourse/f12/dto/response/ReviewResponse.java
@@ -25,7 +25,7 @@ public class ReviewResponse {
     }
 
     public static ReviewResponse from(final Review review) {
-        return new ReviewResponse(review.getId(), review.getProductId(), review.getContent(), review.getRating(),
+        return new ReviewResponse(review.getId(), review.getKeyboard().getId(), review.getContent(), review.getRating(),
                 review.getCreatedAt().toString());
     }
 }

--- a/backend/src/test/java/com/woowacourse/f12/application/ReviewServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/application/ReviewServiceTest.java
@@ -1,5 +1,7 @@
 package com.woowacourse.f12.application;
 
+import static com.woowacourse.f12.support.KeyboardFixtures.KEYBOARD_1;
+import static com.woowacourse.f12.support.KeyboardFixtures.KEYBOARD_2;
 import static com.woowacourse.f12.support.ReviewFixtures.REVIEW_RATING_5;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -9,6 +11,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import com.woowacourse.f12.domain.Keyboard;
 import com.woowacourse.f12.domain.KeyboardRepository;
 import com.woowacourse.f12.domain.Review;
 import com.woowacourse.f12.domain.ReviewRepository;
@@ -16,6 +19,7 @@ import com.woowacourse.f12.dto.request.ReviewRequest;
 import com.woowacourse.f12.dto.response.ReviewPageResponse;
 import com.woowacourse.f12.exception.KeyboardNotFoundException;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -45,11 +49,11 @@ class ReviewServiceTest {
         // given
         ReviewRequest reviewRequest = new ReviewRequest("내용", 5);
         Long productId = 1L;
-
-        given(keyboardRepository.existsById(productId))
-                .willReturn(true);
-        given(reviewRepository.save(reviewRequest.toReview(productId)))
-                .willReturn(REVIEW_RATING_5.작성(1L, productId));
+        Keyboard keyboard = KEYBOARD_1.생성(productId);
+        given(keyboardRepository.findById(productId))
+                .willReturn(Optional.of(keyboard));
+        given(reviewRepository.save(reviewRequest.toReview(keyboard)))
+                .willReturn(REVIEW_RATING_5.작성(1L, keyboard));
 
         // when
         Long reviewId = reviewService.save(productId, reviewRequest);
@@ -57,7 +61,7 @@ class ReviewServiceTest {
         // then
         assertAll(
                 () -> assertThat(reviewId).isEqualTo(1L),
-                () -> verify(keyboardRepository).existsById(productId),
+                () -> verify(keyboardRepository).findById(productId),
                 () -> verify(reviewRepository).save(any(Review.class))
         );
     }
@@ -68,14 +72,14 @@ class ReviewServiceTest {
         ReviewRequest reviewRequest = new ReviewRequest("내용", 5);
         Long productId = 1L;
 
-        given(keyboardRepository.existsById(productId))
-                .willReturn(false);
+        given(keyboardRepository.findById(productId))
+                .willReturn(Optional.empty());
 
         // when, then
         assertAll(
                 () -> assertThatThrownBy(() -> reviewService.save(1L, reviewRequest))
                         .isExactlyInstanceOf(KeyboardNotFoundException.class),
-                () -> verify(keyboardRepository).existsById(productId),
+                () -> verify(keyboardRepository).findById(productId),
                 () -> verify(reviewRepository, times(0)).save(any(Review.class))
         );
     }
@@ -84,9 +88,10 @@ class ReviewServiceTest {
     void 특정_제품에_대한_리뷰_목록을_조회한다() {
         // given
         Long productId = 1L;
+        Keyboard keyboard = KEYBOARD_1.생성();
         Pageable pageable = PageRequest.of(0, 1, Sort.by(Order.desc("createdAt")));
         Slice<Review> slice = new SliceImpl<>(List.of(
-                REVIEW_RATING_5.작성(1L, productId)
+                REVIEW_RATING_5.작성(1L, keyboard)
         ), pageable, true);
 
         given(keyboardRepository.existsById(productId))
@@ -126,12 +131,10 @@ class ReviewServiceTest {
     @Test
     void 전체_리뷰_목록을_조회한다() {
         // given
-        Long product1Id = 1L;
-        Long product2Id = 2L;
         Pageable pageable = PageRequest.of(0, 2, Sort.by(Order.desc("createdAt")));
         Slice<Review> slice = new SliceImpl<>(List.of(
-                REVIEW_RATING_5.작성(3L, product1Id),
-                REVIEW_RATING_5.작성(2L, product2Id)
+                REVIEW_RATING_5.작성(3L, KEYBOARD_1.생성()),
+                REVIEW_RATING_5.작성(2L, KEYBOARD_2.생성())
         ), pageable, true);
 
         given(reviewRepository.findPageBy(pageable))

--- a/backend/src/test/java/com/woowacourse/f12/domain/KeyboardRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/domain/KeyboardRepositoryTest.java
@@ -39,8 +39,8 @@ class KeyboardRepositoryTest {
     void 키보드를_단일_조회_한다() {
         // given
         Keyboard keyboard = 키보드_저장(KEYBOARD_1.생성());
-        리뷰_저장(REVIEW_RATING_4.작성(keyboard.getId()));
-        리뷰_저장(REVIEW_RATING_5.작성(keyboard.getId()));
+        리뷰_저장(REVIEW_RATING_4.작성(keyboard));
+        리뷰_저장(REVIEW_RATING_5.작성(keyboard));
         entityManager.flush();
         entityManager.refresh(keyboard);
 
@@ -78,9 +78,9 @@ class KeyboardRepositoryTest {
         Keyboard keyboard1 = 키보드_저장(KEYBOARD_1.생성());
         Keyboard keyboard2 = 키보드_저장(KEYBOARD_2.생성());
 
-        리뷰_저장(REVIEW_RATING_5.작성(keyboard1.getId()));
-        리뷰_저장(REVIEW_RATING_5.작성(keyboard2.getId()));
-        리뷰_저장(REVIEW_RATING_5.작성(keyboard2.getId()));
+        리뷰_저장(REVIEW_RATING_5.작성(keyboard1));
+        리뷰_저장(REVIEW_RATING_5.작성(keyboard2));
+        리뷰_저장(REVIEW_RATING_5.작성(keyboard2));
 
         Pageable pageable = PageRequest.of(0, 1, Sort.by(Order.desc("reviewCount")));
 
@@ -100,10 +100,10 @@ class KeyboardRepositoryTest {
         Keyboard keyboard2 = 키보드_저장(KEYBOARD_1.생성());
         Keyboard keyboard1 = 키보드_저장(KEYBOARD_2.생성());
 
-        리뷰_저장(REVIEW_RATING_2.작성(keyboard1.getId()));
-        리뷰_저장(REVIEW_RATING_1.작성(keyboard1.getId()));
-        리뷰_저장(REVIEW_RATING_5.작성(keyboard2.getId()));
-        리뷰_저장(REVIEW_RATING_4.작성(keyboard2.getId()));
+        리뷰_저장(REVIEW_RATING_2.작성(keyboard1));
+        리뷰_저장(REVIEW_RATING_1.작성(keyboard1));
+        리뷰_저장(REVIEW_RATING_5.작성(keyboard2));
+        리뷰_저장(REVIEW_RATING_4.작성(keyboard2));
 
         Pageable pageable = PageRequest.of(0, 1, Sort.by(Order.desc("rating")));
 

--- a/backend/src/test/java/com/woowacourse/f12/domain/ReviewRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/domain/ReviewRepositoryTest.java
@@ -1,5 +1,7 @@
 package com.woowacourse.f12.domain;
 
+import static com.woowacourse.f12.support.KeyboardFixtures.KEYBOARD_1;
+import static com.woowacourse.f12.support.KeyboardFixtures.KEYBOARD_2;
 import static com.woowacourse.f12.support.ReviewFixtures.REVIEW_RATING_4;
 import static com.woowacourse.f12.support.ReviewFixtures.REVIEW_RATING_5;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -23,16 +25,19 @@ class ReviewRepositoryTest {
     @Autowired
     private ReviewRepository reviewRepository;
 
+    @Autowired
+    private KeyboardRepository keyboardRepository;
+
     @Test
     void 특정_제품의_리뷰_목록을_최신순으로_페이징하여_조회한다() {
         // given
-        Long productId = 1L;
+        Keyboard keyboard = keyboardRepository.save(KEYBOARD_1.생성());
         Pageable pageable = PageRequest.of(0, 1, Sort.by(desc("createdAt")));
-        리뷰_저장(REVIEW_RATING_5.작성(productId));
-        Review review = 리뷰_저장(REVIEW_RATING_5.작성(productId));
+        리뷰_저장(REVIEW_RATING_5.작성(keyboard));
+        Review review = 리뷰_저장(REVIEW_RATING_5.작성(keyboard));
 
         // when
-        Slice<Review> page = reviewRepository.findPageByProductId(productId, pageable);
+        Slice<Review> page = reviewRepository.findPageByProductId(keyboard.getId(), pageable);
 
         // then
         assertAll(
@@ -46,13 +51,13 @@ class ReviewRepositoryTest {
     @Test
     void 특정_제품의_리뷰_목록을_평점순으로_페이징하여_조회한다() {
         // given
-        Long productId = 1L;
+        Keyboard keyboard = keyboardRepository.save(KEYBOARD_1.생성());
         Pageable pageable = PageRequest.of(0, 1, Sort.by(desc("rating")));
-        Review review = 리뷰_저장(REVIEW_RATING_5.작성(productId));
-        리뷰_저장(REVIEW_RATING_4.작성(productId));
+        Review review = 리뷰_저장(REVIEW_RATING_5.작성(keyboard));
+        리뷰_저장(REVIEW_RATING_4.작성(keyboard));
 
         // when
-        Slice<Review> page = reviewRepository.findPageByProductId(productId, pageable);
+        Slice<Review> page = reviewRepository.findPageByProductId(keyboard.getId(), pageable);
 
         // then
         assertAll(
@@ -66,9 +71,11 @@ class ReviewRepositoryTest {
     @Test
     void 리뷰_목록을_최신순으로_페이징하여_조회한다() {
         // given
+        Keyboard keyboard1 = keyboardRepository.save(KEYBOARD_1.생성());
+        Keyboard keyboard2 = keyboardRepository.save(KEYBOARD_2.생성());
         Pageable pageable = PageRequest.of(0, 1, Sort.by(desc("createdAt")));
-        리뷰_저장(REVIEW_RATING_5.작성(1L));
-        Review review = 리뷰_저장(REVIEW_RATING_5.작성(2L));
+        리뷰_저장(REVIEW_RATING_5.작성(keyboard1));
+        Review review = 리뷰_저장(REVIEW_RATING_5.작성(keyboard2));
 
         // when
         Slice<Review> page = reviewRepository.findPageBy(pageable);

--- a/backend/src/test/java/com/woowacourse/f12/presentation/ReviewControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/ReviewControllerTest.java
@@ -1,5 +1,6 @@
 package com.woowacourse.f12.presentation;
 
+import static com.woowacourse.f12.support.KeyboardFixtures.KEYBOARD_1;
 import static com.woowacourse.f12.support.ReviewFixtures.REVIEW_RATING_5;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -149,7 +150,7 @@ class ReviewControllerTest {
     void 전체_리뷰_페이지_조회_성공() throws Exception {
         // given
         given(reviewService.findPage(any(Pageable.class)))
-                .willReturn(ReviewPageResponse.from(new SliceImpl<>(List.of(REVIEW_RATING_5.작성(1L, PRODUCT_ID)))));
+                .willReturn(ReviewPageResponse.from(new SliceImpl<>(List.of(REVIEW_RATING_5.작성(1L, KEYBOARD_1.생성())))));
 
         // when
         mockMvc.perform(get("/api/v1/reviews?size=150&page=0&sort=rating,desc"))
@@ -164,7 +165,7 @@ class ReviewControllerTest {
     void 특정_상품의_리뷰_페이지_조회() throws Exception {
         // given
         given(reviewService.findPageByProductId(anyLong(), any(Pageable.class)))
-                .willReturn(ReviewPageResponse.from(new SliceImpl<>(List.of(REVIEW_RATING_5.작성(1L, PRODUCT_ID)))));
+                .willReturn(ReviewPageResponse.from(new SliceImpl<>(List.of(REVIEW_RATING_5.작성(1L, KEYBOARD_1.생성())))));
 
         // when
         mockMvc.perform(get("/api/v1/keyboards/" + PRODUCT_ID + "/reviews?size=150&page=0&sort=rating,desc"))

--- a/backend/src/test/java/com/woowacourse/f12/support/ReviewFixtures.java
+++ b/backend/src/test/java/com/woowacourse/f12/support/ReviewFixtures.java
@@ -1,6 +1,7 @@
 package com.woowacourse.f12.support;
 
 import com.woowacourse.f12.acceptance.support.RestAssuredRequestUtil;
+import com.woowacourse.f12.domain.Keyboard;
 import com.woowacourse.f12.domain.Review;
 import com.woowacourse.f12.dto.request.ReviewRequest;
 import io.restassured.response.ExtractableResponse;
@@ -24,14 +25,14 @@ public enum ReviewFixtures {
         this.rating = rating;
     }
 
-    public Review 작성(Long productId) {
-        return 작성(null, productId);
+    public Review 작성(Keyboard keyboard) {
+        return 작성(null, keyboard);
     }
 
-    public Review 작성(Long reviewId, Long productId) {
+    public Review 작성(Long reviewId, Keyboard keyboard) {
         return Review.builder()
                 .id(reviewId)
-                .productId(productId)
+                .keyboard(keyboard)
                 .content(this.content)
                 .rating(this.rating)
                 .createdAt(LocalDateTime.now())


### PR DESCRIPTION
# issue: closed #77 

# 작업 내용
- 리뷰 -> 키보드 ManyToOne 단방향 매핑
- fetch Lazy 로딩 옵션 추가
- 리뷰에서 productId 필드 제거
- 리뷰 페이징 조회에서 JPQL 직접 작성