### PR TITLE
[BE] Interceptor와 Resolver를 스프링 빈으로 만들어 한 번에 주입받아 등록하도록 변경

### DIFF
--- a/backend/src/main/java/com/woowacourse/f12/config/WebConfig.java
+++ b/backend/src/main/java/com/woowacourse/f12/config/WebConfig.java
@@ -1,12 +1,10 @@
 package com.woowacourse.f12.config;
 
-import com.woowacourse.f12.presentation.AuthArgumentResolver;
-import com.woowacourse.f12.presentation.AuthInterceptor;
-import com.woowacourse.f12.presentation.CustomPageableArgumentResolver;
 import java.util.List;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -16,17 +14,17 @@ public class WebConfig implements WebMvcConfigurer {
 
     private static final String CORS_ALLOWED_METHODS = "GET,POST,HEAD,PUT,PATCH,DELETE,TRACE,OPTIONS";
 
-    private final AuthInterceptor authInterceptor;
-    private final AuthArgumentResolver authArgumentResolver;
+    private final List<HandlerInterceptor> interceptors;
+    private final List<HandlerMethodArgumentResolver> resolvers;
 
-    public WebConfig(final AuthInterceptor authInterceptor, final AuthArgumentResolver authArgumentResolver) {
-        this.authInterceptor = authInterceptor;
-        this.authArgumentResolver = authArgumentResolver;
+    public WebConfig(List<HandlerInterceptor> interceptors, List<HandlerMethodArgumentResolver> resolvers) {
+        this.interceptors = interceptors;
+        this.resolvers = resolvers;
     }
 
     @Override
     public void addInterceptors(final InterceptorRegistry registry) {
-        registry.addInterceptor(authInterceptor);
+        interceptors.forEach(registry::addInterceptor);
     }
 
     @Override
@@ -38,9 +36,6 @@ public class WebConfig implements WebMvcConfigurer {
 
     @Override
     public void addArgumentResolvers(final List<HandlerMethodArgumentResolver> resolvers) {
-        final CustomPageableArgumentResolver customPageableArgumentResolver = new CustomPageableArgumentResolver();
-        customPageableArgumentResolver.setMaxPageSize(150);
-        resolvers.add(customPageableArgumentResolver);
-        resolvers.add(authArgumentResolver);
+        resolvers.addAll(this.resolvers);
     }
 }

--- a/backend/src/main/java/com/woowacourse/f12/presentation/CustomPageableArgumentResolver.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/CustomPageableArgumentResolver.java
@@ -9,10 +9,12 @@ import java.util.regex.Pattern;
 import org.springframework.core.MethodParameter;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
+@Component
 public class CustomPageableArgumentResolver extends PageableHandlerMethodArgumentResolver {
 
     private static final int MAX_SIZE = 150;


### PR DESCRIPTION
# issue: #116 

# 작업 내용
- `CustomPageableArgumentResolver`를 스프링 빈으로 등록
- `WebConfig`에서 `HandlerInterceptor` 타입과 `HandlerMethodArgumentResolver` 타입의 빈을 리스트로 주입받도록 수정
- 주입받은 빈들의 리스트를 각각 Interceptor와 Resolver로 등록