### PR TITLE
[BE] 로그인이 필요한 메서드에 붙이는 어노테이션 명 수정

### DIFF
--- a/backend/src/main/java/com/woowacourse/f12/presentation/AuthArgumentResolver.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/AuthArgumentResolver.java
@@ -21,13 +21,12 @@ public class AuthArgumentResolver implements HandlerMethodArgumentResolver {
 
     @Override
     public boolean supportsParameter(final MethodParameter parameter) {
-        return parameter.hasParameterAnnotation(AuthPrincipal.class);
+        return parameter.hasParameterAnnotation(VerifiedMember.class);
     }
 
     @Override
     public Object resolveArgument(final MethodParameter parameter, final ModelAndViewContainer mavContainer,
-                                  final NativeWebRequest webRequest, final WebDataBinderFactory binderFactory)
-            throws Exception {
+                                  final NativeWebRequest webRequest, final WebDataBinderFactory binderFactory) {
         final String authorizationHeader = webRequest.getHeader(HttpHeaders.AUTHORIZATION);
         final String payload = jwtProvider.getPayload(authorizationHeader);
         try {

--- a/backend/src/main/java/com/woowacourse/f12/presentation/AuthInterceptor.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/AuthInterceptor.java
@@ -33,7 +33,7 @@ public class AuthInterceptor implements HandlerInterceptor {
             return true;
         }
         HandlerMethod handlerMethod = (HandlerMethod) handler;
-        Auth auth = handlerMethod.getMethodAnnotation(Auth.class);
+        LoginRequired auth = handlerMethod.getMethodAnnotation(LoginRequired.class);
         return Objects.isNull(auth);
     }
 

--- a/backend/src/main/java/com/woowacourse/f12/presentation/LoginRequired.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/LoginRequired.java
@@ -7,5 +7,5 @@ import java.lang.annotation.Target;
 
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
-public @interface Auth {
+public @interface LoginRequired {
 }

--- a/backend/src/main/java/com/woowacourse/f12/presentation/ReviewController.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/ReviewController.java
@@ -26,7 +26,7 @@ public class ReviewController {
     }
 
     @PostMapping("/keyboards/{productId}/reviews")
-    @Auth
+    @LoginRequired
     public ResponseEntity<Void> create(@PathVariable final Long productId,
                                        @Valid @RequestBody final ReviewRequest reviewRequest,
                                        @AuthPrincipal final Long memberId) {

--- a/backend/src/main/java/com/woowacourse/f12/presentation/ReviewController.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/ReviewController.java
@@ -29,7 +29,7 @@ public class ReviewController {
     @LoginRequired
     public ResponseEntity<Void> create(@PathVariable final Long productId,
                                        @Valid @RequestBody final ReviewRequest reviewRequest,
-                                       @AuthPrincipal final Long memberId) {
+                                       @VerifiedMember final Long memberId) {
         final Long id = reviewService.save(productId, reviewRequest, memberId);
         return ResponseEntity.created(URI.create("/api/v1/reviews/" + id))
                 .build();

--- a/backend/src/main/java/com/woowacourse/f12/presentation/VerifiedMember.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/VerifiedMember.java
@@ -7,5 +7,5 @@ import java.lang.annotation.Target;
 
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
-public @interface AuthPrincipal {
+public @interface VerifiedMember {
 }


### PR DESCRIPTION
# issue: 

# 작업 내용
- 기존에 로그인이 필요한 메서드에 붙이는 어노테이션 이름(`@Auth`)이 직관적이지 않아 로그인이 필요하다는 의미를 직관적으로 담은 `@LoginRequired`로 수정
- 로그인한 회원 정보를 가져오는 어노테이션 이름(`@AuthPrincipal`) 역시 직관적이도록 `@VerifiedMember`로 수정
