### PR TITLE
[BE] 페이지 조회 요청에서 NumberFormat 체크하여 예외 처리하도록 수정

### DIFF
--- a/backend/src/main/java/com/woowacourse/f12/exception/InvalidPageNumberFormatException.java
+++ b/backend/src/main/java/com/woowacourse/f12/exception/InvalidPageNumberFormatException.java
@@ -1,0 +1,8 @@
+package com.woowacourse.f12.exception;
+
+public class InvalidPageNumberFormatException extends InvalidValueException {
+
+    public InvalidPageNumberFormatException() {
+        super("페이지 번호는 숫자 형식이여야 합니다.");
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/exception/InvalidPageSizeFormatException.java
+++ b/backend/src/main/java/com/woowacourse/f12/exception/InvalidPageSizeFormatException.java
@@ -1,0 +1,8 @@
+package com.woowacourse.f12.exception;
+
+public class InvalidPageSizeFormatException extends InvalidValueException {
+
+    public InvalidPageSizeFormatException() {
+        super("패이지 크기는 숫자 형식이어야 합니다.");
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/presentation/CustomPageableHandlerMethodArgumentResolver.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/CustomPageableHandlerMethodArgumentResolver.java
@@ -1,7 +1,10 @@
 package com.woowacourse.f12.presentation;
 
 import com.woowacourse.f12.exception.InvalidPageSizeException;
+import com.woowacourse.f12.exception.InvalidPageSizeFormatException;
 import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.springframework.core.MethodParameter;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
@@ -12,6 +15,7 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 public class CustomPageableHandlerMethodArgumentResolver extends PageableHandlerMethodArgumentResolver {
 
     private static final int MAX_SIZE = 150;
+    private static final Pattern NUMBER_PATTERN = Pattern.compile("^[0-9]*$");
 
     @Override
     public boolean supportsParameter(final MethodParameter parameter) {
@@ -27,7 +31,14 @@ public class CustomPageableHandlerMethodArgumentResolver extends PageableHandler
     }
 
     private void validateSize(final String sizeArgument) {
-        if (Objects.nonNull(sizeArgument) && Integer.parseInt(sizeArgument) > MAX_SIZE) {
+        if (Objects.isNull(sizeArgument)) {
+            return;
+        }
+        final Matcher matcher = NUMBER_PATTERN.matcher(sizeArgument);
+        if (!matcher.matches()) {
+            throw new InvalidPageSizeFormatException();
+        }
+        if (Integer.parseInt(sizeArgument) > MAX_SIZE) {
             throw new InvalidPageSizeException(MAX_SIZE);
         }
     }

--- a/backend/src/main/java/com/woowacourse/f12/presentation/CustomPageableHandlerMethodArgumentResolver.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/CustomPageableHandlerMethodArgumentResolver.java
@@ -1,5 +1,6 @@
 package com.woowacourse.f12.presentation;
 
+import com.woowacourse.f12.exception.InvalidPageNumberFormatException;
 import com.woowacourse.f12.exception.InvalidPageSizeException;
 import com.woowacourse.f12.exception.InvalidPageSizeFormatException;
 import java.util.Objects;
@@ -25,9 +26,21 @@ public class CustomPageableHandlerMethodArgumentResolver extends PageableHandler
     @Override
     public Pageable resolveArgument(final MethodParameter methodParameter, final ModelAndViewContainer mavContainer,
                                     final NativeWebRequest webRequest, final WebDataBinderFactory binderFactory) {
+        final String pageArgument = webRequest.getParameter("page");
+        validatePage(pageArgument);
         final String sizeArgument = webRequest.getParameter("size");
         validateSize(sizeArgument);
         return super.resolveArgument(methodParameter, mavContainer, webRequest, binderFactory);
+    }
+
+    private void validatePage(final String pageArgument) {
+        if (Objects.isNull(pageArgument)) {
+            return;
+        }
+        final Matcher matcher = NUMBER_PATTERN.matcher(pageArgument);
+        if (!matcher.matches()) {
+            throw new InvalidPageNumberFormatException();
+        }
     }
 
     private void validateSize(final String sizeArgument) {

--- a/backend/src/test/java/com/woowacourse/f12/presentation/CustomPageableHandlerMethodArgumentResolverTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/CustomPageableHandlerMethodArgumentResolverTest.java
@@ -31,6 +31,22 @@ public class CustomPageableHandlerMethodArgumentResolverTest {
     private KeyboardService keyboardService;
 
     @Test
+    void 페이징_실패_페이지_번호_숫자_형식_아님() throws Exception {
+        // given
+        given(keyboardService.findPage(any(Pageable.class)))
+                .willReturn(KeyboardPageResponse.from(new SliceImpl<>(List.of())));
+
+        // when
+        mockMvc.perform(get("/api/v1/keyboards?page=abc&size=10&sort=rating,desc"))
+                .andExpect(status().isBadRequest())
+                .andDo(print());
+
+        // then
+        verify(keyboardService, times(0))
+                .findPage(any(Pageable.class));
+    }
+
+    @Test
     void 페이징_실패_최대_페이징_크기_초과() throws Exception {
         // given
         given(keyboardService.findPage(any(Pageable.class)))

--- a/backend/src/test/java/com/woowacourse/f12/presentation/CustomPageableHandlerMethodArgumentResolverTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/CustomPageableHandlerMethodArgumentResolverTest.java
@@ -47,6 +47,22 @@ public class CustomPageableHandlerMethodArgumentResolverTest {
     }
 
     @Test
+    void 페이징_실패_페이징_크기_숫자_형식_아님() throws Exception {
+        // given
+        given(keyboardService.findPage(any(Pageable.class)))
+                .willReturn(KeyboardPageResponse.from(new SliceImpl<>(List.of())));
+
+        // when
+        mockMvc.perform(get("/api/v1/keyboards?page=0&size=abc&sort=rating,desc"))
+                .andExpect(status().isBadRequest())
+                .andDo(print());
+
+        // then
+        verify(keyboardService, times(0))
+                .findPage(any(Pageable.class));
+    }
+
+    @Test
     void 페이징_성공_페이징_값_지정_안할_경우_기본값으로_페이징() throws Exception {
         // given
         given(keyboardService.findPage(any(Pageable.class)))


### PR DESCRIPTION
# issue: #69 

# 작업 내용
- 페이지 번호가 숫자 형식이 아닌 경우 예외 발생하도록 구현
- 페이지 크기가 숫자 형식이 아닌 경우 예외 발생하도록 구현
- null 인 경우 먼저 처리하여 정규표현식 검증에서 NPE 가 발생하지 않도록 구현