### PR TITLE
[BE] 리뷰 작성에 로그인 검증 기능을 추가

### DIFF
--- a/backend/src/main/java/com/woowacourse/f12/application/JwtProvider.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/JwtProvider.java
@@ -61,4 +61,11 @@ public class JwtProvider {
                 .build()
                 .parseClaimsJws(token);
     }
+
+    public String getPayload(final String authorizationHeader) {
+        final String token = authTokenExtractor.extractToken(authorizationHeader, TOKEN_TYPE);
+        return getClaimsJws(token)
+                .getBody()
+                .getSubject();
+    }
 }

--- a/backend/src/main/java/com/woowacourse/f12/application/JwtProvider.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/JwtProvider.java
@@ -1,5 +1,9 @@
 package com.woowacourse.f12.application;
 
+import com.woowacourse.f12.support.AuthTokenExtractor;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
@@ -12,11 +16,16 @@ import org.springframework.stereotype.Component;
 @Component
 public class JwtProvider {
 
+    private static final String TOKEN_TYPE = "Bearer";
+
+    private final AuthTokenExtractor authTokenExtractor;
     private final Key secretKey;
     private final long validityInMilliseconds;
 
-    public JwtProvider(@Value("${security.jwt.secret-key}") final String secretKey,
+    public JwtProvider(final AuthTokenExtractor authTokenExtractor,
+                       @Value("${security.jwt.secret-key}") final String secretKey,
                        @Value("${security.jwt.expire-length}") final long validityInMilliseconds) {
+        this.authTokenExtractor = authTokenExtractor;
         this.secretKey = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
         this.validityInMilliseconds = validityInMilliseconds;
     }
@@ -31,5 +40,25 @@ public class JwtProvider {
                 .setExpiration(validity)
                 .signWith(secretKey, SignatureAlgorithm.HS256)
                 .compact();
+    }
+
+    public boolean validateToken(final String authorizationHeader) {
+        final String token = authTokenExtractor.extractToken(authorizationHeader, TOKEN_TYPE);
+        try {
+            final Jws<Claims> claims = getClaimsJws(token);
+            return !claims
+                    .getBody()
+                    .getExpiration()
+                    .before(new Date());
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    private Jws<Claims> getClaimsJws(final String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(token);
     }
 }

--- a/backend/src/main/java/com/woowacourse/f12/application/ReviewService.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/ReviewService.java
@@ -2,12 +2,15 @@ package com.woowacourse.f12.application;
 
 import com.woowacourse.f12.domain.Keyboard;
 import com.woowacourse.f12.domain.KeyboardRepository;
+import com.woowacourse.f12.domain.Member;
+import com.woowacourse.f12.domain.MemberRepository;
 import com.woowacourse.f12.domain.Review;
 import com.woowacourse.f12.domain.ReviewRepository;
 import com.woowacourse.f12.dto.request.ReviewRequest;
 import com.woowacourse.f12.dto.response.ReviewPageResponse;
 import com.woowacourse.f12.dto.response.ReviewWithProductPageResponse;
 import com.woowacourse.f12.exception.KeyboardNotFoundException;
+import com.woowacourse.f12.exception.MemberNotFoundException;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -19,16 +22,21 @@ public class ReviewService {
 
     private final ReviewRepository reviewRepository;
     private final KeyboardRepository keyboardRepository;
+    private final MemberRepository memberRepository;
 
-    public ReviewService(final ReviewRepository reviewRepository, final KeyboardRepository keyboardRepository) {
+    public ReviewService(final ReviewRepository reviewRepository, final KeyboardRepository keyboardRepository,
+                         final MemberRepository memberRepository) {
         this.reviewRepository = reviewRepository;
         this.keyboardRepository = keyboardRepository;
+        this.memberRepository = memberRepository;
     }
 
     @Transactional
-    public Long save(final Long productId, final ReviewRequest reviewRequest) {
+    public Long save(final Long productId, final ReviewRequest reviewRequest, final Long memberId) {
         final Keyboard keyboard = keyboardRepository.findById(productId)
                 .orElseThrow(KeyboardNotFoundException::new);
+        final Member member = memberRepository.findById(memberId)
+                .orElseThrow(MemberNotFoundException::new);
         final Review review = reviewRequest.toReview(keyboard);
         return reviewRepository.save(review)
                 .getId();

--- a/backend/src/main/java/com/woowacourse/f12/application/ReviewService.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/ReviewService.java
@@ -1,10 +1,12 @@
 package com.woowacourse.f12.application;
 
+import com.woowacourse.f12.domain.Keyboard;
 import com.woowacourse.f12.domain.KeyboardRepository;
 import com.woowacourse.f12.domain.Review;
 import com.woowacourse.f12.domain.ReviewRepository;
 import com.woowacourse.f12.dto.request.ReviewRequest;
 import com.woowacourse.f12.dto.response.ReviewPageResponse;
+import com.woowacourse.f12.dto.response.ReviewWithProductPageResponse;
 import com.woowacourse.f12.exception.KeyboardNotFoundException;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -25,16 +27,11 @@ public class ReviewService {
 
     @Transactional
     public Long save(final Long productId, final ReviewRequest reviewRequest) {
-        validateKeyboardExists(productId);
-        final Review review = reviewRequest.toReview(productId);
+        final Keyboard keyboard = keyboardRepository.findById(productId)
+                .orElseThrow(KeyboardNotFoundException::new);
+        final Review review = reviewRequest.toReview(keyboard);
         return reviewRepository.save(review)
                 .getId();
-    }
-
-    private void validateKeyboardExists(final Long productId) {
-        if (!keyboardRepository.existsById(productId)) {
-            throw new KeyboardNotFoundException();
-        }
     }
 
     public ReviewPageResponse findPageByProductId(final Long productId, final Pageable pageable) {
@@ -43,8 +40,14 @@ public class ReviewService {
         return ReviewPageResponse.from(page);
     }
 
-    public ReviewPageResponse findPage(final Pageable pageable) {
+    private void validateKeyboardExists(final Long productId) {
+        if (!keyboardRepository.existsById(productId)) {
+            throw new KeyboardNotFoundException();
+        }
+    }
+
+    public ReviewWithProductPageResponse findPage(final Pageable pageable) {
         final Slice<Review> page = reviewRepository.findPageBy(pageable);
-        return ReviewPageResponse.from(page);
+        return ReviewWithProductPageResponse.from(page);
     }
 }

--- a/backend/src/main/java/com/woowacourse/f12/config/WebConfig.java
+++ b/backend/src/main/java/com/woowacourse/f12/config/WebConfig.java
@@ -1,5 +1,6 @@
 package com.woowacourse.f12.config;
 
+import com.woowacourse.f12.presentation.AuthArgumentResolver;
 import com.woowacourse.f12.presentation.AuthInterceptor;
 import com.woowacourse.f12.presentation.CustomPageableArgumentResolver;
 import java.util.List;
@@ -16,9 +17,11 @@ public class WebConfig implements WebMvcConfigurer {
     private static final String CORS_ALLOWED_METHODS = "GET,POST,HEAD,PUT,PATCH,DELETE,TRACE,OPTIONS";
 
     private final AuthInterceptor authInterceptor;
+    private final AuthArgumentResolver authArgumentResolver;
 
-    public WebConfig(final AuthInterceptor authInterceptor) {
+    public WebConfig(final AuthInterceptor authInterceptor, final AuthArgumentResolver authArgumentResolver) {
         this.authInterceptor = authInterceptor;
+        this.authArgumentResolver = authArgumentResolver;
     }
 
     @Override
@@ -38,5 +41,6 @@ public class WebConfig implements WebMvcConfigurer {
         final CustomPageableArgumentResolver customPageableArgumentResolver = new CustomPageableArgumentResolver();
         customPageableArgumentResolver.setMaxPageSize(150);
         resolvers.add(customPageableArgumentResolver);
+        resolvers.add(authArgumentResolver);
     }
 }

--- a/backend/src/main/java/com/woowacourse/f12/config/WebConfig.java
+++ b/backend/src/main/java/com/woowacourse/f12/config/WebConfig.java
@@ -1,11 +1,13 @@
 package com.woowacourse.f12.config;
 
+import com.woowacourse.f12.presentation.AuthInterceptor;
 import com.woowacourse.f12.presentation.CustomPageableHandlerMethodArgumentResolver;
 import java.util.List;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
@@ -13,11 +15,15 @@ public class WebConfig implements WebMvcConfigurer {
 
     private static final String CORS_ALLOWED_METHODS = "GET,POST,HEAD,PUT,PATCH,DELETE,TRACE,OPTIONS";
 
+    private final AuthInterceptor authInterceptor;
+
+    public WebConfig(final AuthInterceptor authInterceptor) {
+        this.authInterceptor = authInterceptor;
+    }
+
     @Override
-    public void addArgumentResolvers(final List<HandlerMethodArgumentResolver> resolvers) {
-        final CustomPageableHandlerMethodArgumentResolver customPageableHandlerMethodArgumentResolver = new CustomPageableHandlerMethodArgumentResolver();
-        customPageableHandlerMethodArgumentResolver.setMaxPageSize(150);
-        resolvers.add(customPageableHandlerMethodArgumentResolver);
+    public void addInterceptors(final InterceptorRegistry registry) {
+        registry.addInterceptor(authInterceptor);
     }
 
     @Override
@@ -25,5 +31,12 @@ public class WebConfig implements WebMvcConfigurer {
         registry.addMapping("/api/**")
                 .allowedMethods(CORS_ALLOWED_METHODS.split(","))
                 .exposedHeaders(HttpHeaders.LOCATION);
+    }
+
+    @Override
+    public void addArgumentResolvers(final List<HandlerMethodArgumentResolver> resolvers) {
+        final CustomPageableHandlerMethodArgumentResolver customPageableHandlerMethodArgumentResolver = new CustomPageableHandlerMethodArgumentResolver();
+        customPageableHandlerMethodArgumentResolver.setMaxPageSize(150);
+        resolvers.add(customPageableHandlerMethodArgumentResolver);
     }
 }

--- a/backend/src/main/java/com/woowacourse/f12/config/WebConfig.java
+++ b/backend/src/main/java/com/woowacourse/f12/config/WebConfig.java
@@ -1,7 +1,7 @@
 package com.woowacourse.f12.config;
 
 import com.woowacourse.f12.presentation.AuthInterceptor;
-import com.woowacourse.f12.presentation.CustomPageableHandlerMethodArgumentResolver;
+import com.woowacourse.f12.presentation.CustomPageableArgumentResolver;
 import java.util.List;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
@@ -35,8 +35,8 @@ public class WebConfig implements WebMvcConfigurer {
 
     @Override
     public void addArgumentResolvers(final List<HandlerMethodArgumentResolver> resolvers) {
-        final CustomPageableHandlerMethodArgumentResolver customPageableHandlerMethodArgumentResolver = new CustomPageableHandlerMethodArgumentResolver();
-        customPageableHandlerMethodArgumentResolver.setMaxPageSize(150);
-        resolvers.add(customPageableHandlerMethodArgumentResolver);
+        final CustomPageableArgumentResolver customPageableArgumentResolver = new CustomPageableArgumentResolver();
+        customPageableArgumentResolver.setMaxPageSize(150);
+        resolvers.add(customPageableArgumentResolver);
     }
 }

--- a/backend/src/main/java/com/woowacourse/f12/domain/Review.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/Review.java
@@ -8,9 +8,12 @@ import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EntityListeners;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 import lombok.Builder;
 import lombok.Getter;
@@ -31,14 +34,15 @@ public class Review {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "product_id", nullable = false)
-    private Long productId;
-
     @Column(name = "content", nullable = false, length = MAXIMUM_CONTENT_LENGTH)
     private String content;
 
     @Column(name = "rating", nullable = false)
     private int rating;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id")
+    private Keyboard keyboard;
 
     @CreatedDate
     @Column(name = "created_at", nullable = false, updatable = false)
@@ -48,14 +52,14 @@ public class Review {
     }
 
     @Builder
-    private Review(final Long id, final Long productId, final String content, final int rating,
+    private Review(final Long id, final String content, final int rating, final Keyboard keyboard,
                    final LocalDateTime createdAt) {
         validateContent(content);
         validateRating(rating);
         this.id = id;
-        this.productId = productId;
         this.content = content;
         this.rating = rating;
+        this.keyboard = keyboard;
         this.createdAt = createdAt;
     }
 

--- a/backend/src/main/java/com/woowacourse/f12/domain/ReviewRepository.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/ReviewRepository.java
@@ -3,9 +3,11 @@ package com.woowacourse.f12.domain;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
+    @Query("select r from Review r where r.keyboard.id = :productId")
     Slice<Review> findPageByProductId(Long productId, Pageable pageable);
 
     Slice<Review> findPageBy(Pageable pageable);

--- a/backend/src/main/java/com/woowacourse/f12/dto/request/ReviewRequest.java
+++ b/backend/src/main/java/com/woowacourse/f12/dto/request/ReviewRequest.java
@@ -1,5 +1,6 @@
 package com.woowacourse.f12.dto.request;
 
+import com.woowacourse.f12.domain.Keyboard;
 import com.woowacourse.f12.domain.Review;
 import javax.validation.constraints.NotNull;
 import lombok.Getter;
@@ -21,9 +22,9 @@ public class ReviewRequest {
         this.rating = rating;
     }
 
-    public Review toReview(final Long productId) {
+    public Review toReview(final Keyboard keyboard) {
         return Review.builder()
-                .productId(productId)
+                .keyboard(keyboard)
                 .content(this.content)
                 .rating(this.rating)
                 .build();

--- a/backend/src/main/java/com/woowacourse/f12/dto/response/KeyboardForReviewResponse.java
+++ b/backend/src/main/java/com/woowacourse/f12/dto/response/KeyboardForReviewResponse.java
@@ -1,0 +1,25 @@
+package com.woowacourse.f12.dto.response;
+
+import com.woowacourse.f12.domain.Keyboard;
+import lombok.Getter;
+
+@Getter
+public class KeyboardForReviewResponse {
+
+    private Long id;
+    private String name;
+    private String imageUrl;
+
+    private KeyboardForReviewResponse() {
+    }
+
+    private KeyboardForReviewResponse(final Long id, final String name, final String imageUrl) {
+        this.id = id;
+        this.name = name;
+        this.imageUrl = imageUrl;
+    }
+
+    public static KeyboardForReviewResponse from(final Keyboard keyboard) {
+        return new KeyboardForReviewResponse(keyboard.getId(), keyboard.getName(), keyboard.getImageUrl());
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/dto/response/ReviewResponse.java
+++ b/backend/src/main/java/com/woowacourse/f12/dto/response/ReviewResponse.java
@@ -25,7 +25,7 @@ public class ReviewResponse {
     }
 
     public static ReviewResponse from(final Review review) {
-        return new ReviewResponse(review.getId(), review.getProductId(), review.getContent(), review.getRating(),
+        return new ReviewResponse(review.getId(), review.getKeyboard().getId(), review.getContent(), review.getRating(),
                 review.getCreatedAt().toString());
     }
 }

--- a/backend/src/main/java/com/woowacourse/f12/dto/response/ReviewWithProductPageResponse.java
+++ b/backend/src/main/java/com/woowacourse/f12/dto/response/ReviewWithProductPageResponse.java
@@ -1,0 +1,30 @@
+package com.woowacourse.f12.dto.response;
+
+import com.woowacourse.f12.domain.Review;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.Getter;
+import org.springframework.data.domain.Slice;
+
+@Getter
+public class ReviewWithProductPageResponse {
+
+    private boolean hasNext;
+    private List<ReviewWithProductResponse> items;
+
+    private ReviewWithProductPageResponse() {
+    }
+
+    private ReviewWithProductPageResponse(final boolean hasNext, final List<ReviewWithProductResponse> items) {
+        this.hasNext = hasNext;
+        this.items = items;
+    }
+
+    public static ReviewWithProductPageResponse from(final Slice<Review> reviews) {
+        List<ReviewWithProductResponse> items = reviews.getContent()
+                .stream()
+                .map(ReviewWithProductResponse::from)
+                .collect(Collectors.toList());
+        return new ReviewWithProductPageResponse(reviews.hasNext(), items);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/dto/response/ReviewWithProductResponse.java
+++ b/backend/src/main/java/com/woowacourse/f12/dto/response/ReviewWithProductResponse.java
@@ -1,0 +1,33 @@
+package com.woowacourse.f12.dto.response;
+
+import com.woowacourse.f12.domain.Review;
+import lombok.Getter;
+
+@Getter
+public class ReviewWithProductResponse {
+
+    private Long id;
+    private KeyboardForReviewResponse product;
+    private String content;
+    private int rating;
+    private String createdAt;
+
+    private ReviewWithProductResponse() {
+    }
+
+    private ReviewWithProductResponse(final Long id, final KeyboardForReviewResponse product, final String content,
+                                      final int rating,
+                                      final String createdAt) {
+        this.id = id;
+        this.product = product;
+        this.content = content;
+        this.rating = rating;
+        this.createdAt = createdAt;
+    }
+
+    public static ReviewWithProductResponse from(final Review review) {
+        final KeyboardForReviewResponse product = KeyboardForReviewResponse.from(review.getKeyboard());
+        return new ReviewWithProductResponse(review.getId(), product, review.getContent(), review.getRating(),
+                review.getCreatedAt().toString());
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/exception/MemberNotFoundException.java
+++ b/backend/src/main/java/com/woowacourse/f12/exception/MemberNotFoundException.java
@@ -1,0 +1,8 @@
+package com.woowacourse.f12.exception;
+
+public class MemberNotFoundException extends NotFoundException {
+
+    public MemberNotFoundException() {
+        super("회원을 찾을 수 없습니다.");
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/exception/UnAuthorizedException.java
+++ b/backend/src/main/java/com/woowacourse/f12/exception/UnAuthorizedException.java
@@ -1,0 +1,8 @@
+package com.woowacourse.f12.exception;
+
+public class UnAuthorizedException extends RuntimeException {
+
+    public UnAuthorizedException() {
+        super("로그인이 필요합니다.");
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/presentation/Auth.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/Auth.java
@@ -1,0 +1,11 @@
+package com.woowacourse.f12.presentation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Auth {
+}

--- a/backend/src/main/java/com/woowacourse/f12/presentation/AuthArgumentResolver.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/AuthArgumentResolver.java
@@ -1,0 +1,39 @@
+package com.woowacourse.f12.presentation;
+
+import com.woowacourse.f12.application.JwtProvider;
+import com.woowacourse.f12.exception.UnAuthorizedException;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class AuthArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final JwtProvider jwtProvider;
+
+    public AuthArgumentResolver(final JwtProvider jwtProvider) {
+        this.jwtProvider = jwtProvider;
+    }
+
+    @Override
+    public boolean supportsParameter(final MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(AuthPrincipal.class);
+    }
+
+    @Override
+    public Object resolveArgument(final MethodParameter parameter, final ModelAndViewContainer mavContainer,
+                                  final NativeWebRequest webRequest, final WebDataBinderFactory binderFactory)
+            throws Exception {
+        final String authorizationHeader = webRequest.getHeader(HttpHeaders.AUTHORIZATION);
+        final String payload = jwtProvider.getPayload(authorizationHeader);
+        try {
+            return Long.parseLong(payload);
+        } catch (NumberFormatException e) {
+            throw new UnAuthorizedException();
+        }
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/presentation/AuthInterceptor.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/AuthInterceptor.java
@@ -1,0 +1,39 @@
+package com.woowacourse.f12.presentation;
+
+import com.woowacourse.f12.application.JwtProvider;
+import com.woowacourse.f12.exception.UnAuthorizedException;
+import java.util.Objects;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+public class AuthInterceptor implements HandlerInterceptor {
+
+    private final JwtProvider jwtProvider;
+
+    public AuthInterceptor(final JwtProvider jwtProvider) {
+        this.jwtProvider = jwtProvider;
+    }
+
+    @Override
+    public boolean preHandle(final HttpServletRequest request, final HttpServletResponse response, final Object handler)
+            throws Exception {
+        if (!(handler instanceof HandlerMethod)) {
+            return true;
+        }
+        HandlerMethod handlerMethod = (HandlerMethod) handler;
+        Auth auth = handlerMethod.getMethodAnnotation(Auth.class);
+        if (Objects.isNull(auth)) {
+            return true;
+        }
+        final String authorizationHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (!jwtProvider.validateToken(authorizationHeader)) {
+            throw new UnAuthorizedException();
+        }
+        return true;
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/presentation/AuthPrincipal.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/AuthPrincipal.java
@@ -5,7 +5,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-@Target(ElementType.METHOD)
+@Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
-public @interface Auth {
+public @interface AuthPrincipal {
 }

--- a/backend/src/main/java/com/woowacourse/f12/presentation/CustomPageableArgumentResolver.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/CustomPageableArgumentResolver.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
-public class CustomPageableHandlerMethodArgumentResolver extends PageableHandlerMethodArgumentResolver {
+public class CustomPageableArgumentResolver extends PageableHandlerMethodArgumentResolver {
 
     private static final int MAX_SIZE = 150;
     private static final Pattern NUMBER_PATTERN = Pattern.compile("^[0-9]*$");

--- a/backend/src/main/java/com/woowacourse/f12/presentation/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.woowacourse.f12.presentation;
 import com.woowacourse.f12.dto.response.ExceptionResponse;
 import com.woowacourse.f12.exception.InvalidValueException;
 import com.woowacourse.f12.exception.NotFoundException;
+import com.woowacourse.f12.exception.UnAuthorizedException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -40,6 +41,11 @@ public class GlobalExceptionHandler {
         exception.getBindingResult().getAllErrors().forEach((error) -> stringBuilder.append(error.getDefaultMessage())
                 .append(System.lineSeparator()));
         return ResponseEntity.badRequest().body(ExceptionResponse.from(stringBuilder.toString()));
+    }
+
+    @ExceptionHandler(UnAuthorizedException.class)
+    public ResponseEntity<ExceptionResponse> handleUnAuthorizedException(final UnAuthorizedException e) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ExceptionResponse.from(e));
     }
 
     @ExceptionHandler(Exception.class)

--- a/backend/src/main/java/com/woowacourse/f12/presentation/ReviewController.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/ReviewController.java
@@ -3,6 +3,7 @@ package com.woowacourse.f12.presentation;
 import com.woowacourse.f12.application.ReviewService;
 import com.woowacourse.f12.dto.request.ReviewRequest;
 import com.woowacourse.f12.dto.response.ReviewPageResponse;
+import com.woowacourse.f12.dto.response.ReviewWithProductPageResponse;
 import java.net.URI;
 import javax.validation.Valid;
 import org.springframework.data.domain.Pageable;
@@ -40,8 +41,8 @@ public class ReviewController {
     }
 
     @GetMapping("/reviews")
-    public ResponseEntity<ReviewPageResponse> showPage(final Pageable pageable) {
-        final ReviewPageResponse reviewPageResponse = reviewService.findPage(pageable);
-        return ResponseEntity.ok(reviewPageResponse);
+    public ResponseEntity<ReviewWithProductPageResponse> showPage(final Pageable pageable) {
+        final ReviewWithProductPageResponse reviewWithProductPageResponse = reviewService.findPage(pageable);
+        return ResponseEntity.ok(reviewWithProductPageResponse);
     }
 }

--- a/backend/src/main/java/com/woowacourse/f12/presentation/ReviewController.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/ReviewController.java
@@ -30,7 +30,7 @@ public class ReviewController {
     public ResponseEntity<Void> create(@PathVariable final Long productId,
                                        @Valid @RequestBody final ReviewRequest reviewRequest,
                                        @AuthPrincipal final Long memberId) {
-        final Long id = reviewService.save(productId, reviewRequest);
+        final Long id = reviewService.save(productId, reviewRequest, memberId);
         return ResponseEntity.created(URI.create("/api/v1/reviews/" + id))
                 .build();
     }

--- a/backend/src/main/java/com/woowacourse/f12/presentation/ReviewController.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/ReviewController.java
@@ -26,6 +26,7 @@ public class ReviewController {
     }
 
     @PostMapping("/keyboards/{productId}/reviews")
+    @Auth
     public ResponseEntity<Void> create(@PathVariable final Long productId,
                                        @Valid @RequestBody final ReviewRequest reviewRequest) {
         final Long id = reviewService.save(productId, reviewRequest);

--- a/backend/src/main/java/com/woowacourse/f12/presentation/ReviewController.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/ReviewController.java
@@ -28,7 +28,8 @@ public class ReviewController {
     @PostMapping("/keyboards/{productId}/reviews")
     @Auth
     public ResponseEntity<Void> create(@PathVariable final Long productId,
-                                       @Valid @RequestBody final ReviewRequest reviewRequest) {
+                                       @Valid @RequestBody final ReviewRequest reviewRequest,
+                                       @AuthPrincipal final Long memberId) {
         final Long id = reviewService.save(productId, reviewRequest);
         return ResponseEntity.created(URI.create("/api/v1/reviews/" + id))
                 .build();

--- a/backend/src/main/java/com/woowacourse/f12/support/AuthTokenExtractor.java
+++ b/backend/src/main/java/com/woowacourse/f12/support/AuthTokenExtractor.java
@@ -1,0 +1,20 @@
+package com.woowacourse.f12.support;
+
+import com.woowacourse.f12.exception.UnAuthorizedException;
+import java.util.Objects;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AuthTokenExtractor {
+
+    public String extractToken(final String authorizationHeader, final String tokenType) {
+        if (Objects.isNull(authorizationHeader)) {
+            throw new UnAuthorizedException();
+        }
+        final String[] splitHeaders = authorizationHeader.split(" ");
+        if (splitHeaders.length != 2 || !splitHeaders[0].equalsIgnoreCase(tokenType)) {
+            throw new UnAuthorizedException();
+        }
+        return splitHeaders[1];
+    }
+}

--- a/backend/src/test/java/com/woowacourse/f12/acceptance/KeyboardAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/acceptance/KeyboardAcceptanceTest.java
@@ -14,6 +14,7 @@ import com.woowacourse.f12.domain.Keyboard;
 import com.woowacourse.f12.domain.KeyboardRepository;
 import com.woowacourse.f12.dto.response.KeyboardPageResponse;
 import com.woowacourse.f12.dto.response.KeyboardResponse;
+import com.woowacourse.f12.dto.response.LoginResponse;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.Test;
@@ -65,9 +66,12 @@ class KeyboardAcceptanceTest extends AcceptanceTest {
         // given
         Keyboard keyboard1 = 키보드를_저장한다(KEYBOARD_1.생성());
         Keyboard keyboard2 = 키보드를_저장한다(KEYBOARD_2.생성());
-        REVIEW_RATING_5.작성_요청을_보낸다(keyboard1.getId());
-        REVIEW_RATING_4.작성_요청을_보낸다(keyboard1.getId());
-        REVIEW_RATING_3.작성_요청을_보낸다(keyboard2.getId());
+        String token = GET_요청을_보낸다("/api/v1/login?code=dkasjbdkjas")
+                .as(LoginResponse.class)
+                .getToken();
+        REVIEW_RATING_5.작성_요청을_보낸다(keyboard1.getId(), token);
+        REVIEW_RATING_4.작성_요청을_보낸다(keyboard1.getId(), token);
+        REVIEW_RATING_3.작성_요청을_보낸다(keyboard2.getId(), token);
 
         // when
         ExtractableResponse<Response> response = GET_요청을_보낸다("/api/v1/keyboards?page=0&size=1&sort=reviewCount,desc");
@@ -87,9 +91,12 @@ class KeyboardAcceptanceTest extends AcceptanceTest {
         // given
         Keyboard keyboard1 = 키보드를_저장한다(KEYBOARD_1.생성());
         Keyboard keyboard2 = 키보드를_저장한다(KEYBOARD_2.생성());
-        REVIEW_RATING_5.작성_요청을_보낸다(keyboard1.getId());
-        REVIEW_RATING_1.작성_요청을_보낸다(keyboard1.getId());
-        REVIEW_RATING_4.작성_요청을_보낸다(keyboard2.getId());
+        String token = GET_요청을_보낸다("/api/v1/login?code=dkasjbdkjas")
+                .as(LoginResponse.class)
+                .getToken();
+        REVIEW_RATING_5.작성_요청을_보낸다(keyboard1.getId(), token);
+        REVIEW_RATING_1.작성_요청을_보낸다(keyboard1.getId(), token);
+        REVIEW_RATING_4.작성_요청을_보낸다(keyboard2.getId(), token);
 
         // when
         ExtractableResponse<Response> response = GET_요청을_보낸다("/api/v1/keyboards?page=0&size=1&sort=rating,desc");

--- a/backend/src/test/java/com/woowacourse/f12/acceptance/ReviewAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/acceptance/ReviewAcceptanceTest.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.woowacourse.f12.domain.Keyboard;
 import com.woowacourse.f12.domain.KeyboardRepository;
+import com.woowacourse.f12.dto.response.LoginResponse;
 import com.woowacourse.f12.dto.response.ReviewPageResponse;
 import com.woowacourse.f12.dto.response.ReviewWithProductPageResponse;
 import io.restassured.response.ExtractableResponse;
@@ -27,9 +28,12 @@ public class ReviewAcceptanceTest extends AcceptanceTest {
     void 키보드가_저장되어있고_키보드에_대한_리뷰를_작성한다() {
         // given
         Keyboard keyboard = 키보드를_저장한다(KEYBOARD_1.생성());
+        String token = GET_요청을_보낸다("/api/v1/login?code=dkasjbdkjas")
+                .as(LoginResponse.class)
+                .getToken();
 
         // when
-        ExtractableResponse<Response> response = REVIEW_RATING_5.작성_요청을_보낸다(keyboard.getId());
+        ExtractableResponse<Response> response = REVIEW_RATING_5.작성_요청을_보낸다(keyboard.getId(), token);
 
         // then
         assertAll(
@@ -42,8 +46,11 @@ public class ReviewAcceptanceTest extends AcceptanceTest {
     void 특정_제품_리뷰_목록을_최신순으로_조회한다() {
         // given
         Keyboard keyboard = 키보드를_저장한다(KEYBOARD_1.생성());
-        REVIEW_RATING_5.작성_요청을_보낸다(keyboard.getId());
-        Long reviewId = Location_헤더에서_id값을_꺼낸다(REVIEW_RATING_5.작성_요청을_보낸다(keyboard.getId()));
+        String token = GET_요청을_보낸다("/api/v1/login?code=dkasjbdkjas")
+                .as(LoginResponse.class)
+                .getToken();
+        REVIEW_RATING_5.작성_요청을_보낸다(keyboard.getId(), token);
+        Long reviewId = Location_헤더에서_id값을_꺼낸다(REVIEW_RATING_5.작성_요청을_보낸다(keyboard.getId(), token));
 
         // when
         String url = "/api/v1/keyboards/" + keyboard.getId() + "/reviews?size=1&page=0&sort=createdAt,desc";
@@ -64,8 +71,11 @@ public class ReviewAcceptanceTest extends AcceptanceTest {
     void 특정_제품_리뷰_목록을_평점순으로_조회한다() {
         // given
         Keyboard keyboard = 키보드를_저장한다(KEYBOARD_1.생성());
-        REVIEW_RATING_4.작성_요청을_보낸다(keyboard.getId());
-        Long reviewId = Location_헤더에서_id값을_꺼낸다(REVIEW_RATING_5.작성_요청을_보낸다(keyboard.getId()));
+        String token = GET_요청을_보낸다("/api/v1/login?code=dkasjbdkjas")
+                .as(LoginResponse.class)
+                .getToken();
+        REVIEW_RATING_4.작성_요청을_보낸다(keyboard.getId(), token);
+        Long reviewId = Location_헤더에서_id값을_꺼낸다(REVIEW_RATING_5.작성_요청을_보낸다(keyboard.getId(), token));
 
         // when
         String url = "/api/v1/keyboards/" + keyboard.getId() + "/reviews?size=1&page=0&sort=rating,desc";
@@ -87,8 +97,11 @@ public class ReviewAcceptanceTest extends AcceptanceTest {
         // given
         Keyboard keyboard1 = 키보드를_저장한다(KEYBOARD_1.생성());
         Keyboard keyboard2 = 키보드를_저장한다(KEYBOARD_2.생성());
-        Long reviewId1 = Location_헤더에서_id값을_꺼낸다(REVIEW_RATING_4.작성_요청을_보낸다(keyboard1.getId()));
-        Long reviewId2 = Location_헤더에서_id값을_꺼낸다(REVIEW_RATING_4.작성_요청을_보낸다(keyboard2.getId()));
+        String token = GET_요청을_보낸다("/api/v1/login?code=dkasjbdkjas")
+                .as(LoginResponse.class)
+                .getToken();
+        Long reviewId1 = Location_헤더에서_id값을_꺼낸다(REVIEW_RATING_4.작성_요청을_보낸다(keyboard1.getId(), token));
+        Long reviewId2 = Location_헤더에서_id값을_꺼낸다(REVIEW_RATING_4.작성_요청을_보낸다(keyboard2.getId(), token));
 
         // when
         ExtractableResponse<Response> response = GET_요청을_보낸다(

--- a/backend/src/test/java/com/woowacourse/f12/acceptance/ReviewAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/acceptance/ReviewAcceptanceTest.java
@@ -11,6 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import com.woowacourse.f12.domain.Keyboard;
 import com.woowacourse.f12.domain.KeyboardRepository;
 import com.woowacourse.f12.dto.response.ReviewPageResponse;
+import com.woowacourse.f12.dto.response.ReviewWithProductPageResponse;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.Test;
@@ -96,8 +97,8 @@ public class ReviewAcceptanceTest extends AcceptanceTest {
         // then
         assertAll(
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
-                () -> assertThat(response.as(ReviewPageResponse.class).isHasNext()).isFalse(),
-                () -> assertThat(response.as(ReviewPageResponse.class).getItems())
+                () -> assertThat(response.as(ReviewWithProductPageResponse.class).isHasNext()).isFalse(),
+                () -> assertThat(response.as(ReviewWithProductPageResponse.class).getItems())
                         .extracting("id")
                         .containsExactly(reviewId2, reviewId1)
         );

--- a/backend/src/test/java/com/woowacourse/f12/acceptance/support/RestAssuredRequestUtil.java
+++ b/backend/src/test/java/com/woowacourse/f12/acceptance/support/RestAssuredRequestUtil.java
@@ -3,6 +3,7 @@ package com.woowacourse.f12.acceptance.support;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 
 public class RestAssuredRequestUtil {
@@ -18,8 +19,10 @@ public class RestAssuredRequestUtil {
                 .extract();
     }
 
-    public static ExtractableResponse<Response> POST_요청을_보낸다(final String url, final Object requestBody) {
+    public static ExtractableResponse<Response> 로그인된_상태로_POST_요청을_보낸다(final String url, final String token,
+                                                                      final Object requestBody) {
         return RestAssured.given().log().all()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .body(requestBody)
                 .when()

--- a/backend/src/test/java/com/woowacourse/f12/application/JwtProviderTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/application/JwtProviderTest.java
@@ -67,4 +67,17 @@ class JwtProviderTest {
         // when, then
         assertThat(jwtProvider.validateToken(authorizationHeader)).isFalse();
     }
+
+    @Test
+    void 토큰의_payload를_복호화한다() {
+        // given
+        String token = jwtProvider.createToken(1L);
+        String authorizationHeader = "Bearer " + token;
+
+        // when
+        String payload = jwtProvider.getPayload(authorizationHeader);
+
+        // then
+        assertThat(payload).isEqualTo("1");
+    }
 }

--- a/backend/src/test/java/com/woowacourse/f12/application/JwtProviderTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/application/JwtProviderTest.java
@@ -2,11 +2,13 @@ package com.woowacourse.f12.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.woowacourse.f12.support.AuthTokenExtractor;
 import org.junit.jupiter.api.Test;
 
 class JwtProviderTest {
 
-    private final JwtProvider jwtProvider = new JwtProvider("testadsddersrsfsddsasdfaefasfkk2313123113trssttrs",
+    private final JwtProvider jwtProvider = new JwtProvider(new AuthTokenExtractor(),
+            "testadsddersrsfsddsasdfaefasfkk2313123113trssttrs",
             3600000);
 
     @Test
@@ -19,5 +21,50 @@ class JwtProviderTest {
 
         // then
         assertThat(token).isNotNull();
+    }
+
+    @Test
+    void 토큰이_유효한_경우() {
+        // given
+        String token = jwtProvider.createToken(1L);
+        String authorizationHeader = "Bearer " + token;
+
+        // when, then
+        assertThat(jwtProvider.validateToken(authorizationHeader)).isTrue();
+    }
+
+    @Test
+    void 토큰의_유효기간이_지난_경우() {
+        // given
+        JwtProvider jwtProvider = new JwtProvider(new AuthTokenExtractor(),
+                "testadsddersrsfsddsasdfaefasfkk2313123113trssttrs",
+                0);
+        String token = jwtProvider.createToken(1L);
+        String authorizationHeader = "Bearer " + token;
+
+        // when, then
+        assertThat(jwtProvider.validateToken(authorizationHeader)).isFalse();
+    }
+
+    @Test
+    void 토큰의_형식이_틀린_경우() {
+        // given
+        String authorizationHeader = "Bearer invalidToken";
+
+        // when, then
+        assertThat(jwtProvider.validateToken(authorizationHeader)).isFalse();
+    }
+
+    @Test
+    void 토큰의_시크릿_키가_틀린_경우() {
+        // given
+        JwtProvider invalidJwtProvider = new JwtProvider(new AuthTokenExtractor(),
+                "invalidlasndflkslflkasnf12sdfasdfasdfa",
+                10000000);
+        String token = invalidJwtProvider.createToken(1L);
+        String authorizationHeader = "Bearer " + token;
+
+        // when, then
+        assertThat(jwtProvider.validateToken(authorizationHeader)).isFalse();
     }
 }

--- a/backend/src/test/java/com/woowacourse/f12/application/ReviewServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/application/ReviewServiceTest.java
@@ -1,5 +1,7 @@
 package com.woowacourse.f12.application;
 
+import static com.woowacourse.f12.support.KeyboardFixtures.KEYBOARD_1;
+import static com.woowacourse.f12.support.KeyboardFixtures.KEYBOARD_2;
 import static com.woowacourse.f12.support.ReviewFixtures.REVIEW_RATING_5;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -9,13 +11,16 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import com.woowacourse.f12.domain.Keyboard;
 import com.woowacourse.f12.domain.KeyboardRepository;
 import com.woowacourse.f12.domain.Review;
 import com.woowacourse.f12.domain.ReviewRepository;
 import com.woowacourse.f12.dto.request.ReviewRequest;
 import com.woowacourse.f12.dto.response.ReviewPageResponse;
+import com.woowacourse.f12.dto.response.ReviewWithProductPageResponse;
 import com.woowacourse.f12.exception.KeyboardNotFoundException;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -45,11 +50,11 @@ class ReviewServiceTest {
         // given
         ReviewRequest reviewRequest = new ReviewRequest("내용", 5);
         Long productId = 1L;
-
-        given(keyboardRepository.existsById(productId))
-                .willReturn(true);
-        given(reviewRepository.save(reviewRequest.toReview(productId)))
-                .willReturn(REVIEW_RATING_5.작성(1L, productId));
+        Keyboard keyboard = KEYBOARD_1.생성(productId);
+        given(keyboardRepository.findById(productId))
+                .willReturn(Optional.of(keyboard));
+        given(reviewRepository.save(reviewRequest.toReview(keyboard)))
+                .willReturn(REVIEW_RATING_5.작성(1L, keyboard));
 
         // when
         Long reviewId = reviewService.save(productId, reviewRequest);
@@ -57,7 +62,7 @@ class ReviewServiceTest {
         // then
         assertAll(
                 () -> assertThat(reviewId).isEqualTo(1L),
-                () -> verify(keyboardRepository).existsById(productId),
+                () -> verify(keyboardRepository).findById(productId),
                 () -> verify(reviewRepository).save(any(Review.class))
         );
     }
@@ -68,14 +73,14 @@ class ReviewServiceTest {
         ReviewRequest reviewRequest = new ReviewRequest("내용", 5);
         Long productId = 1L;
 
-        given(keyboardRepository.existsById(productId))
-                .willReturn(false);
+        given(keyboardRepository.findById(productId))
+                .willReturn(Optional.empty());
 
         // when, then
         assertAll(
                 () -> assertThatThrownBy(() -> reviewService.save(1L, reviewRequest))
                         .isExactlyInstanceOf(KeyboardNotFoundException.class),
-                () -> verify(keyboardRepository).existsById(productId),
+                () -> verify(keyboardRepository).findById(productId),
                 () -> verify(reviewRepository, times(0)).save(any(Review.class))
         );
     }
@@ -84,9 +89,10 @@ class ReviewServiceTest {
     void 특정_제품에_대한_리뷰_목록을_조회한다() {
         // given
         Long productId = 1L;
+        Keyboard keyboard = KEYBOARD_1.생성();
         Pageable pageable = PageRequest.of(0, 1, Sort.by(Order.desc("createdAt")));
         Slice<Review> slice = new SliceImpl<>(List.of(
-                REVIEW_RATING_5.작성(1L, productId)
+                REVIEW_RATING_5.작성(1L, keyboard)
         ), pageable, true);
 
         given(keyboardRepository.existsById(productId))
@@ -126,26 +132,24 @@ class ReviewServiceTest {
     @Test
     void 전체_리뷰_목록을_조회한다() {
         // given
-        Long product1Id = 1L;
-        Long product2Id = 2L;
         Pageable pageable = PageRequest.of(0, 2, Sort.by(Order.desc("createdAt")));
         Slice<Review> slice = new SliceImpl<>(List.of(
-                REVIEW_RATING_5.작성(3L, product1Id),
-                REVIEW_RATING_5.작성(2L, product2Id)
+                REVIEW_RATING_5.작성(3L, KEYBOARD_1.생성()),
+                REVIEW_RATING_5.작성(2L, KEYBOARD_2.생성())
         ), pageable, true);
 
         given(reviewRepository.findPageBy(pageable))
                 .willReturn(slice);
 
         // when
-        ReviewPageResponse reviewPageResponse = reviewService.findPage(pageable);
+        ReviewWithProductPageResponse reviewWithProductPageResponse = reviewService.findPage(pageable);
 
         // then
         assertAll(
-                () -> assertThat(reviewPageResponse.getItems()).hasSize(2)
+                () -> assertThat(reviewWithProductPageResponse.getItems()).hasSize(2)
                         .extracting("id")
                         .containsExactly(3L, 2L),
-                () -> assertThat(reviewPageResponse.isHasNext()).isTrue(),
+                () -> assertThat(reviewWithProductPageResponse.isHasNext()).isTrue(),
                 () -> verify(reviewRepository).findPageBy(pageable)
         );
     }

--- a/backend/src/test/java/com/woowacourse/f12/application/ReviewServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/application/ReviewServiceTest.java
@@ -2,6 +2,7 @@ package com.woowacourse.f12.application;
 
 import static com.woowacourse.f12.support.KeyboardFixtures.KEYBOARD_1;
 import static com.woowacourse.f12.support.KeyboardFixtures.KEYBOARD_2;
+import static com.woowacourse.f12.support.MemberFixtures.CORINNE;
 import static com.woowacourse.f12.support.ReviewFixtures.REVIEW_RATING_5;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -13,6 +14,7 @@ import static org.mockito.Mockito.verify;
 
 import com.woowacourse.f12.domain.Keyboard;
 import com.woowacourse.f12.domain.KeyboardRepository;
+import com.woowacourse.f12.domain.MemberRepository;
 import com.woowacourse.f12.domain.Review;
 import com.woowacourse.f12.domain.ReviewRepository;
 import com.woowacourse.f12.dto.request.ReviewRequest;
@@ -42,6 +44,9 @@ class ReviewServiceTest {
     @Mock
     private KeyboardRepository keyboardRepository;
 
+    @Mock
+    private MemberRepository memberRepository;
+
     @InjectMocks
     private ReviewService reviewService;
 
@@ -53,11 +58,13 @@ class ReviewServiceTest {
         Keyboard keyboard = KEYBOARD_1.생성(productId);
         given(keyboardRepository.findById(productId))
                 .willReturn(Optional.of(keyboard));
+        given(memberRepository.findById(1L))
+                .willReturn(Optional.of(CORINNE.생성(1L)));
         given(reviewRepository.save(reviewRequest.toReview(keyboard)))
                 .willReturn(REVIEW_RATING_5.작성(1L, keyboard));
 
         // when
-        Long reviewId = reviewService.save(productId, reviewRequest);
+        Long reviewId = reviewService.save(productId, reviewRequest, 1L);
 
         // then
         assertAll(
@@ -78,7 +85,7 @@ class ReviewServiceTest {
 
         // when, then
         assertAll(
-                () -> assertThatThrownBy(() -> reviewService.save(1L, reviewRequest))
+                () -> assertThatThrownBy(() -> reviewService.save(1L, reviewRequest, 1L))
                         .isExactlyInstanceOf(KeyboardNotFoundException.class),
                 () -> verify(keyboardRepository).findById(productId),
                 () -> verify(reviewRepository, times(0)).save(any(Review.class))

--- a/backend/src/test/java/com/woowacourse/f12/documentation/Documentation.java
+++ b/backend/src/test/java/com/woowacourse/f12/documentation/Documentation.java
@@ -1,5 +1,7 @@
 package com.woowacourse.f12.documentation;
 
+import com.woowacourse.f12.application.JwtProvider;
+import com.woowacourse.f12.support.AuthTokenExtractor;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.context.annotation.Import;
@@ -7,7 +9,7 @@ import org.springframework.restdocs.RestDocumentationExtension;
 
 @AutoConfigureRestDocs
 @ExtendWith(RestDocumentationExtension.class)
-@Import(RestDocsConfig.class)
+@Import({AuthTokenExtractor.class, JwtProvider.class, RestDocsConfig.class})
 public class Documentation {
 
 }

--- a/backend/src/test/java/com/woowacourse/f12/documentation/ReviewDocumentation.java
+++ b/backend/src/test/java/com/woowacourse/f12/documentation/ReviewDocumentation.java
@@ -1,5 +1,7 @@
 package com.woowacourse.f12.documentation;
 
+import static com.woowacourse.f12.support.KeyboardFixtures.KEYBOARD_1;
+import static com.woowacourse.f12.support.KeyboardFixtures.KEYBOARD_2;
 import static com.woowacourse.f12.support.ReviewFixtures.REVIEW_RATING_4;
 import static com.woowacourse.f12.support.ReviewFixtures.REVIEW_RATING_5;
 import static org.mockito.ArgumentMatchers.any;
@@ -13,8 +15,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.woowacourse.f12.application.ReviewService;
+import com.woowacourse.f12.domain.Keyboard;
 import com.woowacourse.f12.dto.request.ReviewRequest;
 import com.woowacourse.f12.dto.response.ReviewPageResponse;
+import com.woowacourse.f12.dto.response.ReviewWithProductPageResponse;
 import com.woowacourse.f12.presentation.ReviewController;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -66,8 +70,9 @@ public class ReviewDocumentation extends Documentation {
     void 특정_제품의_리뷰_목록_조회_API_문서화() throws Exception {
         // given
         PageRequest pageable = PageRequest.of(0, 10, Sort.by("createdAt").descending());
+        Keyboard keyboard = KEYBOARD_1.생성(1L);
         ReviewPageResponse reviewPageResponse = ReviewPageResponse.from(
-                new SliceImpl<>(List.of(REVIEW_RATING_5.작성(1L, 1L), REVIEW_RATING_4.작성(2L, 1L)), pageable, false));
+                new SliceImpl<>(List.of(REVIEW_RATING_5.작성(1L, keyboard), REVIEW_RATING_4.작성(2L, keyboard)), pageable, false));
 
         given(reviewService.findPageByProductId(anyLong(), any(Pageable.class)))
                 .willReturn(reviewPageResponse);
@@ -90,11 +95,13 @@ public class ReviewDocumentation extends Documentation {
     void 모든_리뷰_목록_페이지_조회_API_문서화() throws Exception {
         // given
         PageRequest pageable = PageRequest.of(0, 10, Sort.by("createdAt").descending());
-        ReviewPageResponse reviewPageResponse = ReviewPageResponse.from(
-                new SliceImpl<>(List.of(REVIEW_RATING_5.작성(1L, 1L), REVIEW_RATING_4.작성(2L, 2L)), pageable, false));
+        Keyboard keyboard1 = KEYBOARD_1.생성(1L);
+        Keyboard keyboard2 = KEYBOARD_2.생성(2L);
+        ReviewWithProductPageResponse reviewWithProductPageResponse = ReviewWithProductPageResponse.from(
+                new SliceImpl<>(List.of(REVIEW_RATING_5.작성(1L, keyboard1), REVIEW_RATING_4.작성(2L, keyboard2)), pageable, false));
 
         given(reviewService.findPage(any(Pageable.class)))
-                .willReturn(reviewPageResponse);
+                .willReturn(reviewWithProductPageResponse);
 
         // when
         ResultActions resultActions = mockMvc.perform(get("/api/v1/reviews?page=0&size=10&sort=createdAt,desc"))

--- a/backend/src/test/java/com/woowacourse/f12/documentation/ReviewDocumentation.java
+++ b/backend/src/test/java/com/woowacourse/f12/documentation/ReviewDocumentation.java
@@ -14,6 +14,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.woowacourse.f12.application.JwtProvider;
 import com.woowacourse.f12.application.ReviewService;
 import com.woowacourse.f12.domain.Keyboard;
 import com.woowacourse.f12.dto.request.ReviewRequest;
@@ -29,6 +30,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
@@ -42,11 +44,17 @@ public class ReviewDocumentation extends Documentation {
     @MockBean
     private ReviewService reviewService;
 
+    @MockBean
+    private JwtProvider jwtProvider;
+
     private ObjectMapper objectMapper = new ObjectMapper();
 
     @Test
     void 리뷰_작성_API_문서화() throws Exception {
         // given
+        String authorizationHeader = "Bearer Token";
+        given(jwtProvider.validateToken(authorizationHeader))
+                .willReturn(true);
         given(reviewService.save(anyLong(), any(ReviewRequest.class)))
                 .willReturn(1L);
         ReviewRequest reviewRequest = new ReviewRequest("content", 5);
@@ -54,6 +62,7 @@ public class ReviewDocumentation extends Documentation {
         // when
         ResultActions resultActions = mockMvc.perform(
                 post("/api/v1/keyboards/" + 1L + "/reviews")
+                        .header(HttpHeaders.AUTHORIZATION, authorizationHeader)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(reviewRequest))
         );

--- a/backend/src/test/java/com/woowacourse/f12/documentation/ReviewDocumentation.java
+++ b/backend/src/test/java/com/woowacourse/f12/documentation/ReviewDocumentation.java
@@ -55,7 +55,9 @@ public class ReviewDocumentation extends Documentation {
         String authorizationHeader = "Bearer Token";
         given(jwtProvider.validateToken(authorizationHeader))
                 .willReturn(true);
-        given(reviewService.save(anyLong(), any(ReviewRequest.class)))
+        given(jwtProvider.getPayload(authorizationHeader))
+                .willReturn("1");
+        given(reviewService.save(anyLong(), any(ReviewRequest.class), anyLong()))
                 .willReturn(1L);
         ReviewRequest reviewRequest = new ReviewRequest("content", 5);
 

--- a/backend/src/test/java/com/woowacourse/f12/domain/KeyboardRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/domain/KeyboardRepositoryTest.java
@@ -39,8 +39,8 @@ class KeyboardRepositoryTest {
     void 키보드를_단일_조회_한다() {
         // given
         Keyboard keyboard = 키보드_저장(KEYBOARD_1.생성());
-        리뷰_저장(REVIEW_RATING_4.작성(keyboard.getId()));
-        리뷰_저장(REVIEW_RATING_5.작성(keyboard.getId()));
+        리뷰_저장(REVIEW_RATING_4.작성(keyboard));
+        리뷰_저장(REVIEW_RATING_5.작성(keyboard));
         entityManager.flush();
         entityManager.refresh(keyboard);
 
@@ -78,9 +78,9 @@ class KeyboardRepositoryTest {
         Keyboard keyboard1 = 키보드_저장(KEYBOARD_1.생성());
         Keyboard keyboard2 = 키보드_저장(KEYBOARD_2.생성());
 
-        리뷰_저장(REVIEW_RATING_5.작성(keyboard1.getId()));
-        리뷰_저장(REVIEW_RATING_5.작성(keyboard2.getId()));
-        리뷰_저장(REVIEW_RATING_5.작성(keyboard2.getId()));
+        리뷰_저장(REVIEW_RATING_5.작성(keyboard1));
+        리뷰_저장(REVIEW_RATING_5.작성(keyboard2));
+        리뷰_저장(REVIEW_RATING_5.작성(keyboard2));
 
         Pageable pageable = PageRequest.of(0, 1, Sort.by(Order.desc("reviewCount")));
 
@@ -100,10 +100,10 @@ class KeyboardRepositoryTest {
         Keyboard keyboard2 = 키보드_저장(KEYBOARD_1.생성());
         Keyboard keyboard1 = 키보드_저장(KEYBOARD_2.생성());
 
-        리뷰_저장(REVIEW_RATING_2.작성(keyboard1.getId()));
-        리뷰_저장(REVIEW_RATING_1.작성(keyboard1.getId()));
-        리뷰_저장(REVIEW_RATING_5.작성(keyboard2.getId()));
-        리뷰_저장(REVIEW_RATING_4.작성(keyboard2.getId()));
+        리뷰_저장(REVIEW_RATING_2.작성(keyboard1));
+        리뷰_저장(REVIEW_RATING_1.작성(keyboard1));
+        리뷰_저장(REVIEW_RATING_5.작성(keyboard2));
+        리뷰_저장(REVIEW_RATING_4.작성(keyboard2));
 
         Pageable pageable = PageRequest.of(0, 1, Sort.by(Order.desc("rating")));
 

--- a/backend/src/test/java/com/woowacourse/f12/domain/ReviewRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/domain/ReviewRepositoryTest.java
@@ -1,5 +1,7 @@
 package com.woowacourse.f12.domain;
 
+import static com.woowacourse.f12.support.KeyboardFixtures.KEYBOARD_1;
+import static com.woowacourse.f12.support.KeyboardFixtures.KEYBOARD_2;
 import static com.woowacourse.f12.support.ReviewFixtures.REVIEW_RATING_4;
 import static com.woowacourse.f12.support.ReviewFixtures.REVIEW_RATING_5;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -23,16 +25,19 @@ class ReviewRepositoryTest {
     @Autowired
     private ReviewRepository reviewRepository;
 
+    @Autowired
+    private KeyboardRepository keyboardRepository;
+
     @Test
     void 특정_제품의_리뷰_목록을_최신순으로_페이징하여_조회한다() {
         // given
-        Long productId = 1L;
+        Keyboard keyboard = keyboardRepository.save(KEYBOARD_1.생성());
         Pageable pageable = PageRequest.of(0, 1, Sort.by(desc("createdAt")));
-        리뷰_저장(REVIEW_RATING_5.작성(productId));
-        Review review = 리뷰_저장(REVIEW_RATING_5.작성(productId));
+        리뷰_저장(REVIEW_RATING_5.작성(keyboard));
+        Review review = 리뷰_저장(REVIEW_RATING_5.작성(keyboard));
 
         // when
-        Slice<Review> page = reviewRepository.findPageByProductId(productId, pageable);
+        Slice<Review> page = reviewRepository.findPageByProductId(keyboard.getId(), pageable);
 
         // then
         assertAll(
@@ -46,13 +51,13 @@ class ReviewRepositoryTest {
     @Test
     void 특정_제품의_리뷰_목록을_평점순으로_페이징하여_조회한다() {
         // given
-        Long productId = 1L;
+        Keyboard keyboard = keyboardRepository.save(KEYBOARD_1.생성());
         Pageable pageable = PageRequest.of(0, 1, Sort.by(desc("rating")));
-        Review review = 리뷰_저장(REVIEW_RATING_5.작성(productId));
-        리뷰_저장(REVIEW_RATING_4.작성(productId));
+        Review review = 리뷰_저장(REVIEW_RATING_5.작성(keyboard));
+        리뷰_저장(REVIEW_RATING_4.작성(keyboard));
 
         // when
-        Slice<Review> page = reviewRepository.findPageByProductId(productId, pageable);
+        Slice<Review> page = reviewRepository.findPageByProductId(keyboard.getId(), pageable);
 
         // then
         assertAll(
@@ -66,9 +71,11 @@ class ReviewRepositoryTest {
     @Test
     void 리뷰_목록을_최신순으로_페이징하여_조회한다() {
         // given
+        Keyboard keyboard1 = keyboardRepository.save(KEYBOARD_1.생성());
+        Keyboard keyboard2 = keyboardRepository.save(KEYBOARD_2.생성());
         Pageable pageable = PageRequest.of(0, 1, Sort.by(desc("createdAt")));
-        리뷰_저장(REVIEW_RATING_5.작성(1L));
-        Review review = 리뷰_저장(REVIEW_RATING_5.작성(2L));
+        리뷰_저장(REVIEW_RATING_5.작성(keyboard1));
+        Review review = 리뷰_저장(REVIEW_RATING_5.작성(keyboard2));
 
         // when
         Slice<Review> page = reviewRepository.findPageBy(pageable);

--- a/backend/src/test/java/com/woowacourse/f12/presentation/AuthControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/AuthControllerTest.java
@@ -8,16 +8,20 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.woowacourse.f12.application.AuthService;
+import com.woowacourse.f12.application.JwtProvider;
 import com.woowacourse.f12.dto.response.LoginResponse;
 import com.woowacourse.f12.exception.GitHubServerException;
 import com.woowacourse.f12.exception.InvalidGitHubLoginException;
+import com.woowacourse.f12.support.AuthTokenExtractor;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(AuthController.class)
+@Import({AuthTokenExtractor.class, JwtProvider.class})
 class AuthControllerTest {
 
     @Autowired

--- a/backend/src/test/java/com/woowacourse/f12/presentation/AuthInterceptorTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/AuthInterceptorTest.java
@@ -46,10 +46,10 @@ class AuthInterceptorTest {
         // given
         ReviewRequest reviewRequest = new ReviewRequest("content", 5);
         String authorizationHeader = "Bearer Token";
-        given(reviewService.save(anyLong(), any(ReviewRequest.class)))
-                .willReturn(1L);
         given(jwtProvider.validateToken(authorizationHeader))
                 .willReturn(false);
+        given(reviewService.save(anyLong(), any(ReviewRequest.class), anyLong()))
+                .willReturn(1L);
         // when
         mockMvc.perform(
                         post("/api/v1/keyboards/" + 1L + "/reviews")
@@ -61,8 +61,8 @@ class AuthInterceptorTest {
 
         // then
         assertAll(
-                () -> verify(reviewService, times(0)).save(eq(1L), any(ReviewRequest.class)),
-                () -> verify(jwtProvider).validateToken(authorizationHeader)
+                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(reviewService, times(0)).save(eq(1L), any(ReviewRequest.class), eq(1L))
         );
     }
 }

--- a/backend/src/test/java/com/woowacourse/f12/presentation/AuthInterceptorTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/AuthInterceptorTest.java
@@ -1,0 +1,68 @@
+package com.woowacourse.f12.presentation;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.woowacourse.f12.application.JwtProvider;
+import com.woowacourse.f12.application.ReviewService;
+import com.woowacourse.f12.dto.request.ReviewRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(ReviewController.class)
+class AuthInterceptorTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ReviewService reviewService;
+
+    @MockBean
+    private JwtProvider jwtProvider;
+
+    private final ObjectMapper objectMapper;
+
+    public AuthInterceptorTest() {
+        this.objectMapper = new ObjectMapper();
+    }
+
+    @Test
+    void 인증_인가를_검즘_실패_유효하지_않은_토큰() throws Exception {
+        // given
+        ReviewRequest reviewRequest = new ReviewRequest("content", 5);
+        String authorizationHeader = "Bearer Token";
+        given(reviewService.save(anyLong(), any(ReviewRequest.class)))
+                .willReturn(1L);
+        given(jwtProvider.validateToken(authorizationHeader))
+                .willReturn(false);
+        // when
+        mockMvc.perform(
+                        post("/api/v1/keyboards/" + 1L + "/reviews")
+                                .header(HttpHeaders.AUTHORIZATION, authorizationHeader)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(reviewRequest))
+                ).andExpect(status().isUnauthorized())
+                .andDo(print());
+
+        // then
+        assertAll(
+                () -> verify(reviewService, times(0)).save(eq(1L), any(ReviewRequest.class)),
+                () -> verify(jwtProvider).validateToken(authorizationHeader)
+        );
+    }
+}

--- a/backend/src/test/java/com/woowacourse/f12/presentation/CustomPageableArgumentResolverTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/CustomPageableArgumentResolverTest.java
@@ -26,7 +26,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(KeyboardController.class)
 @Import({AuthTokenExtractor.class, JwtProvider.class})
-public class CustomPageableHandlerMethodArgumentResolverTest {
+public class CustomPageableArgumentResolverTest {
 
     @Autowired
     private MockMvc mockMvc;

--- a/backend/src/test/java/com/woowacourse/f12/presentation/CustomPageableHandlerMethodArgumentResolverTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/CustomPageableHandlerMethodArgumentResolverTest.java
@@ -8,13 +8,16 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.woowacourse.f12.application.JwtProvider;
 import com.woowacourse.f12.application.KeyboardService;
 import com.woowacourse.f12.dto.response.KeyboardPageResponse;
+import com.woowacourse.f12.support.AuthTokenExtractor;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.SliceImpl;
@@ -22,6 +25,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(KeyboardController.class)
+@Import({AuthTokenExtractor.class, JwtProvider.class})
 public class CustomPageableHandlerMethodArgumentResolverTest {
 
     @Autowired

--- a/backend/src/test/java/com/woowacourse/f12/presentation/KeyboardControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/KeyboardControllerTest.java
@@ -9,15 +9,18 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.woowacourse.f12.application.JwtProvider;
 import com.woowacourse.f12.application.KeyboardService;
 import com.woowacourse.f12.dto.response.KeyboardPageResponse;
 import com.woowacourse.f12.dto.response.KeyboardResponse;
 import com.woowacourse.f12.exception.KeyboardNotFoundException;
+import com.woowacourse.f12.support.AuthTokenExtractor;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.SliceImpl;
@@ -25,6 +28,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(KeyboardController.class)
+@Import({AuthTokenExtractor.class, JwtProvider.class})
 class KeyboardControllerTest {
 
     @Autowired

--- a/backend/src/test/java/com/woowacourse/f12/presentation/ReviewControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/ReviewControllerTest.java
@@ -14,6 +14,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.woowacourse.f12.application.JwtProvider;
 import com.woowacourse.f12.application.ReviewService;
 import com.woowacourse.f12.dto.request.ReviewRequest;
 import com.woowacourse.f12.dto.response.ReviewPageResponse;
@@ -22,6 +23,7 @@ import com.woowacourse.f12.exception.BlankContentException;
 import com.woowacourse.f12.exception.InvalidContentLengthException;
 import com.woowacourse.f12.exception.InvalidRatingValueException;
 import com.woowacourse.f12.exception.KeyboardNotFoundException;
+import com.woowacourse.f12.support.AuthTokenExtractor;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -29,6 +31,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.SliceImpl;
@@ -37,6 +40,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(ReviewController.class)
+@Import({AuthTokenExtractor.class, JwtProvider.class})
 class ReviewControllerTest {
 
     private static final long PRODUCT_ID = 1L;

--- a/backend/src/test/java/com/woowacourse/f12/presentation/ReviewControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/ReviewControllerTest.java
@@ -67,10 +67,12 @@ class ReviewControllerTest {
         // given
         ReviewRequest reviewRequest = new ReviewRequest("content", 5);
         String authorizationHeader = "Bearer Token";
-        given(reviewService.save(anyLong(), any(ReviewRequest.class)))
-                .willReturn(1L);
         given(jwtProvider.validateToken(authorizationHeader))
                 .willReturn(true);
+        given(jwtProvider.getPayload(authorizationHeader))
+                .willReturn("1");
+        given(reviewService.save(anyLong(), any(ReviewRequest.class), anyLong()))
+                .willReturn(1L);
         // when
         mockMvc.perform(
                         post("/api/v1/keyboards/" + PRODUCT_ID + "/reviews")
@@ -82,8 +84,9 @@ class ReviewControllerTest {
 
         // then
         assertAll(
-                () -> verify(reviewService).save(eq(PRODUCT_ID), any(ReviewRequest.class)),
-                () -> verify(jwtProvider).validateToken(authorizationHeader)
+                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).getPayload(authorizationHeader),
+                () -> verify(reviewService).save(eq(PRODUCT_ID), any(ReviewRequest.class), eq(1L))
         );
     }
 
@@ -92,10 +95,10 @@ class ReviewControllerTest {
         // given
         ReviewRequest reviewRequest = new ReviewRequest(null, null);
         String authorizationHeader = "Bearer Token";
-        given(reviewService.save(anyLong(), any(ReviewRequest.class)))
-                .willThrow(new BlankContentException());
         given(jwtProvider.validateToken(authorizationHeader))
                 .willReturn(true);
+        given(reviewService.save(anyLong(), any(ReviewRequest.class), anyLong()))
+                .willThrow(new BlankContentException());
 
         // when
         mockMvc.perform(
@@ -108,8 +111,8 @@ class ReviewControllerTest {
 
         // then
         assertAll(
-                () -> verify(reviewService, times(0)).save(eq(PRODUCT_ID), any(ReviewRequest.class)),
-                () -> verify(jwtProvider).validateToken(authorizationHeader)
+                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(reviewService, times(0)).save(eq(PRODUCT_ID), any(ReviewRequest.class), eq(1L))
         );
     }
 
@@ -120,10 +123,10 @@ class ReviewControllerTest {
         Map<String, Object> reviewRequest = new HashMap<>();
         reviewRequest.put("content", "내용");
         reviewRequest.put("rating", "문자");
-        given(reviewService.save(anyLong(), any(ReviewRequest.class)))
-                .willThrow(new BlankContentException());
         given(jwtProvider.validateToken(authorizationHeader))
                 .willReturn(true);
+        given(reviewService.save(anyLong(), any(ReviewRequest.class), anyLong()))
+                .willThrow(new BlankContentException());
 
         // when
         mockMvc.perform(
@@ -136,8 +139,8 @@ class ReviewControllerTest {
 
         // then
         assertAll(
-                () -> verify(reviewService, times(0)).save(eq(PRODUCT_ID), any(ReviewRequest.class)),
-                () -> verify(jwtProvider).validateToken(authorizationHeader)
+                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(reviewService, times(0)).save(eq(PRODUCT_ID), any(ReviewRequest.class), eq(1L))
         );
     }
 
@@ -145,11 +148,13 @@ class ReviewControllerTest {
     void 리뷰_생성_실패_리뷰_내용이_존재하지_않음() throws Exception {
         // given
         String authorizationHeader = "Bearer Token";
-        given(reviewService.save(anyLong(), any(ReviewRequest.class)))
-                .willThrow(new BlankContentException());
+        ReviewRequest reviewRequest = new ReviewRequest("", 5);
         given(jwtProvider.validateToken(authorizationHeader))
                 .willReturn(true);
-        ReviewRequest reviewRequest = new ReviewRequest("", 5);
+        given(jwtProvider.getPayload(authorizationHeader))
+                .willReturn("1");
+        given(reviewService.save(anyLong(), any(ReviewRequest.class), anyLong()))
+                .willThrow(new BlankContentException());
 
         // when
         mockMvc.perform(
@@ -162,8 +167,9 @@ class ReviewControllerTest {
 
         // then
         assertAll(
-                () -> verify(reviewService).save(eq(PRODUCT_ID), any(ReviewRequest.class)),
-                () -> verify(jwtProvider).validateToken(authorizationHeader)
+                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).getPayload(authorizationHeader),
+                () -> verify(reviewService).save(eq(PRODUCT_ID), any(ReviewRequest.class), eq(1L))
         );
     }
 
@@ -171,12 +177,14 @@ class ReviewControllerTest {
     void 리뷰_생성_실패_리뷰_내용_최대_길이_초과() throws Exception {
         // given
         String authorizationHeader = "Bearer Token";
-        given(reviewService.save(anyLong(), any(ReviewRequest.class)))
-                .willThrow(new InvalidContentLengthException(1000));
-        given(jwtProvider.validateToken(authorizationHeader))
-                .willReturn(true);
         String content = "a".repeat(1001);
         ReviewRequest reviewRequest = new ReviewRequest(content, 5);
+        given(jwtProvider.validateToken(authorizationHeader))
+                .willReturn(true);
+        given(jwtProvider.getPayload(authorizationHeader))
+                .willReturn("1");
+        given(reviewService.save(anyLong(), any(ReviewRequest.class), anyLong()))
+                .willThrow(new InvalidContentLengthException(1000));
 
         // when
         mockMvc.perform(
@@ -189,8 +197,9 @@ class ReviewControllerTest {
 
         // then
         assertAll(
-                () -> verify(reviewService).save(eq(PRODUCT_ID), any(ReviewRequest.class)),
-                () -> verify(jwtProvider).validateToken(authorizationHeader)
+                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).getPayload(authorizationHeader),
+                () -> verify(reviewService).save(eq(PRODUCT_ID), any(ReviewRequest.class), eq(1L))
         );
     }
 
@@ -198,11 +207,13 @@ class ReviewControllerTest {
     void 리뷰_생성_실패_평점이_1부터_5사이_정수가_아님() throws Exception {
         // given
         String authorizationHeader = "Bearer Token";
+        ReviewRequest reviewRequest = new ReviewRequest("내용", 0);
         given(jwtProvider.validateToken(authorizationHeader))
                 .willReturn(true);
-        given(reviewService.save(anyLong(), any(ReviewRequest.class)))
+        given(jwtProvider.getPayload(authorizationHeader))
+                .willReturn("1");
+        given(reviewService.save(anyLong(), any(ReviewRequest.class), anyLong()))
                 .willThrow(new InvalidRatingValueException());
-        ReviewRequest reviewRequest = new ReviewRequest("내용", 0);
 
         // when
         mockMvc.perform(
@@ -215,8 +226,9 @@ class ReviewControllerTest {
 
         // then
         assertAll(
-                () -> verify(reviewService).save(eq(PRODUCT_ID), any(ReviewRequest.class)),
-                () -> verify(jwtProvider).validateToken(authorizationHeader)
+                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).getPayload(authorizationHeader),
+                () -> verify(reviewService).save(eq(PRODUCT_ID), any(ReviewRequest.class), eq(1L))
         );
     }
 
@@ -224,11 +236,13 @@ class ReviewControllerTest {
     void 리뷰_생성_실패_제품이_존재하지_않음() throws Exception {
         // given
         String authorizationHeader = "Bearer Token";
+        ReviewRequest reviewRequest = new ReviewRequest("내용", 5);
         given(jwtProvider.validateToken(authorizationHeader))
                 .willReturn(true);
-        given(reviewService.save(anyLong(), any(ReviewRequest.class)))
+        given(jwtProvider.getPayload(authorizationHeader))
+                .willReturn("1");
+        given(reviewService.save(anyLong(), any(ReviewRequest.class), anyLong()))
                 .willThrow(new KeyboardNotFoundException());
-        ReviewRequest reviewRequest = new ReviewRequest("내용", 5);
 
         // when
         mockMvc.perform(
@@ -241,8 +255,9 @@ class ReviewControllerTest {
 
         // then
         assertAll(
-                () -> verify(reviewService).save(eq(0L), any(ReviewRequest.class)),
-                () -> verify(jwtProvider).validateToken(authorizationHeader)
+                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).getPayload(authorizationHeader),
+                () -> verify(reviewService).save(eq(0L), any(ReviewRequest.class), eq(1L))
         );
     }
 

--- a/backend/src/test/java/com/woowacourse/f12/presentation/ReviewControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/ReviewControllerTest.java
@@ -1,5 +1,6 @@
 package com.woowacourse.f12.presentation;
 
+import static com.woowacourse.f12.support.KeyboardFixtures.KEYBOARD_1;
 import static com.woowacourse.f12.support.ReviewFixtures.REVIEW_RATING_5;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -16,6 +17,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.woowacourse.f12.application.ReviewService;
 import com.woowacourse.f12.dto.request.ReviewRequest;
 import com.woowacourse.f12.dto.response.ReviewPageResponse;
+import com.woowacourse.f12.dto.response.ReviewWithProductPageResponse;
 import com.woowacourse.f12.exception.BlankContentException;
 import com.woowacourse.f12.exception.InvalidContentLengthException;
 import com.woowacourse.f12.exception.InvalidRatingValueException;
@@ -192,7 +194,8 @@ class ReviewControllerTest {
     void 전체_리뷰_페이지_조회_성공() throws Exception {
         // given
         given(reviewService.findPage(any(Pageable.class)))
-                .willReturn(ReviewPageResponse.from(new SliceImpl<>(List.of(REVIEW_RATING_5.작성(1L, PRODUCT_ID)))));
+                .willReturn(ReviewWithProductPageResponse.from(
+                        new SliceImpl<>(List.of(REVIEW_RATING_5.작성(1L, KEYBOARD_1.생성())))));
 
         // when
         mockMvc.perform(get("/api/v1/reviews?size=150&page=0&sort=rating,desc"))
@@ -207,7 +210,7 @@ class ReviewControllerTest {
     void 특정_상품의_리뷰_페이지_조회() throws Exception {
         // given
         given(reviewService.findPageByProductId(anyLong(), any(Pageable.class)))
-                .willReturn(ReviewPageResponse.from(new SliceImpl<>(List.of(REVIEW_RATING_5.작성(1L, PRODUCT_ID)))));
+                .willReturn(ReviewPageResponse.from(new SliceImpl<>(List.of(REVIEW_RATING_5.작성(1L, KEYBOARD_1.생성())))));
 
         // when
         mockMvc.perform(get("/api/v1/keyboards/" + PRODUCT_ID + "/reviews?size=150&page=0&sort=rating,desc"))

--- a/backend/src/test/java/com/woowacourse/f12/support/AuthTokenExtractorTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/support/AuthTokenExtractorTest.java
@@ -1,0 +1,50 @@
+package com.woowacourse.f12.support;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.woowacourse.f12.exception.UnAuthorizedException;
+import org.junit.jupiter.api.Test;
+
+class AuthTokenExtractorTest {
+
+    private final AuthTokenExtractor authTokenExtractor = new AuthTokenExtractor();
+
+    @Test
+    void Authorization_헤더에서_토큰을_추출한다() {
+        // given
+        String authorizationHeader = "Bearer token";
+
+        // when
+        String token = authTokenExtractor.extractToken(authorizationHeader, "Bearer");
+
+        // then
+        assertThat(token).isEqualTo("token");
+    }
+
+    @Test
+    void Authorization_헤더가_null_이면_예외가_발생한다() {
+        assertThatThrownBy(() -> authTokenExtractor.extractToken(null, "Bearer"))
+                .isExactlyInstanceOf(UnAuthorizedException.class);
+    }
+
+    @Test
+    void Authorization_헤더의_타입이_불일치하면_예외가_발생한다() {
+        // given
+        String authorizationHeader = "NotBearer token";
+
+        // when, then
+        assertThatThrownBy(() -> authTokenExtractor.extractToken(authorizationHeader, "Bearer"))
+                .isExactlyInstanceOf(UnAuthorizedException.class);
+    }
+
+    @Test
+    void Authorization_헤더의_형식이_불일치하면_예외가_발생한다() {
+        // given
+        String authorizationHeader = "Bearer token token2";
+
+        // when, then
+        assertThatThrownBy(() -> authTokenExtractor.extractToken(authorizationHeader, "Bearer"))
+                .isExactlyInstanceOf(UnAuthorizedException.class);
+    }
+}

--- a/backend/src/test/java/com/woowacourse/f12/support/ReviewFixtures.java
+++ b/backend/src/test/java/com/woowacourse/f12/support/ReviewFixtures.java
@@ -1,6 +1,7 @@
 package com.woowacourse.f12.support;
 
 import com.woowacourse.f12.acceptance.support.RestAssuredRequestUtil;
+import com.woowacourse.f12.domain.Keyboard;
 import com.woowacourse.f12.domain.Review;
 import com.woowacourse.f12.dto.request.ReviewRequest;
 import io.restassured.response.ExtractableResponse;
@@ -24,14 +25,14 @@ public enum ReviewFixtures {
         this.rating = rating;
     }
 
-    public Review 작성(Long productId) {
-        return 작성(null, productId);
+    public Review 작성(Keyboard keyboard) {
+        return 작성(null, keyboard);
     }
 
-    public Review 작성(Long reviewId, Long productId) {
+    public Review 작성(Long reviewId, Keyboard keyboard) {
         return Review.builder()
                 .id(reviewId)
-                .productId(productId)
+                .keyboard(keyboard)
                 .content(this.content)
                 .rating(this.rating)
                 .createdAt(LocalDateTime.now())

--- a/backend/src/test/java/com/woowacourse/f12/support/ReviewFixtures.java
+++ b/backend/src/test/java/com/woowacourse/f12/support/ReviewFixtures.java
@@ -39,8 +39,9 @@ public enum ReviewFixtures {
                 .build();
     }
 
-    public ExtractableResponse<Response> 작성_요청을_보낸다(Long productId) {
+    public ExtractableResponse<Response> 작성_요청을_보낸다(Long productId, String token) {
         final ReviewRequest reviewRequest = new ReviewRequest(this.content, this.rating);
-        return RestAssuredRequestUtil.POST_요청을_보낸다("/api/v1/keyboards/" + productId + "/reviews", reviewRequest);
+        return RestAssuredRequestUtil.로그인된_상태로_POST_요청을_보낸다("/api/v1/keyboards/" + productId + "/reviews", token,
+                reviewRequest);
     }
 }

--- a/frontend/src/components/ReviewListSection/ReviewListSection.tsx
+++ b/frontend/src/components/ReviewListSection/ReviewListSection.tsx
@@ -11,9 +11,10 @@ type Props = {
 
 function ReviewListSection({ columns, data, getNextPage }: Props) {
   const reviewCardList = data.map(
-    ({ id, profileImage, username, rating, content }) => (
+    ({ id, product, profileImage, username, rating, content }) => (
       <ReviewCard
         key={id}
+        product={product}
         profileImage={profileImage}
         username={username}
         rating={rating}

--- a/frontend/src/components/common/ReviewCard/ReviewCard.style.tsx
+++ b/frontend/src/components/common/ReviewCard/ReviewCard.style.tsx
@@ -3,12 +3,31 @@ import styled from 'styled-components';
 export const Container = styled.article`
   display: flex;
   gap: 1rem;
-  flex-direction: column;
   border-radius: 0.375rem;
   padding: 1rem;
-  width: 25rem;
+  width: 35rem;
   height: max-content;
   box-shadow: 0 0.35rem 0.7rem -0.2rem rgba(0, 0, 0, 0.3);
+`;
+
+export const ProductArea = styled.div`
+  display: flex;
+`;
+
+export const Image = styled.img`
+  width: 250px;
+`;
+
+export const Title = styled.div``;
+
+export const ReviewArea = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+`;
+
+export const FlexColumnWrapper = styled(ReviewArea)`
+  gap: 1rem;
 `;
 
 export const Wrapper = styled.div`

--- a/frontend/src/components/common/ReviewCard/ReviewCard.tsx
+++ b/frontend/src/components/common/ReviewCard/ReviewCard.tsx
@@ -5,19 +5,40 @@ import * as S from './ReviewCard.style';
 
 type Props = {
   profileImage: string;
+  product?: {
+    id: number;
+    name: string;
+    imageUrl: string;
+  };
   username: string;
   rating: number;
   content: string;
 };
 
-function ReviewCard({ profileImage, username, rating, content }: Props) {
+function ReviewCard({
+  profileImage,
+  product,
+  username,
+  rating,
+  content,
+}: Props) {
   return (
     <S.Container>
-      <S.Wrapper>
-        <UserNameTag profileImage={profileImage} username={username} />
-        <Rating rating={rating} />
-      </S.Wrapper>
-      <S.Content>{content}</S.Content>
+      {product && (
+        <S.ProductArea>
+          <S.FlexColumnWrapper>
+            <S.Image src={product.imageUrl} />
+            <S.Title>{product.name}</S.Title>
+          </S.FlexColumnWrapper>
+        </S.ProductArea>
+      )}
+      <S.ReviewArea>
+        <S.Wrapper>
+          <UserNameTag profileImage={profileImage} username={username} />
+          <Rating rating={rating} />
+        </S.Wrapper>
+        <S.Content>{content}</S.Content>
+      </S.ReviewArea>
     </S.Container>
   );
 }

--- a/frontend/src/custom.d.ts
+++ b/frontend/src/custom.d.ts
@@ -17,6 +17,11 @@ declare type Product = {
 
 declare type Review = {
   id: number;
+  product?: {
+    id: number;
+    name: string;
+    imageUrl: string;
+  };
   profileImage: string;
   username: string;
   rating: number;

--- a/frontend/src/mocks/data.ts
+++ b/frontend/src/mocks/data.ts
@@ -1,4 +1,5 @@
 import sampleProfile from '@/mocks/sample_profile.jpg';
+import sampleKeyboard from '@/mocks/sample_keyboard.jpg';
 
 export const products = [
   {
@@ -294,122 +295,182 @@ export const products = [
 export const reviews = [
   {
     id: 1,
-    productId: 2,
-    profileImage: sampleProfile,
-    createdAt: '2022-07-03 14:23:23',
-    username: '인도아저씨1',
-    rating: 5,
+    product: {
+      id: 1,
+      name: '예쁜 키보드',
+      imageUrl: sampleKeyboard,
+    },
     content:
       '무접점은 처음 사용이라 바로 적응되진 않아요 그래도 검증된 제품이라 역시 좋긴 좋네요 작업용으로 마지막 키보드라 생각한거라 비싸도 확 질렀습니다 아는 분은 아시겠지만 제품이 국내로 넘어온 후 관세청에서 문자로 제세액 3만원이상의 금액을 입금하라고 오더라구요 알고보니 수입 제한금액 오버.. 추가금을 고려해야 해요 그리고 배송은 딱 2주 걸렸어요 참고하세요^^',
+    rating: 5,
+    createdAt: '2022-07-03 14:23:23',
+    // 실 서버에는 추후 추가 예정 - username, profileImage
+    username: '인도아저씨1',
+    profileImage: sampleProfile,
   },
   {
     id: 2,
-    productId: 2,
-    profileImage: sampleProfile,
-    createdAt: '2022-07-03 14:23:23',
-    username: '인도아저씨2',
-    rating: 5,
+    product: {
+      id: 2,
+      name: '예쁜 키보드',
+      imageUrl: sampleKeyboard,
+    },
     content:
       '무접점은 처음 사용이라 바로 적응되진 않아요 그래도 검증된 제품이라 역시 좋긴 좋네요 작업용으로 마지막 키보드라 생각한거라 비싸도 확 질렀습니다 아는 분은 아시겠지만 제품이 국내로 넘어온 후 관세청에서 문자로 제세액 3만원이상의 금액을 입금하라고 오더라구요 알고보니 수입 제한금액 오버.. 추가금을 고려해야 해요 그리고 배송은 딱 2주 걸렸어요 참고하세요^^',
+    rating: 5,
+    createdAt: '2022-07-03 14:23:23',
+    // 실 서버에는 추후 추가 예정 - username, profileImage
+    username: '인도아저씨2',
+    profileImage: sampleProfile,
   },
   {
     id: 3,
-    productId: 2,
-    profileImage: sampleProfile,
-    createdAt: '2022-07-03 14:23:23',
-    username: '인도아저씨3',
-    rating: 5,
+    product: {
+      id: 3,
+      name: '예쁜 키보드',
+      imageUrl: sampleKeyboard,
+    },
     content:
       '무접점은 처음 사용이라 바로 적응되진 않아요 그래도 검증된 제품이라 역시 좋긴 좋네요 작업용으로 마지막 키보드라 생각한거라 비싸도 확 질렀습니다 아는 분은 아시겠지만 제품이 국내로 넘어온 후 관세청에서 문자로 제세액 3만원이상의 금액을 입금하라고 오더라구요 알고보니 수입 제한금액 오버.. 추가금을 고려해야 해요 그리고 배송은 딱 2주 걸렸어요 참고하세요^^',
+    rating: 5,
+    createdAt: '2022-07-03 14:23:23',
+    // 실 서버에는 추후 추가 예정 - username, profileImage
+    username: '인도아저씨3',
+    profileImage: sampleProfile,
   },
   {
     id: 4,
-    productId: 2,
-    profileImage: sampleProfile,
-    createdAt: '2022-07-03 14:23:23',
-    username: '인도아저씨4',
-    rating: 5,
+    product: {
+      id: 4,
+      name: '예쁜 키보드',
+      imageUrl: sampleKeyboard,
+    },
     content:
       '무접점은 처음 사용이라 바로 적응되진 않아요 그래도 검증된 제품이라 역시 좋긴 좋네요 작업용으로 마지막 키보드라 생각한거라 비싸도 확 질렀습니다 아는 분은 아시겠지만 제품이 국내로 넘어온 후 관세청에서 문자로 제세액 3만원이상의 금액을 입금하라고 오더라구요 알고보니 수입 제한금액 오버.. 추가금을 고려해야 해요 그리고 배송은 딱 2주 걸렸어요 참고하세요^^',
+    rating: 5,
+    createdAt: '2022-07-03 14:23:23',
+    // 실 서버에는 추후 추가 예정 - username, profileImage
+    username: '인도아저씨4',
+    profileImage: sampleProfile,
   },
   {
     id: 5,
-    productId: 2,
-    profileImage: sampleProfile,
-    createdAt: '2022-07-03 14:23:23',
-    username: '인도아저씨5',
-    rating: 5,
+    product: {
+      id: 5,
+      name: '예쁜 키보드',
+      imageUrl: sampleKeyboard,
+    },
     content:
       '무접점은 처음 사용이라 바로 적응되진 않아요 그래도 검증된 제품이라 역시 좋긴 좋네요 작업용으로 마지막 키보드라 생각한거라 비싸도 확 질렀습니다 아는 분은 아시겠지만 제품이 국내로 넘어온 후 관세청에서 문자로 제세액 3만원이상의 금액을 입금하라고 오더라구요 알고보니 수입 제한금액 오버.. 추가금을 고려해야 해요 그리고 배송은 딱 2주 걸렸어요 참고하세요^^',
+    rating: 5,
+    createdAt: '2022-07-03 14:23:23',
+    // 실 서버에는 추후 추가 예정 - username, profileImage
+    username: '인도아저씨5',
+    profileImage: sampleProfile,
   },
   {
     id: 6,
-    productId: 2,
-    profileImage: sampleProfile,
-    createdAt: '2022-07-03 14:23:23',
-    username: '인도아저씨6',
-    rating: 5,
+    product: {
+      id: 6,
+      name: '예쁜 키보드',
+      imageUrl: sampleKeyboard,
+    },
     content:
       '무접점은 처음 사용이라 바로 적응되진 않아요 그래도 검증된 제품이라 역시 좋긴 좋네요 작업용으로 마지막 키보드라 생각한거라 비싸도 확 질렀습니다 아는 분은 아시겠지만 제품이 국내로 넘어온 후 관세청에서 문자로 제세액 3만원이상의 금액을 입금하라고 오더라구요 알고보니 수입 제한금액 오버.. 추가금을 고려해야 해요 그리고 배송은 딱 2주 걸렸어요 참고하세요^^',
+    rating: 5,
+    createdAt: '2022-07-03 14:23:23',
+    // 실 서버에는 추후 추가 예정 - username, profileImage
+    username: '인도아저씨6',
+    profileImage: sampleProfile,
   },
   {
     id: 7,
-    productId: 2,
-    profileImage: sampleProfile,
-    createdAt: '2022-07-03 14:23:23',
-    username: '인도아저씨7',
-    rating: 5,
+    product: {
+      id: 7,
+      name: '예쁜 키보드',
+      imageUrl: sampleKeyboard,
+    },
     content:
       '무접점은 처음 사용이라 바로 적응되진 않아요 그래도 검증된 제품이라 역시 좋긴 좋네요 작업용으로 마지막 키보드라 생각한거라 비싸도 확 질렀습니다 아는 분은 아시겠지만 제품이 국내로 넘어온 후 관세청에서 문자로 제세액 3만원이상의 금액을 입금하라고 오더라구요 알고보니 수입 제한금액 오버.. 추가금을 고려해야 해요 그리고 배송은 딱 2주 걸렸어요 참고하세요^^',
+    rating: 5,
+    createdAt: '2022-07-03 14:23:23',
+    // 실 서버에는 추후 추가 예정 - username, profileImage
+    username: '인도아저씨7',
+    profileImage: sampleProfile,
   },
   {
     id: 8,
-    productId: 2,
-    profileImage: sampleProfile,
-    createdAt: '2022-07-03 14:23:23',
-    username: '인도아저씨8',
-    rating: 5,
+    product: {
+      id: 8,
+      name: '예쁜 키보드',
+      imageUrl: sampleKeyboard,
+    },
     content:
       '무접점은 처음 사용이라 바로 적응되진 않아요 그래도 검증된 제품이라 역시 좋긴 좋네요 작업용으로 마지막 키보드라 생각한거라 비싸도 확 질렀습니다 아는 분은 아시겠지만 제품이 국내로 넘어온 후 관세청에서 문자로 제세액 3만원이상의 금액을 입금하라고 오더라구요 알고보니 수입 제한금액 오버.. 추가금을 고려해야 해요 그리고 배송은 딱 2주 걸렸어요 참고하세요^^',
+    rating: 5,
+    createdAt: '2022-07-03 14:23:23',
+    // 실 서버에는 추후 추가 예정 - username, profileImage
+    username: '인도아저씨8',
+    profileImage: sampleProfile,
   },
   {
     id: 9,
-    productId: 2,
-    profileImage: sampleProfile,
-    createdAt: '2022-07-03 14:23:23',
-    username: '인도아저씨9',
-    rating: 5,
+    product: {
+      id: 9,
+      name: '예쁜 키보드',
+      imageUrl: sampleKeyboard,
+    },
     content:
       '무접점은 처음 사용이라 바로 적응되진 않아요 그래도 검증된 제품이라 역시 좋긴 좋네요 작업용으로 마지막 키보드라 생각한거라 비싸도 확 질렀습니다 아는 분은 아시겠지만 제품이 국내로 넘어온 후 관세청에서 문자로 제세액 3만원이상의 금액을 입금하라고 오더라구요 알고보니 수입 제한금액 오버.. 추가금을 고려해야 해요 그리고 배송은 딱 2주 걸렸어요 참고하세요^^',
+    rating: 5,
+    createdAt: '2022-07-03 14:23:23',
+    // 실 서버에는 추후 추가 예정 - username, profileImage
+    username: '인도아저씨9',
+    profileImage: sampleProfile,
   },
   {
     id: 10,
-    productId: 2,
-    profileImage: sampleProfile,
-    createdAt: '2022-07-03 14:23:23',
-    username: '인도아저씨10',
-    rating: 5,
+    product: {
+      id: 10,
+      name: '예쁜 키보드',
+      imageUrl: sampleKeyboard,
+    },
     content:
       '무접점은 처음 사용이라 바로 적응되진 않아요 그래도 검증된 제품이라 역시 좋긴 좋네요 작업용으로 마지막 키보드라 생각한거라 비싸도 확 질렀습니다 아는 분은 아시겠지만 제품이 국내로 넘어온 후 관세청에서 문자로 제세액 3만원이상의 금액을 입금하라고 오더라구요 알고보니 수입 제한금액 오버.. 추가금을 고려해야 해요 그리고 배송은 딱 2주 걸렸어요 참고하세요^^',
+    rating: 5,
+    createdAt: '2022-07-03 14:23:23',
+    // 실 서버에는 추후 추가 예정 - username, profileImage
+    username: '인도아저씨10',
+    profileImage: sampleProfile,
   },
   {
     id: 11,
-    productId: 2,
-    profileImage: sampleProfile,
-    createdAt: '2022-07-03 14:23:23',
-    username: '인도아저씨11',
-    rating: 5,
+    product: {
+      id: 11,
+      name: '예쁜 키보드',
+      imageUrl: sampleKeyboard,
+    },
     content:
       '무접점은 처음 사용이라 바로 적응되진 않아요 그래도 검증된 제품이라 역시 좋긴 좋네요 작업용으로 마지막 키보드라 생각한거라 비싸도 확 질렀습니다 아는 분은 아시겠지만 제품이 국내로 넘어온 후 관세청에서 문자로 제세액 3만원이상의 금액을 입금하라고 오더라구요 알고보니 수입 제한금액 오버.. 추가금을 고려해야 해요 그리고 배송은 딱 2주 걸렸어요 참고하세요^^',
+    rating: 5,
+    createdAt: '2022-07-03 14:23:23',
+    // 실 서버에는 추후 추가 예정 - username, profileImage
+    username: '인도아저씨11',
+    profileImage: sampleProfile,
   },
   {
     id: 12,
-    productId: 2,
-    profileImage: sampleProfile,
-    createdAt: '2022-07-03 14:23:23',
-    username: '인도아저씨12',
-    rating: 5,
+    product: {
+      id: 12,
+      name: '예쁜 키보드',
+      imageUrl: sampleKeyboard,
+    },
     content:
       '무접점은 처음 사용이라 바로 적응되진 않아요 그래도 검증된 제품이라 역시 좋긴 좋네요 작업용으로 마지막 키보드라 생각한거라 비싸도 확 질렀습니다 아는 분은 아시겠지만 제품이 국내로 넘어온 후 관세청에서 문자로 제세액 3만원이상의 금액을 입금하라고 오더라구요 알고보니 수입 제한금액 오버.. 추가금을 고려해야 해요 그리고 배송은 딱 2주 걸렸어요 참고하세요^^',
+    rating: 5,
+    createdAt: '2022-07-03 14:23:23',
+    // 실 서버에는 추후 추가 예정 - username, profileImage
+    username: '인도아저씨12',
+    profileImage: sampleProfile,
   },
 ];

--- a/frontend/src/pages/Home/Home.tsx
+++ b/frontend/src/pages/Home/Home.tsx
@@ -20,7 +20,7 @@ function Home() {
         data={!!keyboards && keyboards}
         addOn={moreProductsLink}
       />
-      <ReviewListSection columns={3} data={reviews} getNextPage={getNextPage} />
+      <ReviewListSection columns={2} data={reviews} getNextPage={getNextPage} />
     </>
   );
 }


### PR DESCRIPTION
# issue: #104 

# 작업 내용
- Interceptor에서 Authorization 헤더에서 토큰을 추출하여, Token의 유효성을 검증한다.
- 해당 인증/인가 기능이 필요한 메서드에 `@Auth` 어노테이션을 붙여서 사용할 수 있도록 했다.
- Resolver에서 토큰의 Payload 값을 꺼내서 controller에 값을 바인딩 한다.
  - `@AuthPrincipal` 어노테이션을 사용해서 Long 값을 받도록 했다.
- 리뷰를 생성할 때 Member의 id 값을 받아서 확인하는 기능을 추가했다.
