### PR TITLE
[BE] 인증 과정에서 읽기 전용 트랜잭션이 적용되는 오류 수정

### DIFF
--- a/backend/src/main/java/com/woowacourse/f12/application/AuthService.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/AuthService.java
@@ -22,6 +22,7 @@ public class AuthService {
         this.jwtProvider = jwtProvider;
     }
 
+    @Transactional
     public LoginResponse login(final String code) {
         final String gitHubAccessToken = gitHubOauthClient.getAccessToken(code);
         final GitHubProfileResponse gitHubProfileResponse = gitHubOauthClient.getProfile(gitHubAccessToken);


### PR DESCRIPTION
# issue: #106 

# 작업 내용
- AuthService에 `@Transactional(readOnly = true)`가 달려 있어 데이터베이스에 생성, 수정 작업을 해야 하는 `login` 메서드에서 읽기 전용 트랜잭션이 열리는 오류를 수정