### PR TITLE
[BE] GitHub Oauth 로그인 기능 구현

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### auth ###
+application-auth.yml

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -55,6 +55,10 @@ tasks.named('test') {
 tasks.named('asciidoctor') {
     configurations 'asciidoctorExtensions'
     inputs.dir snippetsDir
+    sources {
+        include("**/index.adoc")
+    }
+    baseDirFollowsSourceFile()
     dependsOn test
 }
 

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -18,9 +18,10 @@ repositories {
 }
 
 dependencies {
-	  implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-  	implementation 'org.springframework.boot:spring-boot-starter-web'
-	  implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
     runtimeOnly 'com.h2database:h2'
 

--- a/backend/src/docs/asciidoc/auth.adoc
+++ b/backend/src/docs/asciidoc/auth.adoc
@@ -1,0 +1,11 @@
+[[Auth]]
+== Auth API
+
+:doctype: book
+:toc: left
+:toclevels: 2
+:sectlinks:
+
+=== 로그인
+
+operation::auth-login[snippets='http-request,http-response']

--- a/backend/src/docs/asciidoc/auth.adoc
+++ b/backend/src/docs/asciidoc/auth.adoc
@@ -1,11 +1,6 @@
 [[Auth]]
 == Auth API
 
-:doctype: book
-:toc: left
-:toclevels: 2
-:sectlinks:
-
 === 로그인
 
 operation::auth-login[snippets='http-request,http-response']

--- a/backend/src/docs/asciidoc/index.adoc
+++ b/backend/src/docs/asciidoc/index.adoc
@@ -1,0 +1,10 @@
+:doctype: book
+:toc: left
+:toclevels: 2
+:sectlinks:
+
+= F12
+
+include::auth.adoc[]
+include::keyboards.adoc[]
+include::reviews.adoc[]

--- a/backend/src/docs/asciidoc/keyboards.adoc
+++ b/backend/src/docs/asciidoc/keyboards.adoc
@@ -1,9 +1,5 @@
-= Keyboard API
-
-:doctype: book
-:toc: left
-:toclevels: 2
-:sectlinks:
+[[Keyboard]]
+== Keyboard API
 
 === 키보드 단일 상품 조회
 

--- a/backend/src/docs/asciidoc/reviews.adoc
+++ b/backend/src/docs/asciidoc/reviews.adoc
@@ -1,9 +1,5 @@
-= Review API
-
-:doctype: book
-:toc: left
-:toclevels: 2
-:sectlinks:
+[[Reivew]]
+== Review API
 
 === 리뷰 작성
 

--- a/backend/src/main/java/com/woowacourse/f12/application/AuthService.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/AuthService.java
@@ -1,0 +1,34 @@
+package com.woowacourse.f12.application;
+
+import com.woowacourse.f12.domain.Member;
+import com.woowacourse.f12.domain.MemberRepository;
+import com.woowacourse.f12.dto.response.GitHubProfileResponse;
+import com.woowacourse.f12.dto.response.LoginResponse;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class AuthService {
+
+    private final GitHubOauthClient gitHubOauthClient;
+    private final MemberRepository memberRepository;
+    private final JwtProvider jwtProvider;
+
+    public AuthService(final GitHubOauthClient gitHubOauthClient, final MemberRepository memberRepository,
+                       final JwtProvider jwtProvider) {
+        this.gitHubOauthClient = gitHubOauthClient;
+        this.memberRepository = memberRepository;
+        this.jwtProvider = jwtProvider;
+    }
+
+    public LoginResponse login(final String code) {
+        final String gitHubAccessToken = gitHubOauthClient.getAccessToken(code);
+        final GitHubProfileResponse gitHubProfileResponse = gitHubOauthClient.getProfile(gitHubAccessToken);
+        final Member member = memberRepository.findByGitHubId(gitHubProfileResponse.getGitHubId())
+                .orElseGet(() -> memberRepository.save(gitHubProfileResponse.toMember()));
+        member.updateName(gitHubProfileResponse.getName());
+        final String applicationAccessToken = jwtProvider.createToken(member.getId());
+        return LoginResponse.of(applicationAccessToken, member);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/application/GitHubOauthClient.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/GitHubOauthClient.java
@@ -1,0 +1,57 @@
+package com.woowacourse.f12.application;
+
+import com.woowacourse.f12.dto.request.GitHubTokenRequest;
+import com.woowacourse.f12.dto.response.GitHubTokenResponse;
+import com.woowacourse.f12.exception.GitHubServerException;
+import com.woowacourse.f12.exception.InvalidGitHubLoginException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Component
+public class GitHubOauthClient {
+
+    private final String clientId;
+    private final String secret;
+    private final String accessTokenUrl;
+    private final String profileUrl;
+
+    public GitHubOauthClient(@Value("${github.client.id}") final String clientId,
+                             @Value("${github.client.secret}") final String secret,
+                             @Value("${github.url.accessToken}") final String accessTokenUrl,
+                             @Value("${github.url.user}") final String profileUrl) {
+        this.clientId = clientId;
+        this.secret = secret;
+        this.accessTokenUrl = accessTokenUrl;
+        this.profileUrl = profileUrl;
+    }
+
+    public String getAccessToken(final String code) {
+        final GitHubTokenRequest gitHubTokenRequest = new GitHubTokenRequest(clientId, secret, code);
+        final GitHubTokenResponse gitHubTokenResponse = requestGitHubAccessToken(gitHubTokenRequest);
+        return gitHubTokenResponse.getAccessToken();
+    }
+
+    private GitHubTokenResponse requestGitHubAccessToken(final GitHubTokenRequest gitHubTokenRequest) {
+        final WebClient webClient = WebClient.builder()
+                .baseUrl(accessTokenUrl)
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .build();
+        return webClient.post()
+                .body(Mono.just(gitHubTokenRequest), GitHubTokenRequest.class)
+                .retrieve()
+                .onStatus(HttpStatus::is4xxClientError, clientResponse -> {
+                    throw new InvalidGitHubLoginException();
+                })
+                .onStatus(HttpStatus::is5xxServerError, clientResponse -> {
+                    throw new GitHubServerException();
+                })
+                .bodyToMono(GitHubTokenResponse.class)
+                .blockOptional()
+                .orElseThrow(InvalidGitHubLoginException::new);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/application/GitHubOauthClient.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/GitHubOauthClient.java
@@ -1,6 +1,7 @@
 package com.woowacourse.f12.application;
 
 import com.woowacourse.f12.dto.request.GitHubTokenRequest;
+import com.woowacourse.f12.dto.response.GitHubProfileResponse;
 import com.woowacourse.f12.dto.response.GitHubTokenResponse;
 import com.woowacourse.f12.exception.GitHubServerException;
 import com.woowacourse.f12.exception.InvalidGitHubLoginException;
@@ -51,6 +52,24 @@ public class GitHubOauthClient {
                     throw new GitHubServerException();
                 })
                 .bodyToMono(GitHubTokenResponse.class)
+                .blockOptional()
+                .orElseThrow(InvalidGitHubLoginException::new);
+    }
+
+    public GitHubProfileResponse getProfile(final String accessToken) {
+        final WebClient webClient = WebClient.builder()
+                .baseUrl(profileUrl)
+                .defaultHeader(HttpHeaders.AUTHORIZATION, "token " + accessToken)
+                .build();
+        return webClient.get()
+                .retrieve()
+                .onStatus(HttpStatus::is4xxClientError, clientResponse -> {
+                    throw new InvalidGitHubLoginException();
+                })
+                .onStatus(HttpStatus::is5xxServerError, clientResponse -> {
+                    throw new GitHubServerException();
+                })
+                .bodyToMono(GitHubProfileResponse.class)
                 .blockOptional()
                 .orElseThrow(InvalidGitHubLoginException::new);
     }

--- a/backend/src/main/java/com/woowacourse/f12/application/JwtProvider.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/JwtProvider.java
@@ -1,0 +1,35 @@
+package com.woowacourse.f12.application;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Date;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtProvider {
+
+    private final Key secretKey;
+    private final long validityInMilliseconds;
+
+    public JwtProvider(@Value("${security.jwt.secret-key}") final String secretKey,
+                       @Value("${security.jwt.expire-length}") final long validityInMilliseconds) {
+        this.secretKey = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
+        this.validityInMilliseconds = validityInMilliseconds;
+    }
+
+    public String createToken(final Long id) {
+        final Date now = new Date();
+        final Date validity = new Date(now.getTime() + validityInMilliseconds);
+
+        return Jwts.builder()
+                .setSubject(id.toString())
+                .setIssuedAt(now)
+                .setExpiration(validity)
+                .signWith(secretKey, SignatureAlgorithm.HS256)
+                .compact();
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/domain/Member.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/Member.java
@@ -1,0 +1,65 @@
+package com.woowacourse.f12.domain;
+
+import java.util.Objects;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Table(name = "member")
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "github_id", nullable = false)
+    private String gitHubId;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "image_url", nullable = false)
+    private String imageUrl;
+
+    protected Member() {
+    }
+
+    @Builder
+    private Member(final Long id, final String gitHubId, final String name, final String imageUrl) {
+        this.id = id;
+        this.gitHubId = gitHubId;
+        this.name = name;
+        this.imageUrl = imageUrl;
+    }
+
+    public void updateName(final String name) {
+        this.name = name;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final Member member = (Member) o;
+        return Objects.equals(id, member.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/domain/MemberRepository.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/MemberRepository.java
@@ -1,0 +1,9 @@
+package com.woowacourse.f12.domain;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findByGitHubId(String gitHubId);
+}

--- a/backend/src/main/java/com/woowacourse/f12/dto/request/GitHubTokenRequest.java
+++ b/backend/src/main/java/com/woowacourse/f12/dto/request/GitHubTokenRequest.java
@@ -1,0 +1,24 @@
+package com.woowacourse.f12.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class GitHubTokenRequest {
+
+    @JsonProperty("client_id")
+    private String clientId;
+
+    @JsonProperty("client_secret")
+    private String clientSecret;
+    private String code;
+
+    private GitHubTokenRequest() {
+    }
+
+    public GitHubTokenRequest(final String clientId, final String clientSecret, final String code) {
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+        this.code = code;
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/dto/response/GitHubProfileResponse.java
+++ b/backend/src/main/java/com/woowacourse/f12/dto/response/GitHubProfileResponse.java
@@ -1,6 +1,7 @@
 package com.woowacourse.f12.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.woowacourse.f12.domain.Member;
 import lombok.Getter;
 
 @Getter
@@ -22,5 +23,13 @@ public class GitHubProfileResponse {
         this.gitHubId = gitHubId;
         this.name = name;
         this.imageUrl = imageUrl;
+    }
+
+    public Member toMember() {
+        return Member.builder()
+                .gitHubId(this.gitHubId)
+                .name(this.name)
+                .imageUrl(this.imageUrl)
+                .build();
     }
 }

--- a/backend/src/main/java/com/woowacourse/f12/dto/response/GitHubProfileResponse.java
+++ b/backend/src/main/java/com/woowacourse/f12/dto/response/GitHubProfileResponse.java
@@ -1,0 +1,26 @@
+package com.woowacourse.f12.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class GitHubProfileResponse {
+
+    @JsonProperty("login")
+    private String gitHubId;
+
+    @JsonProperty("name")
+    private String name;
+
+    @JsonProperty("avatar_url")
+    private String imageUrl;
+
+    private GitHubProfileResponse() {
+    }
+
+    public GitHubProfileResponse(final String gitHubId, final String name, final String imageUrl) {
+        this.gitHubId = gitHubId;
+        this.name = name;
+        this.imageUrl = imageUrl;
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/dto/response/GitHubTokenResponse.java
+++ b/backend/src/main/java/com/woowacourse/f12/dto/response/GitHubTokenResponse.java
@@ -1,0 +1,18 @@
+package com.woowacourse.f12.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class GitHubTokenResponse {
+
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    private GitHubTokenResponse() {
+    }
+
+    public GitHubTokenResponse(final String accessToken) {
+        this.accessToken = accessToken;
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/dto/response/LoginResponse.java
+++ b/backend/src/main/java/com/woowacourse/f12/dto/response/LoginResponse.java
@@ -1,0 +1,24 @@
+package com.woowacourse.f12.dto.response;
+
+import com.woowacourse.f12.domain.Member;
+import lombok.Getter;
+
+@Getter
+public class LoginResponse {
+
+    private String token;
+    private MemberResponse member;
+
+    private LoginResponse() {
+    }
+
+    private LoginResponse(final String token, final MemberResponse member) {
+        this.token = token;
+        this.member = member;
+    }
+
+    public static LoginResponse of(final String token, final Member member) {
+        final MemberResponse memberResponse = MemberResponse.from(member);
+        return new LoginResponse(token, memberResponse);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/dto/response/MemberResponse.java
+++ b/backend/src/main/java/com/woowacourse/f12/dto/response/MemberResponse.java
@@ -1,0 +1,27 @@
+package com.woowacourse.f12.dto.response;
+
+import com.woowacourse.f12.domain.Member;
+import lombok.Getter;
+
+@Getter
+public class MemberResponse {
+
+    private Long id;
+    private String gitHubId;
+    private String name;
+    private String imageUrl;
+
+    private MemberResponse() {
+    }
+
+    private MemberResponse(final Long id, final String gitHubId, final String name, final String imageUrl) {
+        this.id = id;
+        this.gitHubId = gitHubId;
+        this.name = name;
+        this.imageUrl = imageUrl;
+    }
+
+    public static MemberResponse from(final Member member) {
+        return new MemberResponse(member.getId(), member.getGitHubId(), member.getName(), member.getImageUrl());
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/exception/ExternalServerException.java
+++ b/backend/src/main/java/com/woowacourse/f12/exception/ExternalServerException.java
@@ -1,0 +1,8 @@
+package com.woowacourse.f12.exception;
+
+public class ExternalServerException extends RuntimeException {
+
+    public ExternalServerException(final String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/exception/GitHubServerException.java
+++ b/backend/src/main/java/com/woowacourse/f12/exception/GitHubServerException.java
@@ -1,0 +1,8 @@
+package com.woowacourse.f12.exception;
+
+public class GitHubServerException extends ExternalServerException {
+
+    public GitHubServerException() {
+        super("GitHub 서버에 문제가 있습니다.");
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/exception/InvalidGitHubLoginException.java
+++ b/backend/src/main/java/com/woowacourse/f12/exception/InvalidGitHubLoginException.java
@@ -1,0 +1,8 @@
+package com.woowacourse.f12.exception;
+
+public class InvalidGitHubLoginException extends InvalidValueException {
+
+    public InvalidGitHubLoginException() {
+        super("잘못된 GitHub 로그인 요청입니다.");
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/presentation/AuthController.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/AuthController.java
@@ -1,0 +1,25 @@
+package com.woowacourse.f12.presentation;
+
+import com.woowacourse.f12.application.AuthService;
+import com.woowacourse.f12.dto.response.LoginResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1")
+public class AuthController {
+
+    private final AuthService authService;
+
+    public AuthController(final AuthService authService) {
+        this.authService = authService;
+    }
+
+    @GetMapping("/login")
+    public ResponseEntity<LoginResponse> login(@RequestParam final String code) {
+        return ResponseEntity.ok().body(authService.login(code));
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,4 +1,6 @@
 spring:
+  profiles:
+    include: auth
   datasource:
     url: jdbc:h2:tcp://localhost/~/f12;MODE=MySQL
     username: sa

--- a/backend/src/test/java/com/woowacourse/f12/acceptance/AcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/acceptance/AcceptanceTest.java
@@ -8,7 +8,7 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
 
-@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@SpringBootTest(webEnvironment = WebEnvironment.DEFINED_PORT)
 @DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
 public class AcceptanceTest {
 

--- a/backend/src/test/java/com/woowacourse/f12/acceptance/AuthAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/acceptance/AuthAcceptanceTest.java
@@ -1,0 +1,26 @@
+package com.woowacourse.f12.acceptance;
+
+import static com.woowacourse.f12.acceptance.support.RestAssuredRequestUtil.GET_요청을_보낸다;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.woowacourse.f12.dto.response.LoginResponse;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+class AuthAcceptanceTest extends AcceptanceTest {
+
+    @Test
+    void 로그인_요청이_들어오고_OAUTH_인증에_성공하면_토큰과_회원정보를_반환한다() {
+        // given, when
+        ExtractableResponse<Response> response = GET_요청을_보낸다("/api/v1/login?code=dkasjbdkjas");
+
+        // then
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(response.as(LoginResponse.class)).isNotNull()
+        );
+    }
+}

--- a/backend/src/test/java/com/woowacourse/f12/application/AuthServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/application/AuthServiceTest.java
@@ -1,5 +1,7 @@
 package com.woowacourse.f12.application;
 
+import static com.woowacourse.f12.support.MemberFixtures.CORINNE;
+import static com.woowacourse.f12.support.MemberFixtures.CORINNE_UPDATED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.BDDMockito.given;
@@ -38,20 +40,15 @@ class AuthServiceTest {
         String code = "abcde";
         String accessToken = "accessToken";
         String applicationToken = "applicationToken";
-        GitHubProfileResponse gitHubProfileResponse = new GitHubProfileResponse("gitHubId", "name", "url");
-        Member member = Member.builder()
-                .id(1L)
-                .gitHubId("gitHubId")
-                .name("name")
-                .imageUrl("url")
-                .build();
+        GitHubProfileResponse gitHubProfile = CORINNE.깃허브_프로필();
+        Member member = CORINNE.생성(1L);
         given(gitHubOauthClient.getAccessToken(code))
                 .willReturn(accessToken);
         given(gitHubOauthClient.getProfile(accessToken))
-                .willReturn(gitHubProfileResponse);
-        given(memberRepository.findByGitHubId("gitHubId"))
+                .willReturn(gitHubProfile);
+        given(memberRepository.findByGitHubId(gitHubProfile.getGitHubId()))
                 .willReturn(Optional.empty());
-        given(memberRepository.save(gitHubProfileResponse.toMember()))
+        given(memberRepository.save(gitHubProfile.toMember()))
                 .willReturn(member);
         given(jwtProvider.createToken(member.getId()))
                 .willReturn(applicationToken);
@@ -66,8 +63,8 @@ class AuthServiceTest {
                         .isEqualTo(MemberResponse.from(member)),
                 () -> verify(gitHubOauthClient).getAccessToken(code),
                 () -> verify(gitHubOauthClient).getProfile(accessToken),
-                () -> verify(memberRepository).findByGitHubId("gitHubId"),
-                () -> verify(memberRepository).save(gitHubProfileResponse.toMember()),
+                () -> verify(memberRepository).findByGitHubId(gitHubProfile.getGitHubId()),
+                () -> verify(memberRepository).save(gitHubProfile.toMember()),
                 () -> verify(jwtProvider).createToken(1L)
         );
     }
@@ -78,18 +75,13 @@ class AuthServiceTest {
         String code = "abcde";
         String accessToken = "accessToken";
         String applicationToken = "applicationToken";
-        GitHubProfileResponse gitHubProfileResponse = new GitHubProfileResponse("gitHubId", "updateName", "url");
-        Member member = Member.builder()
-                .id(1L)
-                .gitHubId("gitHubId")
-                .name("name")
-                .imageUrl("url")
-                .build();
+        GitHubProfileResponse gitHubProfile = CORINNE_UPDATED.깃허브_프로필();
+        Member member = CORINNE.생성(1L);
         given(gitHubOauthClient.getAccessToken(code))
                 .willReturn(accessToken);
         given(gitHubOauthClient.getProfile(accessToken))
-                .willReturn(gitHubProfileResponse);
-        given(memberRepository.findByGitHubId("gitHubId"))
+                .willReturn(gitHubProfile);
+        given(memberRepository.findByGitHubId(gitHubProfile.getGitHubId()))
                 .willReturn(Optional.of(member));
         given(jwtProvider.createToken(member.getId()))
                 .willReturn(applicationToken);
@@ -104,7 +96,7 @@ class AuthServiceTest {
                         .isEqualTo(MemberResponse.from(member)),
                 () -> verify(gitHubOauthClient).getAccessToken(code),
                 () -> verify(gitHubOauthClient).getProfile(accessToken),
-                () -> verify(memberRepository).findByGitHubId("gitHubId"),
+                () -> verify(memberRepository).findByGitHubId(gitHubProfile.getGitHubId()),
                 () -> verify(jwtProvider).createToken(1L)
         );
     }

--- a/backend/src/test/java/com/woowacourse/f12/application/AuthServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/application/AuthServiceTest.java
@@ -1,0 +1,111 @@
+package com.woowacourse.f12.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.woowacourse.f12.domain.Member;
+import com.woowacourse.f12.domain.MemberRepository;
+import com.woowacourse.f12.dto.response.GitHubProfileResponse;
+import com.woowacourse.f12.dto.response.LoginResponse;
+import com.woowacourse.f12.dto.response.MemberResponse;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @InjectMocks
+    private AuthService authService;
+
+    @Mock
+    private GitHubOauthClient gitHubOauthClient;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private JwtProvider jwtProvider;
+
+    @Test
+    void 깃허브_코드가_들어왔을때_회원정보가_없으면_새로_저장하고_회원정보와_토큰을_반환한다() {
+        // given
+        String code = "abcde";
+        String accessToken = "accessToken";
+        String applicationToken = "applicationToken";
+        GitHubProfileResponse gitHubProfileResponse = new GitHubProfileResponse("gitHubId", "name", "url");
+        Member member = Member.builder()
+                .id(1L)
+                .gitHubId("gitHubId")
+                .name("name")
+                .imageUrl("url")
+                .build();
+        given(gitHubOauthClient.getAccessToken(code))
+                .willReturn(accessToken);
+        given(gitHubOauthClient.getProfile(accessToken))
+                .willReturn(gitHubProfileResponse);
+        given(memberRepository.findByGitHubId("gitHubId"))
+                .willReturn(Optional.empty());
+        given(memberRepository.save(gitHubProfileResponse.toMember()))
+                .willReturn(member);
+        given(jwtProvider.createToken(member.getId()))
+                .willReturn(applicationToken);
+
+        // when
+        LoginResponse loginResponse = authService.login(code);
+
+        // then
+        assertAll(
+                () -> assertThat(loginResponse.getToken()).isEqualTo(applicationToken),
+                () -> assertThat(loginResponse.getMember()).usingRecursiveComparison()
+                        .isEqualTo(MemberResponse.from(member)),
+                () -> verify(gitHubOauthClient).getAccessToken(code),
+                () -> verify(gitHubOauthClient).getProfile(accessToken),
+                () -> verify(memberRepository).findByGitHubId("gitHubId"),
+                () -> verify(memberRepository).save(gitHubProfileResponse.toMember()),
+                () -> verify(jwtProvider).createToken(1L)
+        );
+    }
+
+    @Test
+    void 깃허브_코드가_들어왔을때_회원정보가_있으면_이름을_업데이트하고_회원정보와_토큰을_반환한다() {
+        // given
+        String code = "abcde";
+        String accessToken = "accessToken";
+        String applicationToken = "applicationToken";
+        GitHubProfileResponse gitHubProfileResponse = new GitHubProfileResponse("gitHubId", "updateName", "url");
+        Member member = Member.builder()
+                .id(1L)
+                .gitHubId("gitHubId")
+                .name("name")
+                .imageUrl("url")
+                .build();
+        given(gitHubOauthClient.getAccessToken(code))
+                .willReturn(accessToken);
+        given(gitHubOauthClient.getProfile(accessToken))
+                .willReturn(gitHubProfileResponse);
+        given(memberRepository.findByGitHubId("gitHubId"))
+                .willReturn(Optional.of(member));
+        given(jwtProvider.createToken(member.getId()))
+                .willReturn(applicationToken);
+
+        // when
+        LoginResponse loginResponse = authService.login(code);
+
+        // then
+        assertAll(
+                () -> assertThat(loginResponse.getToken()).isEqualTo(applicationToken),
+                () -> assertThat(loginResponse.getMember()).usingRecursiveComparison()
+                        .isEqualTo(MemberResponse.from(member)),
+                () -> verify(gitHubOauthClient).getAccessToken(code),
+                () -> verify(gitHubOauthClient).getProfile(accessToken),
+                () -> verify(memberRepository).findByGitHubId("gitHubId"),
+                () -> verify(jwtProvider).createToken(1L)
+        );
+    }
+}

--- a/backend/src/test/java/com/woowacourse/f12/application/GitHubOauthClientTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/application/GitHubOauthClientTest.java
@@ -1,0 +1,24 @@
+package com.woowacourse.f12.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+
+@SpringBootTest(webEnvironment = WebEnvironment.DEFINED_PORT)
+class GitHubOauthClientTest {
+
+    @Autowired
+    private GitHubOauthClient gitHubOauthClient;
+
+    @Test
+    void GitHub에_accessToken을_요청한다() {
+        // given, when
+        String accessToken = gitHubOauthClient.getAccessToken("code");
+
+        // then
+        assertThat(accessToken).isEqualTo("accessToken");
+    }
+}

--- a/backend/src/test/java/com/woowacourse/f12/application/GitHubOauthClientTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/application/GitHubOauthClientTest.java
@@ -2,6 +2,7 @@ package com.woowacourse.f12.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.woowacourse.f12.dto.response.GitHubProfileResponse;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -20,5 +21,19 @@ class GitHubOauthClientTest {
 
         // then
         assertThat(accessToken).isEqualTo("accessToken");
+    }
+
+    @Test
+    void GitHub에_프로필을_요청한다() {
+        // given
+        String accessToken = "accessToken";
+        GitHubProfileResponse expected = new GitHubProfileResponse("gitHubId", "name", "url");
+
+        // when
+        GitHubProfileResponse gitHubProfileResponse = gitHubOauthClient.getProfile(accessToken);
+
+        // then
+        assertThat(gitHubProfileResponse).usingRecursiveComparison()
+                .isEqualTo(expected);
     }
 }

--- a/backend/src/test/java/com/woowacourse/f12/application/JwtProviderTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/application/JwtProviderTest.java
@@ -1,0 +1,23 @@
+package com.woowacourse.f12.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class JwtProviderTest {
+
+    private final JwtProvider jwtProvider = new JwtProvider("testadsddersrsfsddsasdfaefasfkk2313123113trssttrs",
+            3600000);
+
+    @Test
+    void 토큰을_생성한다() {
+        // given
+        Long memberId = 1L;
+
+        // when
+        String token = jwtProvider.createToken(memberId);
+
+        // then
+        assertThat(token).isNotNull();
+    }
+}

--- a/backend/src/test/java/com/woowacourse/f12/documentation/AuthDocumentation.java
+++ b/backend/src/test/java/com/woowacourse/f12/documentation/AuthDocumentation.java
@@ -1,0 +1,51 @@
+package com.woowacourse.f12.documentation;
+
+import static com.woowacourse.f12.support.MemberFixtures.CORINNE;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.woowacourse.f12.application.AuthService;
+import com.woowacourse.f12.domain.Member;
+import com.woowacourse.f12.dto.response.LoginResponse;
+import com.woowacourse.f12.presentation.AuthController;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@WebMvcTest(AuthController.class)
+class AuthDocumentation extends Documentation {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AuthService authService;
+
+    @Test
+    void 로그인_API_문서화() throws Exception {
+        // given
+        String code = "code";
+        String token = "applicationAccessToken";
+        Member member = CORINNE.생성(1L);
+        given(authService.login(code))
+                .willReturn(LoginResponse.of(token, member));
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                get("/api/v1/login?code=" + code)
+        );
+
+        // then
+        resultActions.andExpect(status().isOk())
+                .andDo(print())
+                .andDo(
+                        document("auth-login")
+                );
+    }
+}

--- a/backend/src/test/java/com/woowacourse/f12/presentation/AuthControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/AuthControllerTest.java
@@ -1,0 +1,81 @@
+package com.woowacourse.f12.presentation;
+
+import static com.woowacourse.f12.support.MemberFixtures.CORINNE;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.woowacourse.f12.application.AuthService;
+import com.woowacourse.f12.dto.response.LoginResponse;
+import com.woowacourse.f12.exception.GitHubServerException;
+import com.woowacourse.f12.exception.InvalidGitHubLoginException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(AuthController.class)
+class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AuthService authService;
+
+    @Test
+    void 로그인_성공() throws Exception {
+        // given
+        String code = "code";
+        String token = "token";
+        LoginResponse loginResponse = LoginResponse.of(token, CORINNE.생성(1L));
+        given(authService.login(code))
+                .willReturn(loginResponse);
+
+        // when
+        mockMvc.perform(
+                        get("/api/v1/login?code=" + code)
+                ).andExpect(status().isOk())
+                .andDo(print());
+
+        // then
+        verify(authService).login(code);
+    }
+
+    @Test
+    void 로그인_실패_올바르지_않은_로그인_요청() throws Exception {
+        // given
+        String code = "code";
+        given(authService.login(code))
+                .willThrow(new InvalidGitHubLoginException());
+
+        // when
+        mockMvc.perform(
+                        get("/api/v1/login?code=" + code)
+                ).andExpect(status().isBadRequest())
+                .andDo(print());
+
+        // then
+        verify(authService).login(code);
+    }
+
+    @Test
+    void 로그인_실패_깃허브_서버_오류() throws Exception {
+        // given
+        String code = "code";
+        given(authService.login(code))
+                .willThrow(new GitHubServerException());
+
+        // when
+        mockMvc.perform(
+                        get("/api/v1/login?code=" + code)
+                ).andExpect(status().isInternalServerError())
+                .andDo(print());
+
+        // then
+        verify(authService).login(code);
+    }
+}

--- a/backend/src/test/java/com/woowacourse/f12/support/FakeGitHubApiController.java
+++ b/backend/src/test/java/com/woowacourse/f12/support/FakeGitHubApiController.java
@@ -1,11 +1,15 @@
 package com.woowacourse.f12.support;
 
 import com.woowacourse.f12.dto.request.GitHubTokenRequest;
+import com.woowacourse.f12.dto.response.GitHubProfileResponse;
 import com.woowacourse.f12.dto.response.GitHubTokenResponse;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -21,12 +25,25 @@ public class FakeGitHubApiController {
     }
 
     @PostMapping("/login/oauth/access_token")
-    public ResponseEntity<GitHubTokenResponse> createFakeAccessToken(
+    public ResponseEntity<GitHubTokenResponse> issueFakeAccessToken(
             @RequestBody final GitHubTokenRequest gitHubTokenRequest) {
         if (!gitHubTokenRequest.getClientId().equals(clientId) || !gitHubTokenRequest.getClientSecret()
                 .equals(clientSecret)) {
             return ResponseEntity.badRequest().build();
         }
         return ResponseEntity.ok(new GitHubTokenResponse("accessToken"));
+    }
+
+    @GetMapping("/user")
+    public ResponseEntity<GitHubProfileResponse> showFakeProfile(
+            @RequestHeader(value = HttpHeaders.AUTHORIZATION) final String authorizationHeaderValue) {
+        if (authorizationHeaderValue == null) {
+            return ResponseEntity.badRequest().build();
+        }
+        final String[] splitValue = authorizationHeaderValue.split(" ");
+        if (splitValue.length != 2 || !splitValue[0].equals("token")) {
+            return ResponseEntity.badRequest().build();
+        }
+        return ResponseEntity.ok(new GitHubProfileResponse("gitHubId", "name", "url"));
     }
 }

--- a/backend/src/test/java/com/woowacourse/f12/support/FakeGitHubApiController.java
+++ b/backend/src/test/java/com/woowacourse/f12/support/FakeGitHubApiController.java
@@ -1,0 +1,32 @@
+package com.woowacourse.f12.support;
+
+import com.woowacourse.f12.dto.request.GitHubTokenRequest;
+import com.woowacourse.f12.dto.response.GitHubTokenResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class FakeGitHubApiController {
+
+    private String clientId;
+    private String clientSecret;
+
+    public FakeGitHubApiController(@Value("${github.client.id}") final String clientId,
+                                   @Value("${github.client.secret}") final String clientSecret) {
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+    }
+
+    @PostMapping("/login/oauth/access_token")
+    public ResponseEntity<GitHubTokenResponse> createFakeAccessToken(
+            @RequestBody final GitHubTokenRequest gitHubTokenRequest) {
+        if (!gitHubTokenRequest.getClientId().equals(clientId) || !gitHubTokenRequest.getClientSecret()
+                .equals(clientSecret)) {
+            return ResponseEntity.badRequest().build();
+        }
+        return ResponseEntity.ok(new GitHubTokenResponse("accessToken"));
+    }
+}

--- a/backend/src/test/java/com/woowacourse/f12/support/MemberFixtures.java
+++ b/backend/src/test/java/com/woowacourse/f12/support/MemberFixtures.java
@@ -1,0 +1,33 @@
+package com.woowacourse.f12.support;
+
+import com.woowacourse.f12.domain.Member;
+import com.woowacourse.f12.dto.response.GitHubProfileResponse;
+
+public enum MemberFixtures {
+
+    CORINNE("hamcheeseburger", "유현지", "corinne_url"),
+    CORINNE_UPDATED("hamcheeseburger", "괴물개발자", "corinne_url");
+
+    private final String gitHubId;
+    private final String name;
+    private final String imageUrl;
+
+    MemberFixtures(final String gitHubId, final String name, final String imageUrl) {
+        this.gitHubId = gitHubId;
+        this.name = name;
+        this.imageUrl = imageUrl;
+    }
+
+    public Member 생성(final Long id) {
+        return Member.builder()
+                .id(id)
+                .gitHubId(this.gitHubId)
+                .name(this.name)
+                .imageUrl(this.imageUrl)
+                .build();
+    }
+
+    public GitHubProfileResponse 깃허브_프로필() {
+        return new GitHubProfileResponse(this.gitHubId, this.name, this.imageUrl);
+    }
+}

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -16,4 +16,4 @@ github:
     secret: secret
   url:
     accessToken: http://localhost:8888/login/oauth/access_token
-    user: http://localhost:8888/user/user
+    user: http://localhost:8888/user

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -17,3 +17,8 @@ github:
   url:
     accessToken: http://localhost:8888/login/oauth/access_token
     user: http://localhost:8888/user
+
+security:
+  jwt:
+    secret-key: testfkjasl123jl1kjdklfha2h3eoi1eojqdoiq112lkdldk
+    expire-length: 3600000

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -8,4 +8,12 @@ spring:
         format_sql: true
 
 server:
-  port: 8080
+  port: 8888
+
+github:
+  client:
+    id: clientId
+    secret: secret
+  url:
+    accessToken: http://localhost:8888/login/oauth/access_token
+    user: http://localhost:8888/user/user


### PR DESCRIPTION
# issue: #98 

# 작업 내용
- GitHub Oauth 로그인 기능 구현
  - JWT access token 만 사용
  - token 유효기간 1시간
  - GitHubId, Name, ProfileImage 저장
  - API 요청시 WebClient 사용
  
- REST Docs
  -  Auth 로그인 문서화
  - Index document 에서 모든 API 볼 수 있도록 설정