### PR TITLE
[BE] 리뷰 작성 시 리뷰에 작성자 정보를 함께 저장

### DIFF
--- a/backend/src/main/java/com/woowacourse/f12/application/ReviewService.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/ReviewService.java
@@ -37,8 +37,7 @@ public class ReviewService {
                 .orElseThrow(KeyboardNotFoundException::new);
         final Member member = memberRepository.findById(memberId)
                 .orElseThrow(MemberNotFoundException::new);
-
-        final Review review = reviewRequest.toReview(keyboard);
+        final Review review = reviewRequest.toReview(keyboard, member);
         return reviewRepository.save(review)
                 .getId();
     }

--- a/backend/src/main/java/com/woowacourse/f12/domain/Review.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/Review.java
@@ -41,8 +41,12 @@ public class Review {
     private int rating;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "product_id")
+    @JoinColumn(name = "product_id", nullable = false)
     private Keyboard keyboard;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
 
     @CreatedDate
     @Column(name = "created_at", nullable = false, updatable = false)
@@ -52,7 +56,7 @@ public class Review {
     }
 
     @Builder
-    private Review(final Long id, final String content, final int rating, final Keyboard keyboard,
+    private Review(final Long id, final String content, final int rating, final Keyboard keyboard, final Member member,
                    final LocalDateTime createdAt) {
         validateContent(content);
         validateRating(rating);
@@ -60,6 +64,7 @@ public class Review {
         this.content = content;
         this.rating = rating;
         this.keyboard = keyboard;
+        this.member = member;
         this.createdAt = createdAt;
     }
 

--- a/backend/src/main/java/com/woowacourse/f12/dto/request/ReviewRequest.java
+++ b/backend/src/main/java/com/woowacourse/f12/dto/request/ReviewRequest.java
@@ -1,6 +1,7 @@
 package com.woowacourse.f12.dto.request;
 
 import com.woowacourse.f12.domain.Keyboard;
+import com.woowacourse.f12.domain.Member;
 import com.woowacourse.f12.domain.Review;
 import javax.validation.constraints.NotNull;
 import lombok.Getter;
@@ -22,9 +23,10 @@ public class ReviewRequest {
         this.rating = rating;
     }
 
-    public Review toReview(final Keyboard keyboard) {
+    public Review toReview(final Keyboard keyboard, final Member member) {
         return Review.builder()
                 .keyboard(keyboard)
+                .member(member)
                 .content(this.content)
                 .rating(this.rating)
                 .build();

--- a/backend/src/test/java/com/woowacourse/f12/application/ReviewServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/application/ReviewServiceTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.verify;
 
 import com.woowacourse.f12.domain.Keyboard;
 import com.woowacourse.f12.domain.KeyboardRepository;
+import com.woowacourse.f12.domain.Member;
 import com.woowacourse.f12.domain.MemberRepository;
 import com.woowacourse.f12.domain.Review;
 import com.woowacourse.f12.domain.ReviewRepository;
@@ -56,12 +57,13 @@ class ReviewServiceTest {
         ReviewRequest reviewRequest = new ReviewRequest("내용", 5);
         Long productId = 1L;
         Keyboard keyboard = KEYBOARD_1.생성(productId);
+        Member member = CORINNE.생성(1L);
         given(keyboardRepository.findById(productId))
                 .willReturn(Optional.of(keyboard));
         given(memberRepository.findById(1L))
                 .willReturn(Optional.of(CORINNE.생성(1L)));
         given(reviewRepository.save(reviewRequest.toReview(keyboard)))
-                .willReturn(REVIEW_RATING_5.작성(1L, keyboard));
+                .willReturn(REVIEW_RATING_5.작성(1L, keyboard, member));
 
         // when
         Long reviewId = reviewService.save(productId, reviewRequest, 1L);
@@ -97,9 +99,10 @@ class ReviewServiceTest {
         // given
         Long productId = 1L;
         Keyboard keyboard = KEYBOARD_1.생성();
+        Member member = CORINNE.생성(1L);
         Pageable pageable = PageRequest.of(0, 1, Sort.by(Order.desc("createdAt")));
         Slice<Review> slice = new SliceImpl<>(List.of(
-                REVIEW_RATING_5.작성(1L, keyboard)
+                REVIEW_RATING_5.작성(1L, keyboard, member)
         ), pageable, true);
 
         given(keyboardRepository.existsById(productId))
@@ -140,9 +143,10 @@ class ReviewServiceTest {
     void 전체_리뷰_목록을_조회한다() {
         // given
         Pageable pageable = PageRequest.of(0, 2, Sort.by(Order.desc("createdAt")));
+        Member member = CORINNE.생성(1L);
         Slice<Review> slice = new SliceImpl<>(List.of(
-                REVIEW_RATING_5.작성(3L, KEYBOARD_1.생성()),
-                REVIEW_RATING_5.작성(2L, KEYBOARD_2.생성())
+                REVIEW_RATING_5.작성(3L, KEYBOARD_1.생성(), member),
+                REVIEW_RATING_5.작성(2L, KEYBOARD_2.생성(), member)
         ), pageable, true);
 
         given(reviewRepository.findPageBy(pageable))

--- a/backend/src/test/java/com/woowacourse/f12/application/ReviewServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/application/ReviewServiceTest.java
@@ -62,7 +62,7 @@ class ReviewServiceTest {
                 .willReturn(Optional.of(keyboard));
         given(memberRepository.findById(1L))
                 .willReturn(Optional.of(CORINNE.생성(1L)));
-        given(reviewRepository.save(reviewRequest.toReview(keyboard)))
+        given(reviewRepository.save(reviewRequest.toReview(keyboard, member)))
                 .willReturn(REVIEW_RATING_5.작성(1L, keyboard, member));
 
         // when

--- a/backend/src/test/java/com/woowacourse/f12/documentation/ReviewDocumentation.java
+++ b/backend/src/test/java/com/woowacourse/f12/documentation/ReviewDocumentation.java
@@ -2,6 +2,7 @@ package com.woowacourse.f12.documentation;
 
 import static com.woowacourse.f12.support.KeyboardFixtures.KEYBOARD_1;
 import static com.woowacourse.f12.support.KeyboardFixtures.KEYBOARD_2;
+import static com.woowacourse.f12.support.MemberFixtures.CORINNE;
 import static com.woowacourse.f12.support.ReviewFixtures.REVIEW_RATING_4;
 import static com.woowacourse.f12.support.ReviewFixtures.REVIEW_RATING_5;
 import static org.mockito.ArgumentMatchers.any;
@@ -17,6 +18,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.woowacourse.f12.application.JwtProvider;
 import com.woowacourse.f12.application.ReviewService;
 import com.woowacourse.f12.domain.Keyboard;
+import com.woowacourse.f12.domain.Member;
 import com.woowacourse.f12.dto.request.ReviewRequest;
 import com.woowacourse.f12.dto.response.ReviewPageResponse;
 import com.woowacourse.f12.dto.response.ReviewWithProductPageResponse;
@@ -82,8 +84,9 @@ public class ReviewDocumentation extends Documentation {
         // given
         PageRequest pageable = PageRequest.of(0, 10, Sort.by("createdAt").descending());
         Keyboard keyboard = KEYBOARD_1.생성(1L);
+        Member member = CORINNE.생성(1L);
         ReviewPageResponse reviewPageResponse = ReviewPageResponse.from(
-                new SliceImpl<>(List.of(REVIEW_RATING_5.작성(1L, keyboard), REVIEW_RATING_4.작성(2L, keyboard)), pageable, false));
+                new SliceImpl<>(List.of(REVIEW_RATING_5.작성(1L, keyboard, member), REVIEW_RATING_4.작성(2L, keyboard, member)), pageable, false));
 
         given(reviewService.findPageByProductId(anyLong(), any(Pageable.class)))
                 .willReturn(reviewPageResponse);
@@ -108,8 +111,9 @@ public class ReviewDocumentation extends Documentation {
         PageRequest pageable = PageRequest.of(0, 10, Sort.by("createdAt").descending());
         Keyboard keyboard1 = KEYBOARD_1.생성(1L);
         Keyboard keyboard2 = KEYBOARD_2.생성(2L);
+        Member member = CORINNE.생성(1L);
         ReviewWithProductPageResponse reviewWithProductPageResponse = ReviewWithProductPageResponse.from(
-                new SliceImpl<>(List.of(REVIEW_RATING_5.작성(1L, keyboard1), REVIEW_RATING_4.작성(2L, keyboard2)), pageable, false));
+                new SliceImpl<>(List.of(REVIEW_RATING_5.작성(1L, keyboard1, member), REVIEW_RATING_4.작성(2L, keyboard2, member)), pageable, false));
 
         given(reviewService.findPage(any(Pageable.class)))
                 .willReturn(reviewWithProductPageResponse);

--- a/backend/src/test/java/com/woowacourse/f12/domain/KeyboardRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/domain/KeyboardRepositoryTest.java
@@ -2,6 +2,7 @@ package com.woowacourse.f12.domain;
 
 import static com.woowacourse.f12.support.KeyboardFixtures.KEYBOARD_1;
 import static com.woowacourse.f12.support.KeyboardFixtures.KEYBOARD_2;
+import static com.woowacourse.f12.support.MemberFixtures.CORINNE;
 import static com.woowacourse.f12.support.ReviewFixtures.REVIEW_RATING_1;
 import static com.woowacourse.f12.support.ReviewFixtures.REVIEW_RATING_2;
 import static com.woowacourse.f12.support.ReviewFixtures.REVIEW_RATING_4;
@@ -30,6 +31,9 @@ class KeyboardRepositoryTest {
     private KeyboardRepository keyboardRepository;
 
     @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
     private ReviewRepository reviewRepository;
 
     @PersistenceContext
@@ -39,8 +43,9 @@ class KeyboardRepositoryTest {
     void 키보드를_단일_조회_한다() {
         // given
         Keyboard keyboard = 키보드_저장(KEYBOARD_1.생성());
-        리뷰_저장(REVIEW_RATING_4.작성(keyboard));
-        리뷰_저장(REVIEW_RATING_5.작성(keyboard));
+        Member member = memberRepository.save(CORINNE.생성(1L));
+        리뷰_저장(REVIEW_RATING_4.작성(keyboard, member));
+        리뷰_저장(REVIEW_RATING_5.작성(keyboard, member));
         entityManager.flush();
         entityManager.refresh(keyboard);
 
@@ -77,10 +82,11 @@ class KeyboardRepositoryTest {
         // given
         Keyboard keyboard1 = 키보드_저장(KEYBOARD_1.생성());
         Keyboard keyboard2 = 키보드_저장(KEYBOARD_2.생성());
+        Member member = memberRepository.save(CORINNE.생성(1L));
 
-        리뷰_저장(REVIEW_RATING_5.작성(keyboard1));
-        리뷰_저장(REVIEW_RATING_5.작성(keyboard2));
-        리뷰_저장(REVIEW_RATING_5.작성(keyboard2));
+        리뷰_저장(REVIEW_RATING_5.작성(keyboard1, member));
+        리뷰_저장(REVIEW_RATING_5.작성(keyboard2, member));
+        리뷰_저장(REVIEW_RATING_5.작성(keyboard2, member));
 
         Pageable pageable = PageRequest.of(0, 1, Sort.by(Order.desc("reviewCount")));
 
@@ -99,11 +105,12 @@ class KeyboardRepositoryTest {
         // given
         Keyboard keyboard2 = 키보드_저장(KEYBOARD_1.생성());
         Keyboard keyboard1 = 키보드_저장(KEYBOARD_2.생성());
+        Member member = memberRepository.save(CORINNE.생성(1L));
 
-        리뷰_저장(REVIEW_RATING_2.작성(keyboard1));
-        리뷰_저장(REVIEW_RATING_1.작성(keyboard1));
-        리뷰_저장(REVIEW_RATING_5.작성(keyboard2));
-        리뷰_저장(REVIEW_RATING_4.작성(keyboard2));
+        리뷰_저장(REVIEW_RATING_2.작성(keyboard1, member));
+        리뷰_저장(REVIEW_RATING_1.작성(keyboard1, member));
+        리뷰_저장(REVIEW_RATING_5.작성(keyboard2, member));
+        리뷰_저장(REVIEW_RATING_4.작성(keyboard2, member));
 
         Pageable pageable = PageRequest.of(0, 1, Sort.by(Order.desc("rating")));
 

--- a/backend/src/test/java/com/woowacourse/f12/domain/ReviewRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/domain/ReviewRepositoryTest.java
@@ -2,6 +2,7 @@ package com.woowacourse.f12.domain;
 
 import static com.woowacourse.f12.support.KeyboardFixtures.KEYBOARD_1;
 import static com.woowacourse.f12.support.KeyboardFixtures.KEYBOARD_2;
+import static com.woowacourse.f12.support.MemberFixtures.CORINNE;
 import static com.woowacourse.f12.support.ReviewFixtures.REVIEW_RATING_4;
 import static com.woowacourse.f12.support.ReviewFixtures.REVIEW_RATING_5;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -28,13 +29,17 @@ class ReviewRepositoryTest {
     @Autowired
     private KeyboardRepository keyboardRepository;
 
+    @Autowired
+    private MemberRepository memberRepository;
+
     @Test
     void 특정_제품의_리뷰_목록을_최신순으로_페이징하여_조회한다() {
         // given
         Keyboard keyboard = keyboardRepository.save(KEYBOARD_1.생성());
+        Member member = memberRepository.save(CORINNE.생성(1L));
         Pageable pageable = PageRequest.of(0, 1, Sort.by(desc("createdAt")));
-        리뷰_저장(REVIEW_RATING_5.작성(keyboard));
-        Review review = 리뷰_저장(REVIEW_RATING_5.작성(keyboard));
+        리뷰_저장(REVIEW_RATING_5.작성(keyboard, member));
+        Review review = 리뷰_저장(REVIEW_RATING_5.작성(keyboard, member));
 
         // when
         Slice<Review> page = reviewRepository.findPageByProductId(keyboard.getId(), pageable);
@@ -52,9 +57,10 @@ class ReviewRepositoryTest {
     void 특정_제품의_리뷰_목록을_평점순으로_페이징하여_조회한다() {
         // given
         Keyboard keyboard = keyboardRepository.save(KEYBOARD_1.생성());
+        Member member = memberRepository.save(CORINNE.생성(1L));
         Pageable pageable = PageRequest.of(0, 1, Sort.by(desc("rating")));
-        Review review = 리뷰_저장(REVIEW_RATING_5.작성(keyboard));
-        리뷰_저장(REVIEW_RATING_4.작성(keyboard));
+        Review review = 리뷰_저장(REVIEW_RATING_5.작성(keyboard, member));
+        리뷰_저장(REVIEW_RATING_4.작성(keyboard, member));
 
         // when
         Slice<Review> page = reviewRepository.findPageByProductId(keyboard.getId(), pageable);
@@ -73,9 +79,10 @@ class ReviewRepositoryTest {
         // given
         Keyboard keyboard1 = keyboardRepository.save(KEYBOARD_1.생성());
         Keyboard keyboard2 = keyboardRepository.save(KEYBOARD_2.생성());
+        Member member = memberRepository.save(CORINNE.생성(1L));
         Pageable pageable = PageRequest.of(0, 1, Sort.by(desc("createdAt")));
-        리뷰_저장(REVIEW_RATING_5.작성(keyboard1));
-        Review review = 리뷰_저장(REVIEW_RATING_5.작성(keyboard2));
+        리뷰_저장(REVIEW_RATING_5.작성(keyboard1, member));
+        Review review = 리뷰_저장(REVIEW_RATING_5.작성(keyboard2, member));
 
         // when
         Slice<Review> page = reviewRepository.findPageBy(pageable);

--- a/backend/src/test/java/com/woowacourse/f12/presentation/ReviewControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/ReviewControllerTest.java
@@ -1,6 +1,7 @@
 package com.woowacourse.f12.presentation;
 
 import static com.woowacourse.f12.support.KeyboardFixtures.KEYBOARD_1;
+import static com.woowacourse.f12.support.MemberFixtures.CORINNE;
 import static com.woowacourse.f12.support.ReviewFixtures.REVIEW_RATING_5;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
@@ -266,7 +267,7 @@ class ReviewControllerTest {
         // given
         given(reviewService.findPage(any(Pageable.class)))
                 .willReturn(ReviewWithProductPageResponse.from(
-                        new SliceImpl<>(List.of(REVIEW_RATING_5.작성(1L, KEYBOARD_1.생성())))));
+                        new SliceImpl<>(List.of(REVIEW_RATING_5.작성(1L, KEYBOARD_1.생성(), CORINNE.생성(1L))))));
 
         // when
         mockMvc.perform(get("/api/v1/reviews?size=150&page=0&sort=rating,desc"))
@@ -281,7 +282,7 @@ class ReviewControllerTest {
     void 특정_상품의_리뷰_페이지_조회() throws Exception {
         // given
         given(reviewService.findPageByProductId(anyLong(), any(Pageable.class)))
-                .willReturn(ReviewPageResponse.from(new SliceImpl<>(List.of(REVIEW_RATING_5.작성(1L, KEYBOARD_1.생성())))));
+                .willReturn(ReviewPageResponse.from(new SliceImpl<>(List.of(REVIEW_RATING_5.작성(1L, KEYBOARD_1.생성(), CORINNE.생성(1L))))));
 
         // when
         mockMvc.perform(get("/api/v1/keyboards/" + PRODUCT_ID + "/reviews?size=150&page=0&sort=rating,desc"))

--- a/backend/src/test/java/com/woowacourse/f12/support/ReviewFixtures.java
+++ b/backend/src/test/java/com/woowacourse/f12/support/ReviewFixtures.java
@@ -2,6 +2,7 @@ package com.woowacourse.f12.support;
 
 import com.woowacourse.f12.acceptance.support.RestAssuredRequestUtil;
 import com.woowacourse.f12.domain.Keyboard;
+import com.woowacourse.f12.domain.Member;
 import com.woowacourse.f12.domain.Review;
 import com.woowacourse.f12.dto.request.ReviewRequest;
 import io.restassured.response.ExtractableResponse;
@@ -25,21 +26,22 @@ public enum ReviewFixtures {
         this.rating = rating;
     }
 
-    public Review 작성(Keyboard keyboard) {
-        return 작성(null, keyboard);
+    public Review 작성(final Keyboard keyboard, final Member member) {
+        return 작성(null, keyboard, member);
     }
 
-    public Review 작성(Long reviewId, Keyboard keyboard) {
+    public Review 작성(final Long reviewId, final Keyboard keyboard, final Member member) {
         return Review.builder()
                 .id(reviewId)
                 .keyboard(keyboard)
+                .member(member)
                 .content(this.content)
                 .rating(this.rating)
                 .createdAt(LocalDateTime.now())
                 .build();
     }
 
-    public ExtractableResponse<Response> 작성_요청을_보낸다(Long productId, String token) {
+    public ExtractableResponse<Response> 작성_요청을_보낸다(final Long productId, final String token) {
         final ReviewRequest reviewRequest = new ReviewRequest(this.content, this.rating);
         return RestAssuredRequestUtil.로그인된_상태로_POST_요청을_보낸다("/api/v1/keyboards/" + productId + "/reviews", token,
                 reviewRequest);


### PR DESCRIPTION
# issue: #141 

# 작업 내용
- `Review`와 `Member` 사이에 `@ManyToOne` 단방향 연관관계를 맺어줌(`Review` -> `Member`)
- 서비스의 리뷰 작성 메서드에서 회원을 조회해 온 뒤 리뷰에 매핑해주고 저장하는 로직 추가