### PR TITLE
[BE] 키보드 정보가 필요한 리뷰 DTO 생성

### DIFF
--- a/backend/src/main/java/com/woowacourse/f12/application/ReviewService.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/ReviewService.java
@@ -6,6 +6,7 @@ import com.woowacourse.f12.domain.Review;
 import com.woowacourse.f12.domain.ReviewRepository;
 import com.woowacourse.f12.dto.request.ReviewRequest;
 import com.woowacourse.f12.dto.response.ReviewPageResponse;
+import com.woowacourse.f12.dto.response.ReviewWithProductPageResponse;
 import com.woowacourse.f12.exception.KeyboardNotFoundException;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -45,8 +46,8 @@ public class ReviewService {
         }
     }
 
-    public ReviewPageResponse findPage(final Pageable pageable) {
+    public ReviewWithProductPageResponse findPage(final Pageable pageable) {
         final Slice<Review> page = reviewRepository.findPageBy(pageable);
-        return ReviewPageResponse.from(page);
+        return ReviewWithProductPageResponse.from(page);
     }
 }

--- a/backend/src/main/java/com/woowacourse/f12/dto/response/KeyboardForReviewResponse.java
+++ b/backend/src/main/java/com/woowacourse/f12/dto/response/KeyboardForReviewResponse.java
@@ -1,0 +1,25 @@
+package com.woowacourse.f12.dto.response;
+
+import com.woowacourse.f12.domain.Keyboard;
+import lombok.Getter;
+
+@Getter
+public class KeyboardForReviewResponse {
+
+    private Long id;
+    private String name;
+    private String imageUrl;
+
+    private KeyboardForReviewResponse() {
+    }
+
+    private KeyboardForReviewResponse(final Long id, final String name, final String imageUrl) {
+        this.id = id;
+        this.name = name;
+        this.imageUrl = imageUrl;
+    }
+
+    public static KeyboardForReviewResponse from(final Keyboard keyboard) {
+        return new KeyboardForReviewResponse(keyboard.getId(), keyboard.getName(), keyboard.getImageUrl());
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/dto/response/ReviewWithProductPageResponse.java
+++ b/backend/src/main/java/com/woowacourse/f12/dto/response/ReviewWithProductPageResponse.java
@@ -1,0 +1,30 @@
+package com.woowacourse.f12.dto.response;
+
+import com.woowacourse.f12.domain.Review;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.Getter;
+import org.springframework.data.domain.Slice;
+
+@Getter
+public class ReviewWithProductPageResponse {
+
+    private boolean hasNext;
+    private List<ReviewWithProductResponse> items;
+
+    private ReviewWithProductPageResponse() {
+    }
+
+    private ReviewWithProductPageResponse(final boolean hasNext, final List<ReviewWithProductResponse> items) {
+        this.hasNext = hasNext;
+        this.items = items;
+    }
+
+    public static ReviewWithProductPageResponse from(final Slice<Review> reviews) {
+        List<ReviewWithProductResponse> items = reviews.getContent()
+                .stream()
+                .map(ReviewWithProductResponse::from)
+                .collect(Collectors.toList());
+        return new ReviewWithProductPageResponse(reviews.hasNext(), items);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/dto/response/ReviewWithProductResponse.java
+++ b/backend/src/main/java/com/woowacourse/f12/dto/response/ReviewWithProductResponse.java
@@ -1,0 +1,33 @@
+package com.woowacourse.f12.dto.response;
+
+import com.woowacourse.f12.domain.Review;
+import lombok.Getter;
+
+@Getter
+public class ReviewWithProductResponse {
+
+    private Long id;
+    private KeyboardForReviewResponse product;
+    private String content;
+    private int rating;
+    private String createdAt;
+
+    private ReviewWithProductResponse() {
+    }
+
+    private ReviewWithProductResponse(final Long id, final KeyboardForReviewResponse product, final String content,
+                                      final int rating,
+                                      final String createdAt) {
+        this.id = id;
+        this.product = product;
+        this.content = content;
+        this.rating = rating;
+        this.createdAt = createdAt;
+    }
+
+    public static ReviewWithProductResponse from(final Review review) {
+        final KeyboardForReviewResponse product = KeyboardForReviewResponse.from(review.getKeyboard());
+        return new ReviewWithProductResponse(review.getId(), product, review.getContent(), review.getRating(),
+                review.getCreatedAt().toString());
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/presentation/ReviewController.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/ReviewController.java
@@ -3,6 +3,7 @@ package com.woowacourse.f12.presentation;
 import com.woowacourse.f12.application.ReviewService;
 import com.woowacourse.f12.dto.request.ReviewRequest;
 import com.woowacourse.f12.dto.response.ReviewPageResponse;
+import com.woowacourse.f12.dto.response.ReviewWithProductPageResponse;
 import java.net.URI;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
@@ -39,8 +40,8 @@ public class ReviewController {
     }
 
     @GetMapping("/reviews")
-    public ResponseEntity<ReviewPageResponse> showPage(final Pageable pageable) {
-        final ReviewPageResponse reviewPageResponse = reviewService.findPage(pageable);
-        return ResponseEntity.ok(reviewPageResponse);
+    public ResponseEntity<ReviewWithProductPageResponse> showPage(final Pageable pageable) {
+        final ReviewWithProductPageResponse reviewWithProductPageResponse = reviewService.findPage(pageable);
+        return ResponseEntity.ok(reviewWithProductPageResponse);
     }
 }

--- a/backend/src/test/java/com/woowacourse/f12/acceptance/ReviewAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/acceptance/ReviewAcceptanceTest.java
@@ -11,6 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import com.woowacourse.f12.domain.Keyboard;
 import com.woowacourse.f12.domain.KeyboardRepository;
 import com.woowacourse.f12.dto.response.ReviewPageResponse;
+import com.woowacourse.f12.dto.response.ReviewWithProductPageResponse;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.Test;
@@ -96,8 +97,8 @@ public class ReviewAcceptanceTest extends AcceptanceTest {
         // then
         assertAll(
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
-                () -> assertThat(response.as(ReviewPageResponse.class).isHasNext()).isFalse(),
-                () -> assertThat(response.as(ReviewPageResponse.class).getItems())
+                () -> assertThat(response.as(ReviewWithProductPageResponse.class).isHasNext()).isFalse(),
+                () -> assertThat(response.as(ReviewWithProductPageResponse.class).getItems())
                         .extracting("id")
                         .containsExactly(reviewId2, reviewId1)
         );

--- a/backend/src/test/java/com/woowacourse/f12/application/ReviewServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/application/ReviewServiceTest.java
@@ -17,6 +17,7 @@ import com.woowacourse.f12.domain.Review;
 import com.woowacourse.f12.domain.ReviewRepository;
 import com.woowacourse.f12.dto.request.ReviewRequest;
 import com.woowacourse.f12.dto.response.ReviewPageResponse;
+import com.woowacourse.f12.dto.response.ReviewWithProductPageResponse;
 import com.woowacourse.f12.exception.KeyboardNotFoundException;
 import java.util.List;
 import java.util.Optional;
@@ -141,14 +142,14 @@ class ReviewServiceTest {
                 .willReturn(slice);
 
         // when
-        ReviewPageResponse reviewPageResponse = reviewService.findPage(pageable);
+        ReviewWithProductPageResponse reviewWithProductPageResponse = reviewService.findPage(pageable);
 
         // then
         assertAll(
-                () -> assertThat(reviewPageResponse.getItems()).hasSize(2)
+                () -> assertThat(reviewWithProductPageResponse.getItems()).hasSize(2)
                         .extracting("id")
                         .containsExactly(3L, 2L),
-                () -> assertThat(reviewPageResponse.isHasNext()).isTrue(),
+                () -> assertThat(reviewWithProductPageResponse.isHasNext()).isTrue(),
                 () -> verify(reviewRepository).findPageBy(pageable)
         );
     }

--- a/backend/src/test/java/com/woowacourse/f12/presentation/ReviewControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/ReviewControllerTest.java
@@ -16,6 +16,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.woowacourse.f12.application.ReviewService;
 import com.woowacourse.f12.dto.request.ReviewRequest;
 import com.woowacourse.f12.dto.response.ReviewPageResponse;
+import com.woowacourse.f12.dto.response.ReviewWithProductPageResponse;
 import com.woowacourse.f12.exception.BlankContentException;
 import com.woowacourse.f12.exception.InvalidContentLengthException;
 import com.woowacourse.f12.exception.InvalidRatingValueException;
@@ -150,7 +151,8 @@ class ReviewControllerTest {
     void 전체_리뷰_페이지_조회_성공() throws Exception {
         // given
         given(reviewService.findPage(any(Pageable.class)))
-                .willReturn(ReviewPageResponse.from(new SliceImpl<>(List.of(REVIEW_RATING_5.작성(1L, KEYBOARD_1.생성())))));
+                .willReturn(ReviewWithProductPageResponse.from(
+                        new SliceImpl<>(List.of(REVIEW_RATING_5.작성(1L, KEYBOARD_1.생성())))));
 
         // when
         mockMvc.perform(get("/api/v1/reviews?size=150&page=0&sort=rating,desc"))


### PR DESCRIPTION
# issue: closed #79 

# 작업 내용
- 키보드 정보를 담은 리뷰 response DTO를 추가했다.
- 해당 response의 페이지를 가지는 새로운 페이지 DTO를 추가했다.
- 특정 조건 없이 전체 리뷰를 조회하는 api의 응답 타입을 새로 만든 DTO로 변경했다.
