### PR TITLE
[BE] 리뷰 조회 시 작성자 정보를 포함하여 조회

### DIFF
--- a/backend/src/main/java/com/woowacourse/f12/domain/Member.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/Member.java
@@ -28,7 +28,7 @@ public class Member {
     @Column(name = "name", nullable = false)
     private String name;
 
-    @Column(name = "image_url", nullable = false)
+    @Column(name = "image_url", length = 65535, nullable = false)
     private String imageUrl;
 
     protected Member() {

--- a/backend/src/main/java/com/woowacourse/f12/dto/response/ReviewAuthor.java
+++ b/backend/src/main/java/com/woowacourse/f12/dto/response/ReviewAuthor.java
@@ -1,0 +1,25 @@
+package com.woowacourse.f12.dto.response;
+
+import com.woowacourse.f12.domain.Member;
+import lombok.Getter;
+
+@Getter
+public class ReviewAuthor {
+
+    private Long id;
+    private String gitHubId;
+    private String imageUrl;
+
+    private ReviewAuthor() {
+    }
+
+    private ReviewAuthor(final Long id, final String gitHubId, final String imageUrl) {
+        this.id = id;
+        this.gitHubId = gitHubId;
+        this.imageUrl = imageUrl;
+    }
+
+    public static ReviewAuthor from(Member member) {
+        return new ReviewAuthor(member.getId(), member.getGitHubId(), member.getImageUrl());
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/dto/response/ReviewResponse.java
+++ b/backend/src/main/java/com/woowacourse/f12/dto/response/ReviewResponse.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 public class ReviewResponse {
 
     private Long id;
+    private ReviewAuthor author;
     private Long productId;
     private String content;
     private int rating;
@@ -15,9 +16,10 @@ public class ReviewResponse {
     private ReviewResponse() {
     }
 
-    public ReviewResponse(final Long id, final Long productId, final String content, final int rating,
-                          final String createdAt) {
+    private ReviewResponse(final Long id, final ReviewAuthor author, final Long productId, final String content,
+                           final int rating, final String createdAt) {
         this.id = id;
+        this.author = author;
         this.productId = productId;
         this.content = content;
         this.rating = rating;
@@ -25,7 +27,8 @@ public class ReviewResponse {
     }
 
     public static ReviewResponse from(final Review review) {
-        return new ReviewResponse(review.getId(), review.getKeyboard().getId(), review.getContent(), review.getRating(),
-                review.getCreatedAt().toString());
+        final ReviewAuthor author = ReviewAuthor.from(review.getMember());
+        return new ReviewResponse(review.getId(), author, review.getKeyboard().getId(), review.getContent(),
+                review.getRating(), review.getCreatedAt().toString());
     }
 }

--- a/backend/src/main/java/com/woowacourse/f12/dto/response/ReviewWithProductResponse.java
+++ b/backend/src/main/java/com/woowacourse/f12/dto/response/ReviewWithProductResponse.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 public class ReviewWithProductResponse {
 
     private Long id;
+    private ReviewAuthor author;
     private KeyboardForReviewResponse product;
     private String content;
     private int rating;
@@ -15,10 +16,10 @@ public class ReviewWithProductResponse {
     private ReviewWithProductResponse() {
     }
 
-    private ReviewWithProductResponse(final Long id, final KeyboardForReviewResponse product, final String content,
-                                      final int rating,
-                                      final String createdAt) {
+    private ReviewWithProductResponse(final Long id, final ReviewAuthor author, final KeyboardForReviewResponse product,
+                                      final String content, final int rating, final String createdAt) {
         this.id = id;
+        this.author = author;
         this.product = product;
         this.content = content;
         this.rating = rating;
@@ -27,7 +28,8 @@ public class ReviewWithProductResponse {
 
     public static ReviewWithProductResponse from(final Review review) {
         final KeyboardForReviewResponse product = KeyboardForReviewResponse.from(review.getKeyboard());
-        return new ReviewWithProductResponse(review.getId(), product, review.getContent(), review.getRating(),
+        final ReviewAuthor author = ReviewAuthor.from(review.getMember());
+        return new ReviewWithProductResponse(review.getId(), author, product, review.getContent(), review.getRating(),
                 review.getCreatedAt().toString());
     }
 }

--- a/backend/src/test/java/com/woowacourse/f12/application/KeyboardServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/application/KeyboardServiceTest.java
@@ -47,8 +47,11 @@ class KeyboardServiceTest {
         // then
         assertAll(
                 () -> verify(keyboardRepository).findById(1L),
-                () -> assertThat(keyboardResponse.getId()).isEqualTo(1L),
-                () -> assertThat(keyboardResponse.getName()).isEqualTo("키보드1")
+                () -> {
+                    assert keyboard != null;
+                    assertThat(keyboardResponse).usingRecursiveComparison()
+                            .isEqualTo(KeyboardResponse.from(keyboard));
+                }
         );
     }
 
@@ -68,11 +71,10 @@ class KeyboardServiceTest {
     @Test
     void 전체_키보드_목록을_조회한다() {
         // given
+        Keyboard keyboard = KEYBOARD_1.생성(1L);
         Pageable pageable = PageRequest.of(0, 1);
         given(keyboardRepository.findPageBy(any(Pageable.class)))
-                .willReturn(new SliceImpl<>(List.of(
-                        KEYBOARD_1.생성(1L)
-                ), pageable, false));
+                .willReturn(new SliceImpl<>(List.of(keyboard), pageable, false));
 
         // when
         KeyboardPageResponse keyboardPageResponse = keyboardService.findPage(pageable);
@@ -82,6 +84,8 @@ class KeyboardServiceTest {
                 () -> verify(keyboardRepository).findPageBy(any(Pageable.class)),
                 () -> assertThat(keyboardPageResponse.isHasNext()).isFalse(),
                 () -> assertThat(keyboardPageResponse.getItems()).hasSize(1)
+                        .usingRecursiveFieldByFieldElementComparator()
+                        .containsOnly(KeyboardResponse.from(keyboard))
         );
     }
 }


### PR DESCRIPTION
# issue: #142 

# 작업 내용
- `Member`에서 필요한 정보만 보여주는 `ReviewAuthor` DTO 추가
- 리뷰 DTO에  `ReviewAuthor author` 필드 추가
- 서비스 테스트 시 DTO 테스트를 값이 정상적으로 매핑되는지 동등성 테스트로 변경
