### PR TITLE
[BugFix] GitHub에 access token 요청할 때 JSON 형태로 요청하도록 수정

### DIFF
--- a/backend/src/main/java/com/woowacourse/f12/application/GitHubOauthClient.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/GitHubOauthClient.java
@@ -43,6 +43,7 @@ public class GitHubOauthClient {
     private GitHubTokenResponse requestAccessToken(final GitHubTokenRequest gitHubTokenRequest,
                                                    final WebClient webClient) {
         return webClient.post()
+                .accept(MediaType.APPLICATION_JSON)
                 .body(Mono.just(gitHubTokenRequest), GitHubTokenRequest.class)
                 .retrieve()
                 .onStatus(HttpStatus::is4xxClientError, clientResponse -> {


### PR DESCRIPTION
# issue: #137 

# 작업 내용
- GitHub에 access token을 요청할 때 `accept` 값을 넣지 않으면 `x-www-urlencoded` 타입으로 응답하는데 반해 응답값 파싱은 `application/json`으로 하고 있었음. 따라서 access token 요청 시 `accept: application/json`을 넣어줌