### PR TITLE
[BE] 대표 장비를 업데이트 하는 기능 구현

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### auth ###
+application-auth.yml

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -18,9 +18,10 @@ repositories {
 }
 
 dependencies {
-	  implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-  	implementation 'org.springframework.boot:spring-boot-starter-web'
-	  implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
     runtimeOnly 'com.h2database:h2'
 
@@ -54,6 +55,10 @@ tasks.named('test') {
 tasks.named('asciidoctor') {
     configurations 'asciidoctorExtensions'
     inputs.dir snippetsDir
+    sources {
+        include("**/index.adoc")
+    }
+    baseDirFollowsSourceFile()
     dependsOn test
 }
 

--- a/backend/src/docs/asciidoc/auth.adoc
+++ b/backend/src/docs/asciidoc/auth.adoc
@@ -1,0 +1,6 @@
+[[Auth]]
+== Auth API
+
+=== 로그인
+
+operation::auth-login[snippets='http-request,http-response']

--- a/backend/src/docs/asciidoc/index.adoc
+++ b/backend/src/docs/asciidoc/index.adoc
@@ -6,5 +6,6 @@
 = F12
 
 include::auth.adoc[]
+include::members.adoc[]
 include::keyboards.adoc[]
 include::reviews.adoc[]

--- a/backend/src/docs/asciidoc/index.adoc
+++ b/backend/src/docs/asciidoc/index.adoc
@@ -1,0 +1,10 @@
+:doctype: book
+:toc: left
+:toclevels: 2
+:sectlinks:
+
+= F12
+
+include::auth.adoc[]
+include::keyboards.adoc[]
+include::reviews.adoc[]

--- a/backend/src/docs/asciidoc/keyboards.adoc
+++ b/backend/src/docs/asciidoc/keyboards.adoc
@@ -1,9 +1,5 @@
-= Keyboard API
-
-:doctype: book
-:toc: left
-:toclevels: 2
-:sectlinks:
+[[Keyboard]]
+== Keyboard API
 
 === 키보드 단일 상품 조회
 

--- a/backend/src/docs/asciidoc/members.adoc
+++ b/backend/src/docs/asciidoc/members.adoc
@@ -1,0 +1,6 @@
+[[Member]]
+== Member API
+
+=== Member 대표 장비 업데이트
+
+operation::member-inventoryProduct-update[snippets='http-request,http-response']

--- a/backend/src/docs/asciidoc/reviews.adoc
+++ b/backend/src/docs/asciidoc/reviews.adoc
@@ -1,9 +1,5 @@
-= Review API
-
-:doctype: book
-:toc: left
-:toclevels: 2
-:sectlinks:
+[[Reivew]]
+== Review API
 
 === 리뷰 작성
 

--- a/backend/src/main/java/com/woowacourse/f12/application/AuthService.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/AuthService.java
@@ -1,0 +1,35 @@
+package com.woowacourse.f12.application;
+
+import com.woowacourse.f12.domain.Member;
+import com.woowacourse.f12.domain.MemberRepository;
+import com.woowacourse.f12.dto.response.GitHubProfileResponse;
+import com.woowacourse.f12.dto.response.LoginResponse;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class AuthService {
+
+    private final GitHubOauthClient gitHubOauthClient;
+    private final MemberRepository memberRepository;
+    private final JwtProvider jwtProvider;
+
+    public AuthService(final GitHubOauthClient gitHubOauthClient, final MemberRepository memberRepository,
+                       final JwtProvider jwtProvider) {
+        this.gitHubOauthClient = gitHubOauthClient;
+        this.memberRepository = memberRepository;
+        this.jwtProvider = jwtProvider;
+    }
+
+    @Transactional
+    public LoginResponse login(final String code) {
+        final String gitHubAccessToken = gitHubOauthClient.getAccessToken(code);
+        final GitHubProfileResponse gitHubProfileResponse = gitHubOauthClient.getProfile(gitHubAccessToken);
+        final Member member = memberRepository.findByGitHubId(gitHubProfileResponse.getGitHubId())
+                .orElseGet(() -> memberRepository.save(gitHubProfileResponse.toMember()));
+        member.updateName(gitHubProfileResponse.getName());
+        final String applicationAccessToken = jwtProvider.createToken(member.getId());
+        return LoginResponse.of(applicationAccessToken, member);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/application/GitHubOauthClient.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/GitHubOauthClient.java
@@ -1,0 +1,80 @@
+package com.woowacourse.f12.application;
+
+import com.woowacourse.f12.dto.request.GitHubTokenRequest;
+import com.woowacourse.f12.dto.response.GitHubProfileResponse;
+import com.woowacourse.f12.dto.response.GitHubTokenResponse;
+import com.woowacourse.f12.exception.GitHubServerException;
+import com.woowacourse.f12.exception.InvalidGitHubLoginException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Component
+public class GitHubOauthClient {
+
+    private final String clientId;
+    private final String secret;
+    private final String accessTokenUrl;
+    private final String profileUrl;
+
+    public GitHubOauthClient(@Value("${github.client.id}") final String clientId,
+                             @Value("${github.client.secret}") final String secret,
+                             @Value("${github.url.accessToken}") final String accessTokenUrl,
+                             @Value("${github.url.user}") final String profileUrl) {
+        this.clientId = clientId;
+        this.secret = secret;
+        this.accessTokenUrl = accessTokenUrl;
+        this.profileUrl = profileUrl;
+    }
+
+    public String getAccessToken(final String code) {
+        final GitHubTokenRequest gitHubTokenRequest = new GitHubTokenRequest(clientId, secret, code);
+        final WebClient webClient = WebClient.builder()
+                .baseUrl(accessTokenUrl)
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .build();
+        return requestAccessToken(gitHubTokenRequest, webClient).getAccessToken();
+    }
+
+    private GitHubTokenResponse requestAccessToken(final GitHubTokenRequest gitHubTokenRequest,
+                                                   final WebClient webClient) {
+        return webClient.post()
+                .body(Mono.just(gitHubTokenRequest), GitHubTokenRequest.class)
+                .retrieve()
+                .onStatus(HttpStatus::is4xxClientError, clientResponse -> {
+                    throw new InvalidGitHubLoginException();
+                })
+                .onStatus(HttpStatus::is5xxServerError, clientResponse -> {
+                    throw new GitHubServerException();
+                })
+                .bodyToMono(GitHubTokenResponse.class)
+                .blockOptional()
+                .orElseThrow(InvalidGitHubLoginException::new);
+    }
+
+    public GitHubProfileResponse getProfile(final String accessToken) {
+        final WebClient webClient = WebClient.builder()
+                .baseUrl(profileUrl)
+                .defaultHeader(HttpHeaders.AUTHORIZATION, "token " + accessToken)
+                .build();
+        return requestProfile(webClient);
+    }
+
+    private GitHubProfileResponse requestProfile(final WebClient webClient) {
+        return webClient.get()
+                .retrieve()
+                .onStatus(HttpStatus::is4xxClientError, clientResponse -> {
+                    throw new InvalidGitHubLoginException();
+                })
+                .onStatus(HttpStatus::is5xxServerError, clientResponse -> {
+                    throw new GitHubServerException();
+                })
+                .bodyToMono(GitHubProfileResponse.class)
+                .blockOptional()
+                .orElseThrow(InvalidGitHubLoginException::new);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/application/JwtProvider.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/JwtProvider.java
@@ -1,0 +1,71 @@
+package com.woowacourse.f12.application;
+
+import com.woowacourse.f12.support.AuthTokenExtractor;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Date;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtProvider {
+
+    private static final String TOKEN_TYPE = "Bearer";
+
+    private final AuthTokenExtractor authTokenExtractor;
+    private final Key secretKey;
+    private final long validityInMilliseconds;
+
+    public JwtProvider(final AuthTokenExtractor authTokenExtractor,
+                       @Value("${security.jwt.secret-key}") final String secretKey,
+                       @Value("${security.jwt.expire-length}") final long validityInMilliseconds) {
+        this.authTokenExtractor = authTokenExtractor;
+        this.secretKey = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
+        this.validityInMilliseconds = validityInMilliseconds;
+    }
+
+    public String createToken(final Long id) {
+        final Date now = new Date();
+        final Date validity = new Date(now.getTime() + validityInMilliseconds);
+
+        return Jwts.builder()
+                .setSubject(id.toString())
+                .setIssuedAt(now)
+                .setExpiration(validity)
+                .signWith(secretKey, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public boolean validateToken(final String authorizationHeader) {
+        final String token = authTokenExtractor.extractToken(authorizationHeader, TOKEN_TYPE);
+        try {
+            final Jws<Claims> claims = getClaimsJws(token);
+            return !claims
+                    .getBody()
+                    .getExpiration()
+                    .before(new Date());
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    private Jws<Claims> getClaimsJws(final String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(token);
+    }
+
+    public String getPayload(final String authorizationHeader) {
+        final String token = authTokenExtractor.extractToken(authorizationHeader, TOKEN_TYPE);
+        return getClaimsJws(token)
+                .getBody()
+                .getSubject();
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/application/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/MemberService.java
@@ -27,10 +27,10 @@ public class MemberService {
     public void updateProfileProducts(final Long memberId, final ProfileProductRequest profileProductRequest) {
         validateMember(memberId);
         if (!Objects.isNull(profileProductRequest.getSelectedInventoryProductId())) {
-            updateProfileProduct(profileProductRequest.getSelectedInventoryProductId());
+            updateProfileProduct(profileProductRequest.getSelectedInventoryProductId(), true);
         }
         if (!Objects.isNull(profileProductRequest.getUnselectedInventoryProductId())) {
-            updateProfileProduct(profileProductRequest.getUnselectedInventoryProductId());
+            updateProfileProduct(profileProductRequest.getUnselectedInventoryProductId(), false);
         }
     }
 
@@ -39,9 +39,9 @@ public class MemberService {
                 .orElseThrow(MemberNotFoundException::new);
     }
 
-    private void updateProfileProduct(final Long inventoryItemId) {
+    private void updateProfileProduct(final Long inventoryItemId, final boolean isSelected) {
         final InventoryProduct inventoryProduct = inventoryProductRepository.findById(inventoryItemId)
                 .orElseThrow(InventoryItemNotFoundException::new);
-        inventoryProduct.updateIsSelected();
+        inventoryProduct.updateIsSelected(isSelected);
     }
 }

--- a/backend/src/main/java/com/woowacourse/f12/application/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/MemberService.java
@@ -1,0 +1,47 @@
+package com.woowacourse.f12.application;
+
+import com.woowacourse.f12.domain.InventoryProduct;
+import com.woowacourse.f12.domain.InventoryProductRepository;
+import com.woowacourse.f12.domain.MemberRepository;
+import com.woowacourse.f12.dto.request.ProfileProductRequest;
+import com.woowacourse.f12.exception.InventoryItemNotFoundException;
+import com.woowacourse.f12.exception.MemberNotFoundException;
+import java.util.Objects;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+    private final InventoryProductRepository inventoryProductRepository;
+
+    public MemberService(final MemberRepository memberRepository,
+                         final InventoryProductRepository inventoryProductRepository) {
+        this.memberRepository = memberRepository;
+        this.inventoryProductRepository = inventoryProductRepository;
+    }
+
+    @Transactional
+    public void updateProfileProducts(final Long memberId, final ProfileProductRequest profileProductRequest) {
+        validateMember(memberId);
+        if (!Objects.isNull(profileProductRequest.getSelectedInventoryProductId())) {
+            updateProfileProduct(profileProductRequest.getSelectedInventoryProductId());
+        }
+        if (!Objects.isNull(profileProductRequest.getUnselectedInventoryProductId())) {
+            updateProfileProduct(profileProductRequest.getUnselectedInventoryProductId());
+        }
+    }
+
+    private void validateMember(final Long memberId) {
+        memberRepository.findById(memberId)
+                .orElseThrow(MemberNotFoundException::new);
+    }
+
+    private void updateProfileProduct(final Long inventoryItemId) {
+        final InventoryProduct inventoryProduct = inventoryProductRepository.findById(inventoryItemId)
+                .orElseThrow(InventoryItemNotFoundException::new);
+        inventoryProduct.updateIsSelected();
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/application/ReviewService.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/ReviewService.java
@@ -2,12 +2,15 @@ package com.woowacourse.f12.application;
 
 import com.woowacourse.f12.domain.Keyboard;
 import com.woowacourse.f12.domain.KeyboardRepository;
+import com.woowacourse.f12.domain.Member;
+import com.woowacourse.f12.domain.MemberRepository;
 import com.woowacourse.f12.domain.Review;
 import com.woowacourse.f12.domain.ReviewRepository;
 import com.woowacourse.f12.dto.request.ReviewRequest;
 import com.woowacourse.f12.dto.response.ReviewPageResponse;
 import com.woowacourse.f12.dto.response.ReviewWithProductPageResponse;
 import com.woowacourse.f12.exception.KeyboardNotFoundException;
+import com.woowacourse.f12.exception.MemberNotFoundException;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -19,16 +22,22 @@ public class ReviewService {
 
     private final ReviewRepository reviewRepository;
     private final KeyboardRepository keyboardRepository;
+    private final MemberRepository memberRepository;
 
-    public ReviewService(final ReviewRepository reviewRepository, final KeyboardRepository keyboardRepository) {
+    public ReviewService(final ReviewRepository reviewRepository, final KeyboardRepository keyboardRepository,
+                         final MemberRepository memberRepository) {
         this.reviewRepository = reviewRepository;
         this.keyboardRepository = keyboardRepository;
+        this.memberRepository = memberRepository;
     }
 
     @Transactional
-    public Long save(final Long productId, final ReviewRequest reviewRequest) {
+    public Long save(final Long productId, final ReviewRequest reviewRequest, final Long memberId) {
         final Keyboard keyboard = keyboardRepository.findById(productId)
                 .orElseThrow(KeyboardNotFoundException::new);
+        final Member member = memberRepository.findById(memberId)
+                .orElseThrow(MemberNotFoundException::new);
+
         final Review review = reviewRequest.toReview(keyboard);
         return reviewRepository.save(review)
                 .getId();

--- a/backend/src/main/java/com/woowacourse/f12/config/WebConfig.java
+++ b/backend/src/main/java/com/woowacourse/f12/config/WebConfig.java
@@ -1,11 +1,12 @@
 package com.woowacourse.f12.config;
 
-import com.woowacourse.f12.presentation.CustomPageableHandlerMethodArgumentResolver;
 import java.util.List;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
@@ -13,11 +14,17 @@ public class WebConfig implements WebMvcConfigurer {
 
     private static final String CORS_ALLOWED_METHODS = "GET,POST,HEAD,PUT,PATCH,DELETE,TRACE,OPTIONS";
 
+    private final List<HandlerInterceptor> interceptors;
+    private final List<HandlerMethodArgumentResolver> resolvers;
+
+    public WebConfig(List<HandlerInterceptor> interceptors, List<HandlerMethodArgumentResolver> resolvers) {
+        this.interceptors = interceptors;
+        this.resolvers = resolvers;
+    }
+
     @Override
-    public void addArgumentResolvers(final List<HandlerMethodArgumentResolver> resolvers) {
-        final CustomPageableHandlerMethodArgumentResolver customPageableHandlerMethodArgumentResolver = new CustomPageableHandlerMethodArgumentResolver();
-        customPageableHandlerMethodArgumentResolver.setMaxPageSize(150);
-        resolvers.add(customPageableHandlerMethodArgumentResolver);
+    public void addInterceptors(final InterceptorRegistry registry) {
+        interceptors.forEach(registry::addInterceptor);
     }
 
     @Override
@@ -25,5 +32,10 @@ public class WebConfig implements WebMvcConfigurer {
         registry.addMapping("/api/**")
                 .allowedMethods(CORS_ALLOWED_METHODS.split(","))
                 .exposedHeaders(HttpHeaders.LOCATION);
+    }
+
+    @Override
+    public void addArgumentResolvers(final List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.addAll(this.resolvers);
     }
 }

--- a/backend/src/main/java/com/woowacourse/f12/domain/InventoryProduct.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/InventoryProduct.java
@@ -33,8 +33,8 @@ public class InventoryProduct {
     protected InventoryProduct() {
     }
 
-    public void updateIsSelected() {
-        this.isSelected = !this.isSelected;
+    public void updateIsSelected(boolean isSelected) {
+        this.isSelected = isSelected;
     }
 
     @Builder

--- a/backend/src/main/java/com/woowacourse/f12/domain/InventoryProduct.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/InventoryProduct.java
@@ -1,0 +1,47 @@
+package com.woowacourse.f12.domain;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import lombok.Builder;
+import lombok.Getter;
+
+@Entity
+@Table(name = "inventroy_product")
+@Getter
+public class InventoryProduct {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "is_selected")
+    private boolean isSelected;
+
+    @Column(name = "member_id")
+    private Long memberId;
+
+    @ManyToOne
+    @JoinColumn(name = "keyboard_id")
+    private Keyboard keyboard;
+
+    protected InventoryProduct() {
+    }
+
+    public void updateIsSelected() {
+        this.isSelected = !this.isSelected;
+    }
+
+    @Builder
+    private InventoryProduct(final Long id, final boolean isSelected, final Long memberId, final Keyboard keyboard) {
+        this.id = id;
+        this.isSelected = isSelected;
+        this.memberId = memberId;
+        this.keyboard = keyboard;
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/domain/InventoryProductRepository.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/InventoryProductRepository.java
@@ -1,0 +1,7 @@
+package com.woowacourse.f12.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface InventoryProductRepository extends JpaRepository<InventoryProduct, Long> {
+
+}

--- a/backend/src/main/java/com/woowacourse/f12/domain/Member.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/Member.java
@@ -25,7 +25,7 @@ public class Member {
     @Column(name = "github_id", nullable = false)
     private String gitHubId;
 
-    @Column(name = "name", nullable = false)
+    @Column(name = "name")
     private String name;
 
     @Column(name = "image_url", nullable = false)

--- a/backend/src/main/java/com/woowacourse/f12/domain/Member.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/Member.java
@@ -1,0 +1,65 @@
+package com.woowacourse.f12.domain;
+
+import java.util.Objects;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Table(name = "member")
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "github_id", nullable = false)
+    private String gitHubId;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "image_url", nullable = false)
+    private String imageUrl;
+
+    protected Member() {
+    }
+
+    @Builder
+    private Member(final Long id, final String gitHubId, final String name, final String imageUrl) {
+        this.id = id;
+        this.gitHubId = gitHubId;
+        this.name = name;
+        this.imageUrl = imageUrl;
+    }
+
+    public void updateName(final String name) {
+        this.name = name;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final Member member = (Member) o;
+        return Objects.equals(id, member.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/domain/MemberRepository.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/MemberRepository.java
@@ -1,0 +1,9 @@
+package com.woowacourse.f12.domain;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findByGitHubId(String gitHubId);
+}

--- a/backend/src/main/java/com/woowacourse/f12/dto/request/GitHubTokenRequest.java
+++ b/backend/src/main/java/com/woowacourse/f12/dto/request/GitHubTokenRequest.java
@@ -1,0 +1,24 @@
+package com.woowacourse.f12.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class GitHubTokenRequest {
+
+    @JsonProperty("client_id")
+    private String clientId;
+
+    @JsonProperty("client_secret")
+    private String clientSecret;
+    private String code;
+
+    private GitHubTokenRequest() {
+    }
+
+    public GitHubTokenRequest(final String clientId, final String clientSecret, final String code) {
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+        this.code = code;
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/dto/request/ProfileProductRequest.java
+++ b/backend/src/main/java/com/woowacourse/f12/dto/request/ProfileProductRequest.java
@@ -1,0 +1,18 @@
+package com.woowacourse.f12.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class ProfileProductRequest {
+
+    private Long selectedInventoryProductId;
+    private Long unselectedInventoryProductId;
+
+    private ProfileProductRequest() {
+    }
+
+    public ProfileProductRequest(final Long selectedInventoryProductId, final Long unselectedInventoryProductId) {
+        this.selectedInventoryProductId = selectedInventoryProductId;
+        this.unselectedInventoryProductId = unselectedInventoryProductId;
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/dto/response/GitHubProfileResponse.java
+++ b/backend/src/main/java/com/woowacourse/f12/dto/response/GitHubProfileResponse.java
@@ -1,0 +1,35 @@
+package com.woowacourse.f12.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.woowacourse.f12.domain.Member;
+import lombok.Getter;
+
+@Getter
+public class GitHubProfileResponse {
+
+    @JsonProperty("login")
+    private String gitHubId;
+
+    @JsonProperty("name")
+    private String name;
+
+    @JsonProperty("avatar_url")
+    private String imageUrl;
+
+    private GitHubProfileResponse() {
+    }
+
+    public GitHubProfileResponse(final String gitHubId, final String name, final String imageUrl) {
+        this.gitHubId = gitHubId;
+        this.name = name;
+        this.imageUrl = imageUrl;
+    }
+
+    public Member toMember() {
+        return Member.builder()
+                .gitHubId(this.gitHubId)
+                .name(this.name)
+                .imageUrl(this.imageUrl)
+                .build();
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/dto/response/GitHubTokenResponse.java
+++ b/backend/src/main/java/com/woowacourse/f12/dto/response/GitHubTokenResponse.java
@@ -1,0 +1,18 @@
+package com.woowacourse.f12.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class GitHubTokenResponse {
+
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    private GitHubTokenResponse() {
+    }
+
+    public GitHubTokenResponse(final String accessToken) {
+        this.accessToken = accessToken;
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/dto/response/LoginResponse.java
+++ b/backend/src/main/java/com/woowacourse/f12/dto/response/LoginResponse.java
@@ -1,0 +1,24 @@
+package com.woowacourse.f12.dto.response;
+
+import com.woowacourse.f12.domain.Member;
+import lombok.Getter;
+
+@Getter
+public class LoginResponse {
+
+    private String token;
+    private MemberResponse member;
+
+    private LoginResponse() {
+    }
+
+    private LoginResponse(final String token, final MemberResponse member) {
+        this.token = token;
+        this.member = member;
+    }
+
+    public static LoginResponse of(final String token, final Member member) {
+        final MemberResponse memberResponse = MemberResponse.from(member);
+        return new LoginResponse(token, memberResponse);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/dto/response/MemberResponse.java
+++ b/backend/src/main/java/com/woowacourse/f12/dto/response/MemberResponse.java
@@ -1,0 +1,27 @@
+package com.woowacourse.f12.dto.response;
+
+import com.woowacourse.f12.domain.Member;
+import lombok.Getter;
+
+@Getter
+public class MemberResponse {
+
+    private Long id;
+    private String gitHubId;
+    private String name;
+    private String imageUrl;
+
+    private MemberResponse() {
+    }
+
+    private MemberResponse(final Long id, final String gitHubId, final String name, final String imageUrl) {
+        this.id = id;
+        this.gitHubId = gitHubId;
+        this.name = name;
+        this.imageUrl = imageUrl;
+    }
+
+    public static MemberResponse from(final Member member) {
+        return new MemberResponse(member.getId(), member.getGitHubId(), member.getName(), member.getImageUrl());
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/exception/ExternalServerException.java
+++ b/backend/src/main/java/com/woowacourse/f12/exception/ExternalServerException.java
@@ -1,0 +1,8 @@
+package com.woowacourse.f12.exception;
+
+public class ExternalServerException extends RuntimeException {
+
+    public ExternalServerException(final String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/exception/GitHubServerException.java
+++ b/backend/src/main/java/com/woowacourse/f12/exception/GitHubServerException.java
@@ -1,0 +1,8 @@
+package com.woowacourse.f12.exception;
+
+public class GitHubServerException extends ExternalServerException {
+
+    public GitHubServerException() {
+        super("GitHub 서버에 문제가 있습니다.");
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/exception/InvalidGitHubLoginException.java
+++ b/backend/src/main/java/com/woowacourse/f12/exception/InvalidGitHubLoginException.java
@@ -1,0 +1,8 @@
+package com.woowacourse.f12.exception;
+
+public class InvalidGitHubLoginException extends InvalidValueException {
+
+    public InvalidGitHubLoginException() {
+        super("잘못된 GitHub 로그인 요청입니다.");
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/exception/InventoryItemNotFoundException.java
+++ b/backend/src/main/java/com/woowacourse/f12/exception/InventoryItemNotFoundException.java
@@ -1,0 +1,8 @@
+package com.woowacourse.f12.exception;
+
+public class InventoryItemNotFoundException extends NotFoundException {
+
+    public InventoryItemNotFoundException() {
+        super("등록 장비를 찾을 수 없습니다.");
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/exception/MemberNotFoundException.java
+++ b/backend/src/main/java/com/woowacourse/f12/exception/MemberNotFoundException.java
@@ -1,0 +1,8 @@
+package com.woowacourse.f12.exception;
+
+public class MemberNotFoundException extends NotFoundException {
+
+    public MemberNotFoundException() {
+        super("회원을 찾을 수 없습니다.");
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/exception/UnauthorizedException.java
+++ b/backend/src/main/java/com/woowacourse/f12/exception/UnauthorizedException.java
@@ -1,0 +1,8 @@
+package com.woowacourse.f12.exception;
+
+public class UnauthorizedException extends RuntimeException {
+
+    public UnauthorizedException() {
+        super("로그인이 필요합니다.");
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/presentation/AuthArgumentResolver.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/AuthArgumentResolver.java
@@ -1,0 +1,38 @@
+package com.woowacourse.f12.presentation;
+
+import com.woowacourse.f12.application.JwtProvider;
+import com.woowacourse.f12.exception.UnauthorizedException;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class AuthArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final JwtProvider jwtProvider;
+
+    public AuthArgumentResolver(final JwtProvider jwtProvider) {
+        this.jwtProvider = jwtProvider;
+    }
+
+    @Override
+    public boolean supportsParameter(final MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(VerifiedMember.class);
+    }
+
+    @Override
+    public Object resolveArgument(final MethodParameter parameter, final ModelAndViewContainer mavContainer,
+                                  final NativeWebRequest webRequest, final WebDataBinderFactory binderFactory) {
+        final String authorizationHeader = webRequest.getHeader(HttpHeaders.AUTHORIZATION);
+        final String payload = jwtProvider.getPayload(authorizationHeader);
+        try {
+            return Long.parseLong(payload);
+        } catch (NumberFormatException e) {
+            throw new UnauthorizedException();
+        }
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/presentation/AuthController.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/AuthController.java
@@ -1,0 +1,25 @@
+package com.woowacourse.f12.presentation;
+
+import com.woowacourse.f12.application.AuthService;
+import com.woowacourse.f12.dto.response.LoginResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1")
+public class AuthController {
+
+    private final AuthService authService;
+
+    public AuthController(final AuthService authService) {
+        this.authService = authService;
+    }
+
+    @GetMapping("/login")
+    public ResponseEntity<LoginResponse> login(@RequestParam final String code) {
+        return ResponseEntity.ok().body(authService.login(code));
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/presentation/AuthInterceptor.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/AuthInterceptor.java
@@ -1,0 +1,46 @@
+package com.woowacourse.f12.presentation;
+
+import com.woowacourse.f12.application.JwtProvider;
+import com.woowacourse.f12.exception.UnauthorizedException;
+import java.util.Objects;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+public class AuthInterceptor implements HandlerInterceptor {
+
+    private final JwtProvider jwtProvider;
+
+    public AuthInterceptor(final JwtProvider jwtProvider) {
+        this.jwtProvider = jwtProvider;
+    }
+
+    @Override
+    public boolean preHandle(final HttpServletRequest request, final HttpServletResponse response, final Object handler) {
+        if (isNotTarget(handler)) {
+            return true;
+        }
+        validateAuthorization(request);
+        return true;
+    }
+
+    private boolean isNotTarget(final Object handler) {
+        if (!(handler instanceof HandlerMethod)) {
+            return true;
+        }
+        HandlerMethod handlerMethod = (HandlerMethod) handler;
+        LoginRequired auth = handlerMethod.getMethodAnnotation(LoginRequired.class);
+        return Objects.isNull(auth);
+    }
+
+    private void validateAuthorization(final HttpServletRequest request) {
+        final String authorizationHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (!jwtProvider.validateToken(authorizationHeader)) {
+            throw new UnauthorizedException();
+        }
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/presentation/CustomPageableArgumentResolver.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/CustomPageableArgumentResolver.java
@@ -9,11 +9,13 @@ import java.util.regex.Pattern;
 import org.springframework.core.MethodParameter;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
-public class CustomPageableHandlerMethodArgumentResolver extends PageableHandlerMethodArgumentResolver {
+@Component
+public class CustomPageableArgumentResolver extends PageableHandlerMethodArgumentResolver {
 
     private static final int MAX_SIZE = 150;
     private static final Pattern NUMBER_PATTERN = Pattern.compile("^[0-9]*$");

--- a/backend/src/main/java/com/woowacourse/f12/presentation/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.woowacourse.f12.presentation;
 import com.woowacourse.f12.dto.response.ExceptionResponse;
 import com.woowacourse.f12.exception.InvalidValueException;
 import com.woowacourse.f12.exception.NotFoundException;
+import com.woowacourse.f12.exception.UnauthorizedException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -40,6 +41,11 @@ public class GlobalExceptionHandler {
         exception.getBindingResult().getAllErrors().forEach((error) -> stringBuilder.append(error.getDefaultMessage())
                 .append(System.lineSeparator()));
         return ResponseEntity.badRequest().body(ExceptionResponse.from(stringBuilder.toString()));
+    }
+
+    @ExceptionHandler(UnauthorizedException.class)
+    public ResponseEntity<ExceptionResponse> handleUnAuthorizedException(final UnauthorizedException e) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ExceptionResponse.from(e));
     }
 
     @ExceptionHandler(Exception.class)

--- a/backend/src/main/java/com/woowacourse/f12/presentation/LoginRequired.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/LoginRequired.java
@@ -1,0 +1,11 @@
+package com.woowacourse.f12.presentation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LoginRequired {
+}

--- a/backend/src/main/java/com/woowacourse/f12/presentation/MemberController.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/MemberController.java
@@ -1,0 +1,28 @@
+package com.woowacourse.f12.presentation;
+
+import com.woowacourse.f12.application.MemberService;
+import com.woowacourse.f12.dto.request.ProfileProductRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/members")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    public MemberController(final MemberService memberService) {
+        this.memberService = memberService;
+    }
+
+    @PatchMapping("/inventoryProducts")
+    @LoginRequired
+    public ResponseEntity<Void> updateProfileProducts(@RequestBody final ProfileProductRequest profileProductRequest,
+                                                      @VerifiedMember final Long memberId) {
+        memberService.updateProfileProducts(memberId, profileProductRequest);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/presentation/ReviewController.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/ReviewController.java
@@ -26,9 +26,11 @@ public class ReviewController {
     }
 
     @PostMapping("/keyboards/{productId}/reviews")
+    @LoginRequired
     public ResponseEntity<Void> create(@PathVariable final Long productId,
-                                       @Valid @RequestBody final ReviewRequest reviewRequest) {
-        final Long id = reviewService.save(productId, reviewRequest);
+                                       @Valid @RequestBody final ReviewRequest reviewRequest,
+                                       @VerifiedMember final Long memberId) {
+        final Long id = reviewService.save(productId, reviewRequest, memberId);
         return ResponseEntity.created(URI.create("/api/v1/reviews/" + id))
                 .build();
     }

--- a/backend/src/main/java/com/woowacourse/f12/presentation/VerifiedMember.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/VerifiedMember.java
@@ -1,0 +1,11 @@
+package com.woowacourse.f12.presentation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface VerifiedMember {
+}

--- a/backend/src/main/java/com/woowacourse/f12/support/AuthTokenExtractor.java
+++ b/backend/src/main/java/com/woowacourse/f12/support/AuthTokenExtractor.java
@@ -1,0 +1,20 @@
+package com.woowacourse.f12.support;
+
+import com.woowacourse.f12.exception.UnauthorizedException;
+import java.util.Objects;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AuthTokenExtractor {
+
+    public String extractToken(final String authorizationHeader, final String tokenType) {
+        if (Objects.isNull(authorizationHeader)) {
+            throw new UnauthorizedException();
+        }
+        final String[] splitHeaders = authorizationHeader.split(" ");
+        if (splitHeaders.length != 2 || !splitHeaders[0].equalsIgnoreCase(tokenType)) {
+            throw new UnauthorizedException();
+        }
+        return splitHeaders[1];
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,4 +1,6 @@
 spring:
+  profiles:
+    include: auth
   datasource:
     url: jdbc:h2:~/test;MODE=MySQL;
     username: sa

--- a/backend/src/test/java/com/woowacourse/f12/acceptance/AcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/acceptance/AcceptanceTest.java
@@ -8,7 +8,7 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
 
-@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@SpringBootTest(webEnvironment = WebEnvironment.DEFINED_PORT)
 @DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
 public class AcceptanceTest {
 

--- a/backend/src/test/java/com/woowacourse/f12/acceptance/AuthAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/acceptance/AuthAcceptanceTest.java
@@ -1,0 +1,26 @@
+package com.woowacourse.f12.acceptance;
+
+import static com.woowacourse.f12.acceptance.support.RestAssuredRequestUtil.GET_요청을_보낸다;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.woowacourse.f12.dto.response.LoginResponse;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+class AuthAcceptanceTest extends AcceptanceTest {
+
+    @Test
+    void 로그인_요청이_들어오고_OAUTH_인증에_성공하면_토큰과_회원정보를_반환한다() {
+        // given, when
+        ExtractableResponse<Response> response = GET_요청을_보낸다("/api/v1/login?code=dkasjbdkjas");
+
+        // then
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(response.as(LoginResponse.class)).isNotNull()
+        );
+    }
+}

--- a/backend/src/test/java/com/woowacourse/f12/acceptance/KeyboardAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/acceptance/KeyboardAcceptanceTest.java
@@ -14,6 +14,7 @@ import com.woowacourse.f12.domain.Keyboard;
 import com.woowacourse.f12.domain.KeyboardRepository;
 import com.woowacourse.f12.dto.response.KeyboardPageResponse;
 import com.woowacourse.f12.dto.response.KeyboardResponse;
+import com.woowacourse.f12.dto.response.LoginResponse;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.Test;
@@ -65,9 +66,12 @@ class KeyboardAcceptanceTest extends AcceptanceTest {
         // given
         Keyboard keyboard1 = 키보드를_저장한다(KEYBOARD_1.생성());
         Keyboard keyboard2 = 키보드를_저장한다(KEYBOARD_2.생성());
-        REVIEW_RATING_5.작성_요청을_보낸다(keyboard1.getId());
-        REVIEW_RATING_4.작성_요청을_보낸다(keyboard1.getId());
-        REVIEW_RATING_3.작성_요청을_보낸다(keyboard2.getId());
+        String token = GET_요청을_보낸다("/api/v1/login?code=dkasjbdkjas")
+                .as(LoginResponse.class)
+                .getToken();
+        REVIEW_RATING_5.작성_요청을_보낸다(keyboard1.getId(), token);
+        REVIEW_RATING_4.작성_요청을_보낸다(keyboard1.getId(), token);
+        REVIEW_RATING_3.작성_요청을_보낸다(keyboard2.getId(), token);
 
         // when
         ExtractableResponse<Response> response = GET_요청을_보낸다("/api/v1/keyboards?page=0&size=1&sort=reviewCount,desc");
@@ -87,9 +91,12 @@ class KeyboardAcceptanceTest extends AcceptanceTest {
         // given
         Keyboard keyboard1 = 키보드를_저장한다(KEYBOARD_1.생성());
         Keyboard keyboard2 = 키보드를_저장한다(KEYBOARD_2.생성());
-        REVIEW_RATING_5.작성_요청을_보낸다(keyboard1.getId());
-        REVIEW_RATING_1.작성_요청을_보낸다(keyboard1.getId());
-        REVIEW_RATING_4.작성_요청을_보낸다(keyboard2.getId());
+        String token = GET_요청을_보낸다("/api/v1/login?code=dkasjbdkjas")
+                .as(LoginResponse.class)
+                .getToken();
+        REVIEW_RATING_5.작성_요청을_보낸다(keyboard1.getId(), token);
+        REVIEW_RATING_1.작성_요청을_보낸다(keyboard1.getId(), token);
+        REVIEW_RATING_4.작성_요청을_보낸다(keyboard2.getId(), token);
 
         // when
         ExtractableResponse<Response> response = GET_요청을_보낸다("/api/v1/keyboards?page=0&size=1&sort=rating,desc");

--- a/backend/src/test/java/com/woowacourse/f12/acceptance/MemberAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/acceptance/MemberAcceptanceTest.java
@@ -1,0 +1,54 @@
+package com.woowacourse.f12.acceptance;
+
+import static com.woowacourse.f12.acceptance.support.RestAssuredRequestUtil.GET_요청을_보낸다;
+import static com.woowacourse.f12.acceptance.support.RestAssuredRequestUtil.로그인된_상태로_PATCH_요청을_보낸다;
+import static com.woowacourse.f12.support.KeyboardFixtures.KEYBOARD_1;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.woowacourse.f12.domain.InventoryProduct;
+import com.woowacourse.f12.domain.InventoryProductRepository;
+import com.woowacourse.f12.domain.Keyboard;
+import com.woowacourse.f12.domain.KeyboardRepository;
+import com.woowacourse.f12.dto.request.ProfileProductRequest;
+import com.woowacourse.f12.dto.response.LoginResponse;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+
+public class MemberAcceptanceTest extends AcceptanceTest {
+
+    @Autowired
+    private KeyboardRepository keyboardRepository;
+
+    @Autowired
+    private InventoryProductRepository inventoryProductRepository;
+
+    @Test
+    void 대표_장비가_없는_상태에서_대표_장비를_등록한다() {
+        // given
+        Keyboard keyboard = 키보드를_저장한다(KEYBOARD_1.생성());
+        ExtractableResponse<Response> response = GET_요청을_보낸다("/api/v1/login?code=dkasjbdkjas");
+        String token = response.as(LoginResponse.class).getToken();
+        Long memberId = response.as(LoginResponse.class).getMember().getId();
+
+        InventoryProduct inventoryProduct = InventoryProduct.builder()
+                .memberId(memberId)
+                .keyboard(keyboard)
+                .build();
+        InventoryProduct savedInventoryProduct = inventoryProductRepository.save(inventoryProduct);
+
+        // when
+        ExtractableResponse<Response> saveProfileProductResponse = 로그인된_상태로_PATCH_요청을_보낸다(
+                "api/v1/members/inventoryProducts", token,
+                new ProfileProductRequest(savedInventoryProduct.getId(), null));
+
+        // then
+        assertThat(saveProfileProductResponse.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
+
+    private Keyboard 키보드를_저장한다(Keyboard keyboard) {
+        return keyboardRepository.save(keyboard);
+    }
+}

--- a/backend/src/test/java/com/woowacourse/f12/acceptance/ReviewAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/acceptance/ReviewAcceptanceTest.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.woowacourse.f12.domain.Keyboard;
 import com.woowacourse.f12.domain.KeyboardRepository;
+import com.woowacourse.f12.dto.response.LoginResponse;
 import com.woowacourse.f12.dto.response.ReviewPageResponse;
 import com.woowacourse.f12.dto.response.ReviewWithProductPageResponse;
 import io.restassured.response.ExtractableResponse;
@@ -27,9 +28,12 @@ public class ReviewAcceptanceTest extends AcceptanceTest {
     void 키보드가_저장되어있고_키보드에_대한_리뷰를_작성한다() {
         // given
         Keyboard keyboard = 키보드를_저장한다(KEYBOARD_1.생성());
+        String token = GET_요청을_보낸다("/api/v1/login?code=dkasjbdkjas")
+                .as(LoginResponse.class)
+                .getToken();
 
         // when
-        ExtractableResponse<Response> response = REVIEW_RATING_5.작성_요청을_보낸다(keyboard.getId());
+        ExtractableResponse<Response> response = REVIEW_RATING_5.작성_요청을_보낸다(keyboard.getId(), token);
 
         // then
         assertAll(
@@ -42,8 +46,11 @@ public class ReviewAcceptanceTest extends AcceptanceTest {
     void 특정_제품_리뷰_목록을_최신순으로_조회한다() {
         // given
         Keyboard keyboard = 키보드를_저장한다(KEYBOARD_1.생성());
-        REVIEW_RATING_5.작성_요청을_보낸다(keyboard.getId());
-        Long reviewId = Location_헤더에서_id값을_꺼낸다(REVIEW_RATING_5.작성_요청을_보낸다(keyboard.getId()));
+        String token = GET_요청을_보낸다("/api/v1/login?code=dkasjbdkjas")
+                .as(LoginResponse.class)
+                .getToken();
+        REVIEW_RATING_5.작성_요청을_보낸다(keyboard.getId(), token);
+        Long reviewId = Location_헤더에서_id값을_꺼낸다(REVIEW_RATING_5.작성_요청을_보낸다(keyboard.getId(), token));
 
         // when
         String url = "/api/v1/keyboards/" + keyboard.getId() + "/reviews?size=1&page=0&sort=createdAt,desc";
@@ -64,8 +71,11 @@ public class ReviewAcceptanceTest extends AcceptanceTest {
     void 특정_제품_리뷰_목록을_평점순으로_조회한다() {
         // given
         Keyboard keyboard = 키보드를_저장한다(KEYBOARD_1.생성());
-        REVIEW_RATING_4.작성_요청을_보낸다(keyboard.getId());
-        Long reviewId = Location_헤더에서_id값을_꺼낸다(REVIEW_RATING_5.작성_요청을_보낸다(keyboard.getId()));
+        String token = GET_요청을_보낸다("/api/v1/login?code=dkasjbdkjas")
+                .as(LoginResponse.class)
+                .getToken();
+        REVIEW_RATING_4.작성_요청을_보낸다(keyboard.getId(), token);
+        Long reviewId = Location_헤더에서_id값을_꺼낸다(REVIEW_RATING_5.작성_요청을_보낸다(keyboard.getId(), token));
 
         // when
         String url = "/api/v1/keyboards/" + keyboard.getId() + "/reviews?size=1&page=0&sort=rating,desc";
@@ -87,8 +97,11 @@ public class ReviewAcceptanceTest extends AcceptanceTest {
         // given
         Keyboard keyboard1 = 키보드를_저장한다(KEYBOARD_1.생성());
         Keyboard keyboard2 = 키보드를_저장한다(KEYBOARD_2.생성());
-        Long reviewId1 = Location_헤더에서_id값을_꺼낸다(REVIEW_RATING_4.작성_요청을_보낸다(keyboard1.getId()));
-        Long reviewId2 = Location_헤더에서_id값을_꺼낸다(REVIEW_RATING_4.작성_요청을_보낸다(keyboard2.getId()));
+        String token = GET_요청을_보낸다("/api/v1/login?code=dkasjbdkjas")
+                .as(LoginResponse.class)
+                .getToken();
+        Long reviewId1 = Location_헤더에서_id값을_꺼낸다(REVIEW_RATING_4.작성_요청을_보낸다(keyboard1.getId(), token));
+        Long reviewId2 = Location_헤더에서_id값을_꺼낸다(REVIEW_RATING_4.작성_요청을_보낸다(keyboard2.getId(), token));
 
         // when
         ExtractableResponse<Response> response = GET_요청을_보낸다(

--- a/backend/src/test/java/com/woowacourse/f12/acceptance/support/RestAssuredRequestUtil.java
+++ b/backend/src/test/java/com/woowacourse/f12/acceptance/support/RestAssuredRequestUtil.java
@@ -3,6 +3,7 @@ package com.woowacourse.f12.acceptance.support;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 
 public class RestAssuredRequestUtil {
@@ -18,8 +19,10 @@ public class RestAssuredRequestUtil {
                 .extract();
     }
 
-    public static ExtractableResponse<Response> POST_요청을_보낸다(final String url, final Object requestBody) {
+    public static ExtractableResponse<Response> 로그인된_상태로_POST_요청을_보낸다(final String url, final String token,
+                                                                      final Object requestBody) {
         return RestAssured.given().log().all()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .body(requestBody)
                 .when()

--- a/backend/src/test/java/com/woowacourse/f12/acceptance/support/RestAssuredRequestUtil.java
+++ b/backend/src/test/java/com/woowacourse/f12/acceptance/support/RestAssuredRequestUtil.java
@@ -30,4 +30,16 @@ public class RestAssuredRequestUtil {
                 .then().log().all()
                 .extract();
     }
+
+    public static ExtractableResponse<Response> 로그인된_상태로_PATCH_요청을_보낸다(final String url, final String token,
+                                                                       final Object requestBody) {
+        return RestAssured.given().log().all()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(requestBody)
+                .when()
+                .patch(url)
+                .then().log().all()
+                .extract();
+    }
 }

--- a/backend/src/test/java/com/woowacourse/f12/application/AuthServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/application/AuthServiceTest.java
@@ -1,0 +1,103 @@
+package com.woowacourse.f12.application;
+
+import static com.woowacourse.f12.support.MemberFixtures.CORINNE;
+import static com.woowacourse.f12.support.MemberFixtures.CORINNE_UPDATED;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.woowacourse.f12.domain.Member;
+import com.woowacourse.f12.domain.MemberRepository;
+import com.woowacourse.f12.dto.response.GitHubProfileResponse;
+import com.woowacourse.f12.dto.response.LoginResponse;
+import com.woowacourse.f12.dto.response.MemberResponse;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @InjectMocks
+    private AuthService authService;
+
+    @Mock
+    private GitHubOauthClient gitHubOauthClient;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private JwtProvider jwtProvider;
+
+    @Test
+    void 깃허브_코드가_들어왔을때_회원정보가_없으면_새로_저장하고_회원정보와_토큰을_반환한다() {
+        // given
+        String code = "abcde";
+        String accessToken = "accessToken";
+        String applicationToken = "applicationToken";
+        GitHubProfileResponse gitHubProfile = CORINNE.깃허브_프로필();
+        Member member = CORINNE.생성(1L);
+        given(gitHubOauthClient.getAccessToken(code))
+                .willReturn(accessToken);
+        given(gitHubOauthClient.getProfile(accessToken))
+                .willReturn(gitHubProfile);
+        given(memberRepository.findByGitHubId(gitHubProfile.getGitHubId()))
+                .willReturn(Optional.empty());
+        given(memberRepository.save(gitHubProfile.toMember()))
+                .willReturn(member);
+        given(jwtProvider.createToken(member.getId()))
+                .willReturn(applicationToken);
+
+        // when
+        LoginResponse loginResponse = authService.login(code);
+
+        // then
+        assertAll(
+                () -> assertThat(loginResponse.getToken()).isEqualTo(applicationToken),
+                () -> assertThat(loginResponse.getMember()).usingRecursiveComparison()
+                        .isEqualTo(MemberResponse.from(member)),
+                () -> verify(gitHubOauthClient).getAccessToken(code),
+                () -> verify(gitHubOauthClient).getProfile(accessToken),
+                () -> verify(memberRepository).findByGitHubId(gitHubProfile.getGitHubId()),
+                () -> verify(memberRepository).save(gitHubProfile.toMember()),
+                () -> verify(jwtProvider).createToken(1L)
+        );
+    }
+
+    @Test
+    void 깃허브_코드가_들어왔을때_회원정보가_있으면_이름을_업데이트하고_회원정보와_토큰을_반환한다() {
+        // given
+        String code = "abcde";
+        String accessToken = "accessToken";
+        String applicationToken = "applicationToken";
+        GitHubProfileResponse gitHubProfile = CORINNE_UPDATED.깃허브_프로필();
+        Member member = CORINNE.생성(1L);
+        given(gitHubOauthClient.getAccessToken(code))
+                .willReturn(accessToken);
+        given(gitHubOauthClient.getProfile(accessToken))
+                .willReturn(gitHubProfile);
+        given(memberRepository.findByGitHubId(gitHubProfile.getGitHubId()))
+                .willReturn(Optional.of(member));
+        given(jwtProvider.createToken(member.getId()))
+                .willReturn(applicationToken);
+
+        // when
+        LoginResponse loginResponse = authService.login(code);
+
+        // then
+        assertAll(
+                () -> assertThat(loginResponse.getToken()).isEqualTo(applicationToken),
+                () -> assertThat(loginResponse.getMember()).usingRecursiveComparison()
+                        .isEqualTo(MemberResponse.from(member)),
+                () -> verify(gitHubOauthClient).getAccessToken(code),
+                () -> verify(gitHubOauthClient).getProfile(accessToken),
+                () -> verify(memberRepository).findByGitHubId(gitHubProfile.getGitHubId()),
+                () -> verify(jwtProvider).createToken(1L)
+        );
+    }
+}

--- a/backend/src/test/java/com/woowacourse/f12/application/GitHubOauthClientTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/application/GitHubOauthClientTest.java
@@ -1,0 +1,39 @@
+package com.woowacourse.f12.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.woowacourse.f12.dto.response.GitHubProfileResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+
+@SpringBootTest(webEnvironment = WebEnvironment.DEFINED_PORT)
+class GitHubOauthClientTest {
+
+    @Autowired
+    private GitHubOauthClient gitHubOauthClient;
+
+    @Test
+    void GitHub에_accessToken을_요청한다() {
+        // given, when
+        String accessToken = gitHubOauthClient.getAccessToken("code");
+
+        // then
+        assertThat(accessToken).isEqualTo("accessToken");
+    }
+
+    @Test
+    void GitHub에_프로필을_요청한다() {
+        // given
+        String accessToken = "accessToken";
+        GitHubProfileResponse expected = new GitHubProfileResponse("gitHubId", "name", "url");
+
+        // when
+        GitHubProfileResponse gitHubProfileResponse = gitHubOauthClient.getProfile(accessToken);
+
+        // then
+        assertThat(gitHubProfileResponse).usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+}

--- a/backend/src/test/java/com/woowacourse/f12/application/JwtProviderTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/application/JwtProviderTest.java
@@ -1,0 +1,83 @@
+package com.woowacourse.f12.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.woowacourse.f12.support.AuthTokenExtractor;
+import org.junit.jupiter.api.Test;
+
+class JwtProviderTest {
+
+    private final JwtProvider jwtProvider = new JwtProvider(new AuthTokenExtractor(),
+            "testadsddersrsfsddsasdfaefasfkk2313123113trssttrs",
+            3600000);
+
+    @Test
+    void 토큰을_생성한다() {
+        // given
+        Long memberId = 1L;
+
+        // when
+        String token = jwtProvider.createToken(memberId);
+
+        // then
+        assertThat(token).isNotNull();
+    }
+
+    @Test
+    void 토큰이_유효한_경우() {
+        // given
+        String token = jwtProvider.createToken(1L);
+        String authorizationHeader = "Bearer " + token;
+
+        // when, then
+        assertThat(jwtProvider.validateToken(authorizationHeader)).isTrue();
+    }
+
+    @Test
+    void 토큰의_유효기간이_지난_경우() {
+        // given
+        JwtProvider jwtProvider = new JwtProvider(new AuthTokenExtractor(),
+                "testadsddersrsfsddsasdfaefasfkk2313123113trssttrs",
+                0);
+        String token = jwtProvider.createToken(1L);
+        String authorizationHeader = "Bearer " + token;
+
+        // when, then
+        assertThat(jwtProvider.validateToken(authorizationHeader)).isFalse();
+    }
+
+    @Test
+    void 토큰의_형식이_틀린_경우() {
+        // given
+        String authorizationHeader = "Bearer invalidToken";
+
+        // when, then
+        assertThat(jwtProvider.validateToken(authorizationHeader)).isFalse();
+    }
+
+    @Test
+    void 토큰의_시크릿_키가_틀린_경우() {
+        // given
+        JwtProvider invalidJwtProvider = new JwtProvider(new AuthTokenExtractor(),
+                "invalidlasndflkslflkasnf12sdfasdfasdfa",
+                10000000);
+        String token = invalidJwtProvider.createToken(1L);
+        String authorizationHeader = "Bearer " + token;
+
+        // when, then
+        assertThat(jwtProvider.validateToken(authorizationHeader)).isFalse();
+    }
+
+    @Test
+    void 토큰의_payload를_복호화한다() {
+        // given
+        String token = jwtProvider.createToken(1L);
+        String authorizationHeader = "Bearer " + token;
+
+        // when
+        String payload = jwtProvider.getPayload(authorizationHeader);
+
+        // then
+        assertThat(payload).isEqualTo("1");
+    }
+}

--- a/backend/src/test/java/com/woowacourse/f12/application/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/application/MemberServiceTest.java
@@ -1,0 +1,66 @@
+package com.woowacourse.f12.application;
+
+import static com.woowacourse.f12.support.KeyboardFixtures.KEYBOARD_1;
+import static com.woowacourse.f12.support.KeyboardFixtures.KEYBOARD_2;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.verify;
+
+import com.woowacourse.f12.domain.InventoryProduct;
+import com.woowacourse.f12.domain.InventoryProductRepository;
+import com.woowacourse.f12.domain.MemberRepository;
+import com.woowacourse.f12.dto.request.ProfileProductRequest;
+import com.woowacourse.f12.support.MemberFixtures;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MemberServiceTest {
+
+    @Mock
+    private InventoryProductRepository inventoryProductRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @InjectMocks
+    private MemberService memberService;
+
+    @Test
+    void 대표_장비를_등록한다() {
+        // given
+        ProfileProductRequest profileProductRequest = new ProfileProductRequest(1L, 2L);
+        InventoryProduct selectInventoryProduct = InventoryProduct.builder()
+                .id(1L)
+                .memberId(1L)
+                .keyboard(KEYBOARD_1.생성())
+                .isSelected(false)
+                .build();
+        InventoryProduct unselectInventoryProduct = InventoryProduct.builder()
+                .id(2L)
+                .memberId(1L)
+                .keyboard(KEYBOARD_2.생성())
+                .isSelected(true)
+                .build();
+        given(memberRepository.findById(1L))
+                .willReturn(Optional.of(MemberFixtures.CORINNE.생성(1L)));
+        given(inventoryProductRepository.findById(1L))
+                .willReturn(Optional.of(selectInventoryProduct));
+        given(inventoryProductRepository.findById(2L))
+                .willReturn(Optional.of(unselectInventoryProduct));
+
+        // when
+        memberService.updateProfileProducts(1L, profileProductRequest);
+
+        // then
+        assertAll(
+                () -> verify(memberRepository).findById(1L),
+                () -> verify(inventoryProductRepository).findById(1L),
+                () -> verify(inventoryProductRepository).findById(2L)
+        );
+    }
+}

--- a/backend/src/test/java/com/woowacourse/f12/application/ReviewServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/application/ReviewServiceTest.java
@@ -2,6 +2,7 @@ package com.woowacourse.f12.application;
 
 import static com.woowacourse.f12.support.KeyboardFixtures.KEYBOARD_1;
 import static com.woowacourse.f12.support.KeyboardFixtures.KEYBOARD_2;
+import static com.woowacourse.f12.support.MemberFixtures.CORINNE;
 import static com.woowacourse.f12.support.ReviewFixtures.REVIEW_RATING_5;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -13,6 +14,7 @@ import static org.mockito.Mockito.verify;
 
 import com.woowacourse.f12.domain.Keyboard;
 import com.woowacourse.f12.domain.KeyboardRepository;
+import com.woowacourse.f12.domain.MemberRepository;
 import com.woowacourse.f12.domain.Review;
 import com.woowacourse.f12.domain.ReviewRepository;
 import com.woowacourse.f12.dto.request.ReviewRequest;
@@ -42,6 +44,9 @@ class ReviewServiceTest {
     @Mock
     private KeyboardRepository keyboardRepository;
 
+    @Mock
+    private MemberRepository memberRepository;
+
     @InjectMocks
     private ReviewService reviewService;
 
@@ -53,11 +58,13 @@ class ReviewServiceTest {
         Keyboard keyboard = KEYBOARD_1.생성(productId);
         given(keyboardRepository.findById(productId))
                 .willReturn(Optional.of(keyboard));
+        given(memberRepository.findById(1L))
+                .willReturn(Optional.of(CORINNE.생성(1L)));
         given(reviewRepository.save(reviewRequest.toReview(keyboard)))
                 .willReturn(REVIEW_RATING_5.작성(1L, keyboard));
 
         // when
-        Long reviewId = reviewService.save(productId, reviewRequest);
+        Long reviewId = reviewService.save(productId, reviewRequest, 1L);
 
         // then
         assertAll(
@@ -78,7 +85,7 @@ class ReviewServiceTest {
 
         // when, then
         assertAll(
-                () -> assertThatThrownBy(() -> reviewService.save(1L, reviewRequest))
+                () -> assertThatThrownBy(() -> reviewService.save(1L, reviewRequest, 1L))
                         .isExactlyInstanceOf(KeyboardNotFoundException.class),
                 () -> verify(keyboardRepository).findById(productId),
                 () -> verify(reviewRepository, times(0)).save(any(Review.class))

--- a/backend/src/test/java/com/woowacourse/f12/documentation/AuthDocumentation.java
+++ b/backend/src/test/java/com/woowacourse/f12/documentation/AuthDocumentation.java
@@ -1,0 +1,51 @@
+package com.woowacourse.f12.documentation;
+
+import static com.woowacourse.f12.support.MemberFixtures.CORINNE;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.woowacourse.f12.application.AuthService;
+import com.woowacourse.f12.domain.Member;
+import com.woowacourse.f12.dto.response.LoginResponse;
+import com.woowacourse.f12.presentation.AuthController;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@WebMvcTest(AuthController.class)
+class AuthDocumentation extends Documentation {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AuthService authService;
+
+    @Test
+    void 로그인_API_문서화() throws Exception {
+        // given
+        String code = "code";
+        String token = "applicationAccessToken";
+        Member member = CORINNE.생성(1L);
+        given(authService.login(code))
+                .willReturn(LoginResponse.of(token, member));
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                get("/api/v1/login?code=" + code)
+        );
+
+        // then
+        resultActions.andExpect(status().isOk())
+                .andDo(print())
+                .andDo(
+                        document("auth-login")
+                );
+    }
+}

--- a/backend/src/test/java/com/woowacourse/f12/documentation/Documentation.java
+++ b/backend/src/test/java/com/woowacourse/f12/documentation/Documentation.java
@@ -1,5 +1,7 @@
 package com.woowacourse.f12.documentation;
 
+import com.woowacourse.f12.application.JwtProvider;
+import com.woowacourse.f12.support.AuthTokenExtractor;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.context.annotation.Import;
@@ -7,7 +9,7 @@ import org.springframework.restdocs.RestDocumentationExtension;
 
 @AutoConfigureRestDocs
 @ExtendWith(RestDocumentationExtension.class)
-@Import(RestDocsConfig.class)
+@Import({AuthTokenExtractor.class, JwtProvider.class, RestDocsConfig.class})
 public class Documentation {
 
 }

--- a/backend/src/test/java/com/woowacourse/f12/documentation/MemberDocumentation.java
+++ b/backend/src/test/java/com/woowacourse/f12/documentation/MemberDocumentation.java
@@ -1,0 +1,65 @@
+package com.woowacourse.f12.documentation;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.woowacourse.f12.application.JwtProvider;
+import com.woowacourse.f12.application.MemberService;
+import com.woowacourse.f12.dto.request.ProfileProductRequest;
+import com.woowacourse.f12.presentation.MemberController;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@WebMvcTest(MemberController.class)
+class MemberDocumentation extends Documentation {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private MemberService memberService;
+
+    @MockBean
+    private JwtProvider jwtProvider;
+
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void 대표_장비를_등록하는_API_문서화() throws Exception {
+        // given
+        String authorizationHeader = "Bearer Token";
+        given(jwtProvider.validateToken(authorizationHeader))
+                .willReturn(true);
+        given(jwtProvider.getPayload(authorizationHeader))
+                .willReturn("1");
+        Long memberId = 1L;
+        ProfileProductRequest profileProductRequest = new ProfileProductRequest(1L, 2L);
+        willDoNothing().given(memberService).updateProfileProducts(memberId, profileProductRequest);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                patch("/api/v1/members/inventoryProducts")
+                        .header(HttpHeaders.AUTHORIZATION, authorizationHeader)
+                        .content(objectMapper.writeValueAsString(profileProductRequest))
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        );
+
+        // then
+        resultActions.andExpect(status().isOk())
+                .andDo(print())
+                .andDo(
+                        document("member-inventoryProduct-update")
+                );
+    }
+}

--- a/backend/src/test/java/com/woowacourse/f12/documentation/ReviewDocumentation.java
+++ b/backend/src/test/java/com/woowacourse/f12/documentation/ReviewDocumentation.java
@@ -14,6 +14,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.woowacourse.f12.application.JwtProvider;
 import com.woowacourse.f12.application.ReviewService;
 import com.woowacourse.f12.domain.Keyboard;
 import com.woowacourse.f12.dto.request.ReviewRequest;
@@ -29,6 +30,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
@@ -42,18 +44,27 @@ public class ReviewDocumentation extends Documentation {
     @MockBean
     private ReviewService reviewService;
 
+    @MockBean
+    private JwtProvider jwtProvider;
+
     private ObjectMapper objectMapper = new ObjectMapper();
 
     @Test
     void 리뷰_작성_API_문서화() throws Exception {
         // given
-        given(reviewService.save(anyLong(), any(ReviewRequest.class)))
+        String authorizationHeader = "Bearer Token";
+        given(jwtProvider.validateToken(authorizationHeader))
+                .willReturn(true);
+        given(jwtProvider.getPayload(authorizationHeader))
+                .willReturn("1");
+        given(reviewService.save(anyLong(), any(ReviewRequest.class), anyLong()))
                 .willReturn(1L);
         ReviewRequest reviewRequest = new ReviewRequest("content", 5);
 
         // when
         ResultActions resultActions = mockMvc.perform(
                 post("/api/v1/keyboards/" + 1L + "/reviews")
+                        .header(HttpHeaders.AUTHORIZATION, authorizationHeader)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(reviewRequest))
         );

--- a/backend/src/test/java/com/woowacourse/f12/presentation/AuthControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/AuthControllerTest.java
@@ -1,0 +1,85 @@
+package com.woowacourse.f12.presentation;
+
+import static com.woowacourse.f12.support.MemberFixtures.CORINNE;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.woowacourse.f12.application.AuthService;
+import com.woowacourse.f12.application.JwtProvider;
+import com.woowacourse.f12.dto.response.LoginResponse;
+import com.woowacourse.f12.exception.GitHubServerException;
+import com.woowacourse.f12.exception.InvalidGitHubLoginException;
+import com.woowacourse.f12.support.AuthTokenExtractor;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(AuthController.class)
+@Import({AuthTokenExtractor.class, JwtProvider.class})
+class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AuthService authService;
+
+    @Test
+    void 로그인_성공() throws Exception {
+        // given
+        String code = "code";
+        String token = "token";
+        LoginResponse loginResponse = LoginResponse.of(token, CORINNE.생성(1L));
+        given(authService.login(code))
+                .willReturn(loginResponse);
+
+        // when
+        mockMvc.perform(
+                        get("/api/v1/login?code=" + code)
+                ).andExpect(status().isOk())
+                .andDo(print());
+
+        // then
+        verify(authService).login(code);
+    }
+
+    @Test
+    void 로그인_실패_올바르지_않은_로그인_요청() throws Exception {
+        // given
+        String code = "code";
+        given(authService.login(code))
+                .willThrow(new InvalidGitHubLoginException());
+
+        // when
+        mockMvc.perform(
+                        get("/api/v1/login?code=" + code)
+                ).andExpect(status().isBadRequest())
+                .andDo(print());
+
+        // then
+        verify(authService).login(code);
+    }
+
+    @Test
+    void 로그인_실패_깃허브_서버_오류() throws Exception {
+        // given
+        String code = "code";
+        given(authService.login(code))
+                .willThrow(new GitHubServerException());
+
+        // when
+        mockMvc.perform(
+                        get("/api/v1/login?code=" + code)
+                ).andExpect(status().isInternalServerError())
+                .andDo(print());
+
+        // then
+        verify(authService).login(code);
+    }
+}

--- a/backend/src/test/java/com/woowacourse/f12/presentation/AuthInterceptorTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/AuthInterceptorTest.java
@@ -1,0 +1,68 @@
+package com.woowacourse.f12.presentation;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.woowacourse.f12.application.JwtProvider;
+import com.woowacourse.f12.application.ReviewService;
+import com.woowacourse.f12.dto.request.ReviewRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(ReviewController.class)
+class AuthInterceptorTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ReviewService reviewService;
+
+    @MockBean
+    private JwtProvider jwtProvider;
+
+    private final ObjectMapper objectMapper;
+
+    public AuthInterceptorTest() {
+        this.objectMapper = new ObjectMapper();
+    }
+
+    @Test
+    void 인증_인가를_검즘_실패_유효하지_않은_토큰() throws Exception {
+        // given
+        ReviewRequest reviewRequest = new ReviewRequest("content", 5);
+        String authorizationHeader = "Bearer Token";
+        given(jwtProvider.validateToken(authorizationHeader))
+                .willReturn(false);
+        given(reviewService.save(anyLong(), any(ReviewRequest.class), anyLong()))
+                .willReturn(1L);
+        // when
+        mockMvc.perform(
+                        post("/api/v1/keyboards/" + 1L + "/reviews")
+                                .header(HttpHeaders.AUTHORIZATION, authorizationHeader)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(reviewRequest))
+                ).andExpect(status().isUnauthorized())
+                .andDo(print());
+
+        // then
+        assertAll(
+                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(reviewService, times(0)).save(eq(1L), any(ReviewRequest.class), eq(1L))
+        );
+    }
+}

--- a/backend/src/test/java/com/woowacourse/f12/presentation/CustomPageableArgumentResolverTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/CustomPageableArgumentResolverTest.java
@@ -8,13 +8,16 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.woowacourse.f12.application.JwtProvider;
 import com.woowacourse.f12.application.KeyboardService;
 import com.woowacourse.f12.dto.response.KeyboardPageResponse;
+import com.woowacourse.f12.support.AuthTokenExtractor;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.SliceImpl;
@@ -22,7 +25,8 @@ import org.springframework.data.domain.Sort;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(KeyboardController.class)
-public class CustomPageableHandlerMethodArgumentResolverTest {
+@Import({AuthTokenExtractor.class, JwtProvider.class})
+public class CustomPageableArgumentResolverTest {
 
     @Autowired
     private MockMvc mockMvc;

--- a/backend/src/test/java/com/woowacourse/f12/presentation/KeyboardControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/KeyboardControllerTest.java
@@ -9,15 +9,18 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.woowacourse.f12.application.JwtProvider;
 import com.woowacourse.f12.application.KeyboardService;
 import com.woowacourse.f12.dto.response.KeyboardPageResponse;
 import com.woowacourse.f12.dto.response.KeyboardResponse;
 import com.woowacourse.f12.exception.KeyboardNotFoundException;
+import com.woowacourse.f12.support.AuthTokenExtractor;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.SliceImpl;
@@ -25,6 +28,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(KeyboardController.class)
+@Import({AuthTokenExtractor.class, JwtProvider.class})
 class KeyboardControllerTest {
 
     @Autowired

--- a/backend/src/test/java/com/woowacourse/f12/presentation/MemberControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/MemberControllerTest.java
@@ -1,0 +1,99 @@
+package com.woowacourse.f12.presentation;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.woowacourse.f12.application.JwtProvider;
+import com.woowacourse.f12.application.MemberService;
+import com.woowacourse.f12.dto.request.ProfileProductRequest;
+import com.woowacourse.f12.exception.InventoryItemNotFoundException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(MemberController.class)
+class MemberControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private MemberService memberService;
+
+    @MockBean
+    private JwtProvider jwtProvider;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void 대표_장비_등록_성공() throws Exception {
+        // given
+        String authorizationHeader = "Bearer Token";
+        given(jwtProvider.validateToken(authorizationHeader))
+                .willReturn(true);
+        given(jwtProvider.getPayload(authorizationHeader))
+                .willReturn("1");
+        ProfileProductRequest profileProductRequest = new ProfileProductRequest(1L, 2L);
+        willDoNothing().given(memberService).updateProfileProducts(1L, profileProductRequest);
+
+        // when
+        mockMvc.perform(
+                        patch("/api/v1/members/inventoryProducts")
+                                .header(HttpHeaders.AUTHORIZATION, authorizationHeader)
+                                .content(objectMapper.writeValueAsString(profileProductRequest))
+                                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                )
+                .andExpect(status().isOk())
+                .andDo(print());
+
+        // then
+        assertAll(
+                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).getPayload(authorizationHeader),
+                () -> verify(memberService).updateProfileProducts(anyLong(), any(ProfileProductRequest.class))
+        );
+    }
+
+    @Test
+    void 대표_장비_등록_실패_인벤토리_상품_id가_없는_경우() throws Exception {
+        // given
+        String authorizationHeader = "Bearer Token";
+        given(jwtProvider.validateToken(authorizationHeader))
+                .willReturn(true);
+        given(jwtProvider.getPayload(authorizationHeader))
+                .willReturn("1");
+        ProfileProductRequest profileProductRequest = new ProfileProductRequest(1L, 2L);
+        willThrow(new InventoryItemNotFoundException()).given(memberService)
+                .updateProfileProducts(anyLong(), any(ProfileProductRequest.class));
+
+        // when
+        mockMvc.perform(
+                        patch("/api/v1/members/inventoryProducts")
+                                .header(HttpHeaders.AUTHORIZATION, authorizationHeader)
+                                .content(objectMapper.writeValueAsString(profileProductRequest))
+                                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                )
+                .andExpect(status().isNotFound())
+                .andDo(print());
+
+        // then
+        assertAll(
+                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).getPayload(authorizationHeader),
+                () -> verify(memberService).updateProfileProducts(anyLong(), any(ProfileProductRequest.class))
+        );
+    }
+}

--- a/backend/src/test/java/com/woowacourse/f12/presentation/ReviewControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/ReviewControllerTest.java
@@ -2,6 +2,7 @@ package com.woowacourse.f12.presentation;
 
 import static com.woowacourse.f12.support.KeyboardFixtures.KEYBOARD_1;
 import static com.woowacourse.f12.support.ReviewFixtures.REVIEW_RATING_5;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
@@ -14,6 +15,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.woowacourse.f12.application.JwtProvider;
 import com.woowacourse.f12.application.ReviewService;
 import com.woowacourse.f12.dto.request.ReviewRequest;
 import com.woowacourse.f12.dto.response.ReviewPageResponse;
@@ -22,6 +24,7 @@ import com.woowacourse.f12.exception.BlankContentException;
 import com.woowacourse.f12.exception.InvalidContentLengthException;
 import com.woowacourse.f12.exception.InvalidRatingValueException;
 import com.woowacourse.f12.exception.KeyboardNotFoundException;
+import com.woowacourse.f12.support.AuthTokenExtractor;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -29,14 +32,17 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(ReviewController.class)
+@Import(AuthTokenExtractor.class)
 class ReviewControllerTest {
 
     private static final long PRODUCT_ID = 1L;
@@ -49,6 +55,9 @@ class ReviewControllerTest {
     @MockBean
     private ReviewService reviewService;
 
+    @MockBean
+    private JwtProvider jwtProvider;
+
     public ReviewControllerTest() {
         this.objectMapper = new ObjectMapper();
     }
@@ -56,138 +65,200 @@ class ReviewControllerTest {
     @Test
     void 리뷰_생성_성공() throws Exception {
         // given
-        given(reviewService.save(anyLong(), any(ReviewRequest.class)))
-                .willReturn(1L);
         ReviewRequest reviewRequest = new ReviewRequest("content", 5);
-
+        String authorizationHeader = "Bearer Token";
+        given(jwtProvider.validateToken(authorizationHeader))
+                .willReturn(true);
+        given(jwtProvider.getPayload(authorizationHeader))
+                .willReturn("1");
+        given(reviewService.save(anyLong(), any(ReviewRequest.class), anyLong()))
+                .willReturn(1L);
         // when
         mockMvc.perform(
                         post("/api/v1/keyboards/" + PRODUCT_ID + "/reviews")
+                                .header(HttpHeaders.AUTHORIZATION, authorizationHeader)
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(reviewRequest))
                 ).andExpect(status().isCreated())
                 .andDo(print());
 
         // then
-        verify(reviewService).save(eq(PRODUCT_ID), any(ReviewRequest.class));
+        assertAll(
+                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).getPayload(authorizationHeader),
+                () -> verify(reviewService).save(eq(PRODUCT_ID), any(ReviewRequest.class), eq(1L))
+        );
     }
 
     @Test
     void 리뷰_생성_실패_Request_DTO_의_필드가_null_인_경우() throws Exception {
         // given
-        given(reviewService.save(anyLong(), any(ReviewRequest.class)))
-                .willThrow(new BlankContentException());
         ReviewRequest reviewRequest = new ReviewRequest(null, null);
+        String authorizationHeader = "Bearer Token";
+        given(jwtProvider.validateToken(authorizationHeader))
+                .willReturn(true);
+        given(reviewService.save(anyLong(), any(ReviewRequest.class), anyLong()))
+                .willThrow(new BlankContentException());
 
         // when
         mockMvc.perform(
                         post("/api/v1/keyboards/" + PRODUCT_ID + "/reviews")
+                                .header(HttpHeaders.AUTHORIZATION, authorizationHeader)
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(reviewRequest))
                 ).andExpect(status().isBadRequest())
                 .andDo(print());
 
         // then
-        verify(reviewService, times(0)).save(eq(PRODUCT_ID), any(ReviewRequest.class));
+        assertAll(
+                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(reviewService, times(0)).save(eq(PRODUCT_ID), any(ReviewRequest.class), eq(1L))
+        );
     }
 
     @Test
     void 리뷰_생성_실패_rating_타입이_올바르지_않을_경우() throws Exception {
         // given
-        given(reviewService.save(anyLong(), any(ReviewRequest.class)))
-                .willThrow(new BlankContentException());
+        String authorizationHeader = "Bearer Token";
         Map<String, Object> reviewRequest = new HashMap<>();
         reviewRequest.put("content", "내용");
         reviewRequest.put("rating", "문자");
+        given(jwtProvider.validateToken(authorizationHeader))
+                .willReturn(true);
+        given(reviewService.save(anyLong(), any(ReviewRequest.class), anyLong()))
+                .willThrow(new BlankContentException());
 
         // when
         mockMvc.perform(
                         post("/api/v1/keyboards/" + PRODUCT_ID + "/reviews")
+                                .header(HttpHeaders.AUTHORIZATION, authorizationHeader)
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(reviewRequest))
                 ).andExpect(status().isBadRequest())
                 .andDo(print());
 
         // then
-        verify(reviewService, times(0)).save(eq(PRODUCT_ID), any(ReviewRequest.class));
+        assertAll(
+                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(reviewService, times(0)).save(eq(PRODUCT_ID), any(ReviewRequest.class), eq(1L))
+        );
     }
 
     @Test
     void 리뷰_생성_실패_리뷰_내용이_존재하지_않음() throws Exception {
         // given
-        given(reviewService.save(anyLong(), any(ReviewRequest.class)))
-                .willThrow(new BlankContentException());
+        String authorizationHeader = "Bearer Token";
         ReviewRequest reviewRequest = new ReviewRequest("", 5);
+        given(jwtProvider.validateToken(authorizationHeader))
+                .willReturn(true);
+        given(jwtProvider.getPayload(authorizationHeader))
+                .willReturn("1");
+        given(reviewService.save(anyLong(), any(ReviewRequest.class), anyLong()))
+                .willThrow(new BlankContentException());
 
         // when
         mockMvc.perform(
                         post("/api/v1/keyboards/" + PRODUCT_ID + "/reviews")
+                                .header(HttpHeaders.AUTHORIZATION, authorizationHeader)
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(reviewRequest))
                 ).andExpect(status().isBadRequest())
                 .andDo(print());
 
         // then
-        verify(reviewService).save(eq(PRODUCT_ID), any(ReviewRequest.class));
+        assertAll(
+                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).getPayload(authorizationHeader),
+                () -> verify(reviewService).save(eq(PRODUCT_ID), any(ReviewRequest.class), eq(1L))
+        );
     }
 
     @Test
     void 리뷰_생성_실패_리뷰_내용_최대_길이_초과() throws Exception {
         // given
-        given(reviewService.save(anyLong(), any(ReviewRequest.class)))
-                .willThrow(new InvalidContentLengthException(1000));
+        String authorizationHeader = "Bearer Token";
         String content = "a".repeat(1001);
         ReviewRequest reviewRequest = new ReviewRequest(content, 5);
+        given(jwtProvider.validateToken(authorizationHeader))
+                .willReturn(true);
+        given(jwtProvider.getPayload(authorizationHeader))
+                .willReturn("1");
+        given(reviewService.save(anyLong(), any(ReviewRequest.class), anyLong()))
+                .willThrow(new InvalidContentLengthException(1000));
 
         // when
         mockMvc.perform(
                         post("/api/v1/keyboards/" + PRODUCT_ID + "/reviews")
+                                .header(HttpHeaders.AUTHORIZATION, authorizationHeader)
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(reviewRequest))
                 ).andExpect(status().isBadRequest())
                 .andDo(print());
 
         // then
-        verify(reviewService).save(eq(PRODUCT_ID), any(ReviewRequest.class));
-
+        assertAll(
+                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).getPayload(authorizationHeader),
+                () -> verify(reviewService).save(eq(PRODUCT_ID), any(ReviewRequest.class), eq(1L))
+        );
     }
 
     @Test
     void 리뷰_생성_실패_평점이_1부터_5사이_정수가_아님() throws Exception {
         // given
-        given(reviewService.save(anyLong(), any(ReviewRequest.class)))
-                .willThrow(new InvalidRatingValueException());
+        String authorizationHeader = "Bearer Token";
         ReviewRequest reviewRequest = new ReviewRequest("내용", 0);
+        given(jwtProvider.validateToken(authorizationHeader))
+                .willReturn(true);
+        given(jwtProvider.getPayload(authorizationHeader))
+                .willReturn("1");
+        given(reviewService.save(anyLong(), any(ReviewRequest.class), anyLong()))
+                .willThrow(new InvalidRatingValueException());
 
         // when
         mockMvc.perform(
                         post("/api/v1/keyboards/" + PRODUCT_ID + "/reviews")
+                                .header(HttpHeaders.AUTHORIZATION, authorizationHeader)
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(reviewRequest))
                 ).andExpect(status().isBadRequest())
                 .andDo(print());
 
         // then
-        verify(reviewService).save(eq(PRODUCT_ID), any(ReviewRequest.class));
+        assertAll(
+                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).getPayload(authorizationHeader),
+                () -> verify(reviewService).save(eq(PRODUCT_ID), any(ReviewRequest.class), eq(1L))
+        );
     }
 
     @Test
     void 리뷰_생성_실패_제품이_존재하지_않음() throws Exception {
         // given
-        given(reviewService.save(anyLong(), any(ReviewRequest.class)))
-                .willThrow(new KeyboardNotFoundException());
+        String authorizationHeader = "Bearer Token";
         ReviewRequest reviewRequest = new ReviewRequest("내용", 5);
+        given(jwtProvider.validateToken(authorizationHeader))
+                .willReturn(true);
+        given(jwtProvider.getPayload(authorizationHeader))
+                .willReturn("1");
+        given(reviewService.save(anyLong(), any(ReviewRequest.class), anyLong()))
+                .willThrow(new KeyboardNotFoundException());
 
         // when
         mockMvc.perform(
                         post("/api/v1/keyboards/" + 0L + "/reviews")
+                                .header(HttpHeaders.AUTHORIZATION, authorizationHeader)
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(reviewRequest))
                 ).andExpect(status().isNotFound())
                 .andDo(print());
 
         // then
-        verify(reviewService).save(eq(0L), any(ReviewRequest.class));
+        assertAll(
+                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).getPayload(authorizationHeader),
+                () -> verify(reviewService).save(eq(0L), any(ReviewRequest.class), eq(1L))
+        );
     }
 
     @Test

--- a/backend/src/test/java/com/woowacourse/f12/support/AuthTokenExtractorTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/support/AuthTokenExtractorTest.java
@@ -1,0 +1,50 @@
+package com.woowacourse.f12.support;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.woowacourse.f12.exception.UnauthorizedException;
+import org.junit.jupiter.api.Test;
+
+class AuthTokenExtractorTest {
+
+    private final AuthTokenExtractor authTokenExtractor = new AuthTokenExtractor();
+
+    @Test
+    void Authorization_헤더에서_토큰을_추출한다() {
+        // given
+        String authorizationHeader = "Bearer token";
+
+        // when
+        String token = authTokenExtractor.extractToken(authorizationHeader, "Bearer");
+
+        // then
+        assertThat(token).isEqualTo("token");
+    }
+
+    @Test
+    void Authorization_헤더가_null_이면_예외가_발생한다() {
+        assertThatThrownBy(() -> authTokenExtractor.extractToken(null, "Bearer"))
+                .isExactlyInstanceOf(UnauthorizedException.class);
+    }
+
+    @Test
+    void Authorization_헤더의_타입이_불일치하면_예외가_발생한다() {
+        // given
+        String authorizationHeader = "NotBearer token";
+
+        // when, then
+        assertThatThrownBy(() -> authTokenExtractor.extractToken(authorizationHeader, "Bearer"))
+                .isExactlyInstanceOf(UnauthorizedException.class);
+    }
+
+    @Test
+    void Authorization_헤더의_형식이_불일치하면_예외가_발생한다() {
+        // given
+        String authorizationHeader = "Bearer token token2";
+
+        // when, then
+        assertThatThrownBy(() -> authTokenExtractor.extractToken(authorizationHeader, "Bearer"))
+                .isExactlyInstanceOf(UnauthorizedException.class);
+    }
+}

--- a/backend/src/test/java/com/woowacourse/f12/support/FakeGitHubApiController.java
+++ b/backend/src/test/java/com/woowacourse/f12/support/FakeGitHubApiController.java
@@ -1,0 +1,49 @@
+package com.woowacourse.f12.support;
+
+import com.woowacourse.f12.dto.request.GitHubTokenRequest;
+import com.woowacourse.f12.dto.response.GitHubProfileResponse;
+import com.woowacourse.f12.dto.response.GitHubTokenResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class FakeGitHubApiController {
+
+    private String clientId;
+    private String clientSecret;
+
+    public FakeGitHubApiController(@Value("${github.client.id}") final String clientId,
+                                   @Value("${github.client.secret}") final String clientSecret) {
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+    }
+
+    @PostMapping("/login/oauth/access_token")
+    public ResponseEntity<GitHubTokenResponse> issueFakeAccessToken(
+            @RequestBody final GitHubTokenRequest gitHubTokenRequest) {
+        if (!gitHubTokenRequest.getClientId().equals(clientId) || !gitHubTokenRequest.getClientSecret()
+                .equals(clientSecret)) {
+            return ResponseEntity.badRequest().build();
+        }
+        return ResponseEntity.ok(new GitHubTokenResponse("accessToken"));
+    }
+
+    @GetMapping("/user")
+    public ResponseEntity<GitHubProfileResponse> showFakeProfile(
+            @RequestHeader(value = HttpHeaders.AUTHORIZATION) final String authorizationHeaderValue) {
+        if (authorizationHeaderValue == null) {
+            return ResponseEntity.badRequest().build();
+        }
+        final String[] splitValue = authorizationHeaderValue.split(" ");
+        if (splitValue.length != 2 || !splitValue[0].equals("token")) {
+            return ResponseEntity.badRequest().build();
+        }
+        return ResponseEntity.ok(new GitHubProfileResponse("gitHubId", "name", "url"));
+    }
+}

--- a/backend/src/test/java/com/woowacourse/f12/support/MemberFixtures.java
+++ b/backend/src/test/java/com/woowacourse/f12/support/MemberFixtures.java
@@ -1,0 +1,33 @@
+package com.woowacourse.f12.support;
+
+import com.woowacourse.f12.domain.Member;
+import com.woowacourse.f12.dto.response.GitHubProfileResponse;
+
+public enum MemberFixtures {
+
+    CORINNE("hamcheeseburger", "유현지", "corinne_url"),
+    CORINNE_UPDATED("hamcheeseburger", "괴물개발자", "corinne_url");
+
+    private final String gitHubId;
+    private final String name;
+    private final String imageUrl;
+
+    MemberFixtures(final String gitHubId, final String name, final String imageUrl) {
+        this.gitHubId = gitHubId;
+        this.name = name;
+        this.imageUrl = imageUrl;
+    }
+
+    public Member 생성(final Long id) {
+        return Member.builder()
+                .id(id)
+                .gitHubId(this.gitHubId)
+                .name(this.name)
+                .imageUrl(this.imageUrl)
+                .build();
+    }
+
+    public GitHubProfileResponse 깃허브_프로필() {
+        return new GitHubProfileResponse(this.gitHubId, this.name, this.imageUrl);
+    }
+}

--- a/backend/src/test/java/com/woowacourse/f12/support/ReviewFixtures.java
+++ b/backend/src/test/java/com/woowacourse/f12/support/ReviewFixtures.java
@@ -39,8 +39,9 @@ public enum ReviewFixtures {
                 .build();
     }
 
-    public ExtractableResponse<Response> 작성_요청을_보낸다(Long productId) {
+    public ExtractableResponse<Response> 작성_요청을_보낸다(Long productId, String token) {
         final ReviewRequest reviewRequest = new ReviewRequest(this.content, this.rating);
-        return RestAssuredRequestUtil.POST_요청을_보낸다("/api/v1/keyboards/" + productId + "/reviews", reviewRequest);
+        return RestAssuredRequestUtil.로그인된_상태로_POST_요청을_보낸다("/api/v1/keyboards/" + productId + "/reviews", token,
+                reviewRequest);
     }
 }

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -8,4 +8,17 @@ spring:
         format_sql: true
 
 server:
-  port: 8080
+  port: 8888
+
+github:
+  client:
+    id: clientId
+    secret: secret
+  url:
+    accessToken: http://localhost:8888/login/oauth/access_token
+    user: http://localhost:8888/user
+
+security:
+  jwt:
+    secret-key: testfkjasl123jl1kjdklfha2h3eoi1eojqdoiq112lkdldk
+    expire-length: 3600000

--- a/frontend/src/components/Login/Login.tsx
+++ b/frontend/src/components/Login/Login.tsx
@@ -1,0 +1,25 @@
+import ROUTES from '@/constants/routes';
+import useAuth from '@/hooks/useAuth';
+import { useEffect } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+
+function Login() {
+  const { login } = useAuth();
+  const { code } = useParams();
+
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    login(code)
+      .catch(() => {
+        alert('로그인에 실패했습니다. 잠시 후 다시 시도해주세요.');
+      })
+      .finally(() => {
+        navigate(ROUTES.HOME);
+      });
+  }, []);
+
+  return <div>로그인 진행중..</div>;
+}
+
+export default Login;

--- a/frontend/src/components/common/HeaderNav/HeaderNav.style.tsx
+++ b/frontend/src/components/common/HeaderNav/HeaderNav.style.tsx
@@ -9,9 +9,17 @@ export const Main = styled.main`
   gap: 3rem;
 `;
 
+export const Wrapper = styled.div`
+  max-width: 1320px;
+  width: 100%;
+  margin: 0 auto;
+  display: flex;
+`;
+
 export const Nav = styled.nav`
   width: 100%;
   height: 3rem;
+  display: flex;
 
   position: sticky;
   top: 0;
@@ -33,12 +41,23 @@ export const Nav = styled.nav`
   }
 `;
 
-export const FlexUl = styled.ul`
+export const FlexLeftUl = styled.ul`
   width: 90%;
   height: 3rem;
   margin: 0 auto;
-
   display: flex;
   align-items: center;
   gap: 2rem;
+`;
+
+export const FlexRightUl = styled(FlexLeftUl)`
+  justify-content: flex-end;
+`;
+
+export const LoginButton = styled.a``;
+
+export const LogoutButton = styled.button`
+  background-color: transparent;
+  border: none;
+  font-size: 1rem;
 `;

--- a/frontend/src/components/common/HeaderNav/HeaderNav.tsx
+++ b/frontend/src/components/common/HeaderNav/HeaderNav.tsx
@@ -1,13 +1,39 @@
+import { GITHUB_AUTH_URL } from '@/constants/api';
+import useAuth from '@/hooks/useAuth';
+
 import * as S from './HeaderNav.style';
+
 function HeaderNav() {
+  const { logout, isLoggedIn } = useAuth();
+
+  const handleLogout: React.MouseEventHandler<HTMLButtonElement> = () => {
+    if (window.confirm('로그아웃 하시겠습니까?')) {
+      try {
+        logout();
+        window.alert('로그아웃이 완료되었습니다.');
+      } catch {
+        window.alert('로그아웃에 실패했습니다. 다시 시도해주세요.');
+      }
+    }
+  };
+
   return (
     <S.Nav>
-      <S.FlexUl>
-        <li>메뉴1</li>
-        <li>메뉴2</li>
-        <li>메뉴3</li>
-        <li>메뉴4</li>
-      </S.FlexUl>
+      <S.Wrapper>
+        <S.FlexLeftUl>
+          <li>메뉴1</li>
+          <li>메뉴2</li>
+          <li>메뉴3</li>
+          <li>메뉴4</li>
+        </S.FlexLeftUl>
+        <S.FlexRightUl>
+          {isLoggedIn ? (
+            <S.LogoutButton onClick={handleLogout}>로그아웃</S.LogoutButton>
+          ) : (
+            <S.LoginButton href={GITHUB_AUTH_URL}>로그인</S.LoginButton>
+          )}
+        </S.FlexRightUl>
+      </S.Wrapper>
     </S.Nav>
   );
 }

--- a/frontend/src/components/common/ReviewCard/ReviewCard.style.tsx
+++ b/frontend/src/components/common/ReviewCard/ReviewCard.style.tsx
@@ -41,6 +41,26 @@ export const ReviewArea = styled.div<{ isFull: boolean }>`
   width: ${({ isFull }) => (isFull ? '100%' : '60%')};
 `;
 
+export const ProductArea = styled.div`
+  display: flex;
+`;
+
+export const Image = styled.img`
+  width: 250px;
+`;
+
+export const Title = styled.div``;
+
+export const ReviewArea = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+`;
+
+export const FlexColumnWrapper = styled(ReviewArea)`
+  gap: 1rem;
+`;
+
 export const Wrapper = styled.div`
   display: flex;
   justify-content: space-between;

--- a/frontend/src/components/common/ReviewCard/ReviewCard.style.tsx
+++ b/frontend/src/components/common/ReviewCard/ReviewCard.style.tsx
@@ -41,22 +41,6 @@ export const ReviewArea = styled.div<{ isFull: boolean }>`
   width: ${({ isFull }) => (isFull ? '100%' : '60%')};
 `;
 
-export const ProductArea = styled.div`
-  display: flex;
-`;
-
-export const Image = styled.img`
-  width: 250px;
-`;
-
-export const Title = styled.div``;
-
-export const ReviewArea = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-`;
-
 export const FlexColumnWrapper = styled(ReviewArea)`
   gap: 1rem;
 `;

--- a/frontend/src/components/common/Stepper/Stepper.stories.tsx
+++ b/frontend/src/components/common/Stepper/Stepper.stories.tsx
@@ -1,0 +1,10 @@
+import Stepper from './Stepper';
+
+export default {
+  component: Stepper,
+  title: 'Components/Stepper',
+};
+
+export const FirstStep = () => <Stepper step={1} />;
+export const SecondStep = () => <Stepper step={2} />;
+export const ThirdStep = () => <Stepper step={3} />;

--- a/frontend/src/components/common/Stepper/Stepper.style.ts
+++ b/frontend/src/components/common/Stepper/Stepper.style.ts
@@ -1,0 +1,114 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  display: flex;
+  justify-content: space-between;
+  width: 40rem;
+`;
+
+export const Item = styled.div<{ step: number }>`
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  flex: 1;
+
+  &::before {
+    position: absolute;
+    content: '';
+    width: 100%;
+    top: 25px;
+    left: -50%;
+    z-index: 2;
+  }
+
+  &::after {
+    position: absolute;
+    content: '';
+    border: 2px solid #cfcfcf;
+    width: 100%;
+    top: 25px;
+    left: 50%;
+    z-index: 2;
+  }
+
+  &:first-child::before {
+    content: none;
+  }
+
+  &:first-child::after {
+    ${(props) => {
+      if (props.step === 2 || props.step === 3)
+        return `border: 2px solid #f6bebe;
+        transition: ease-in 0.2s;`;
+    }};
+  }
+
+  &:last-child::after {
+    content: none;
+  }
+
+  &:nth-child(2)::after {
+    ${(props) => {
+      if (props.step === 3)
+        return `border: 2px solid #f6bebe;
+      transition: ease-in 0.2s;`;
+    }};
+  }
+
+  &:first-child {
+    .step {
+      ${(props) => {
+        if (props.step === 1)
+          return `border: 5px solid #f6bebe;
+        transition: ease-in 0.2s;`;
+        if (props.step === 2 || props.step === 3)
+          return `border: 5px solid #f6bebe;
+          background-color: #f6bebe`;
+      }};
+    }
+  }
+
+  &:nth-child(2) {
+    .step {
+      ${(props) => {
+        if (props.step === 2)
+          return `border: 5px solid #f6bebe;
+        transition: ease-in 0.2s`;
+        if (props.step === 3)
+          return `border: 5px solid #f6bebe;
+        background-color: #f6bebe;
+        transition: ease-in 0.2s`;
+      }};
+    }
+  }
+
+  &:last-child {
+    .step {
+      ${(props) => {
+        if (props.step === 3)
+          return `border: 5px solid #f6bebe;
+        transition: ease-in 0.2s;`;
+      }};
+    }
+  }
+`;
+
+export const Step = styled.div`
+  position: relative;
+  z-index: 3;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 50px;
+  height: 50px;
+  border-radius: 50%;
+  border: 5px solid #cfcfcf;
+  background-color: #faf9f9;
+  margin-bottom: 6px;
+  font-size: 1.5rem;
+`;
+
+export const Title = styled.div`
+  font-size: 1rem;
+`;

--- a/frontend/src/components/common/Stepper/Stepper.tsx
+++ b/frontend/src/components/common/Stepper/Stepper.tsx
@@ -1,0 +1,26 @@
+import * as S from '@/components/common/Stepper/Stepper.style';
+
+type Prop = {
+  step: number;
+};
+
+function Stepper({ step }: Prop) {
+  return (
+    <S.Container>
+      <S.Item step={step}>
+        <S.Step className="step">1</S.Step>
+        <S.Title>{step === 1 && '연차 입력'}</S.Title>
+      </S.Item>
+      <S.Item step={step}>
+        <S.Step className="step">2</S.Step>
+        <S.Title>{step === 2 && '직군 입력'}</S.Title>
+      </S.Item>
+      <S.Item step={step}>
+        <S.Step className="step">3</S.Step>
+        <S.Title>{step === 3 && '정보 확인'}</S.Title>
+      </S.Item>
+    </S.Container>
+  );
+}
+
+export default Stepper;

--- a/frontend/src/constants/api.ts
+++ b/frontend/src/constants/api.ts
@@ -1,8 +1,13 @@
-export const BASE_URL = 'http://ec2-52-78-192-78.ap-northeast-2.compute.amazonaws.com:8080/api/v1';
+export const BASE_URL =
+  'http://ec2-52-78-192-78.ap-northeast-2.compute.amazonaws.com:8080/api/v1';
+
+export const GITHUB_AUTH_URL =
+  'https://github.com/login/oauth/authorize?client_id=f1e73a9ac502f1b6712a&redirect_uri=http://localhost:3000/login';
 
 export const ENDPOINTS = {
   PRODUCTS: '/keyboards',
   PRODUCT: (id: number | ':id') => `/keyboards/${id}`,
   REVIEWS: '/reviews',
   REVIEWS_BY_PRODUCT_ID: (id: number | ':id') => `/keyboards/${id}/reviews`,
+  LOGIN: '/login',
 } as const;

--- a/frontend/src/constants/routes.ts
+++ b/frontend/src/constants/routes.ts
@@ -2,6 +2,8 @@ const ROUTES = {
   HOME: '/',
   PRODUCTS: '/products',
   PRODUCT: '/product',
+  REGISTER: '/register',
+  LOGIN: '/login',
 } as const;
 
 export default ROUTES;

--- a/frontend/src/contexts/LoginContextProvider.tsx
+++ b/frontend/src/contexts/LoginContextProvider.tsx
@@ -1,0 +1,44 @@
+import useSessionStorage from '@/hooks/useSessionStorage';
+import { createContext, PropsWithChildren, useEffect, useState } from 'react';
+
+const initialState: UserData = {
+  accessToken: null,
+  jobType: null,
+  career: null,
+};
+
+export const IsLoggedInContext = createContext<boolean>(false);
+export const UserDataContext = createContext(initialState);
+export const SetUserDataContext = createContext<React.Dispatch<
+  React.SetStateAction<UserData>
+> | null>(null);
+export const LogoutContext = createContext<() => void | null>(null);
+
+function LoginContextProvider({ children }: PropsWithChildren) {
+  const [userData, setUserData, removeUserData] =
+    useSessionStorage<UserData>('userData');
+  const [isLoggedIn, setLoggedIn] = useState(false);
+
+  useEffect(() => {
+    if (userData && userData.accessToken && !isLoggedIn) {
+      setLoggedIn(true);
+      return;
+    }
+
+    setLoggedIn(false);
+  }, [userData]);
+
+  return (
+    <IsLoggedInContext.Provider value={isLoggedIn}>
+      <UserDataContext.Provider value={userData}>
+        <SetUserDataContext.Provider value={setUserData}>
+          <LogoutContext.Provider value={removeUserData}>
+            {children}
+          </LogoutContext.Provider>
+        </SetUserDataContext.Provider>
+      </UserDataContext.Provider>
+    </IsLoggedInContext.Provider>
+  );
+}
+
+export default LoginContextProvider;

--- a/frontend/src/custom.d.ts
+++ b/frontend/src/custom.d.ts
@@ -8,6 +8,12 @@ declare module '*.svg' {
   export = value;
 }
 
+declare type UserData = {
+  jobType: string;
+  career: string;
+  accessToken: string;
+};
+
 declare type Product = {
   id: number;
   name: string;

--- a/frontend/src/hooks/api/useGet.tsx
+++ b/frontend/src/hooks/api/useGet.tsx
@@ -1,0 +1,24 @@
+import { AxiosRequestHeaders, AxiosResponse } from 'axios';
+import axiosInstance from '@/hooks/api/axiosInstance';
+
+type Props = {
+  url: string;
+  headers?: null | AxiosRequestHeaders;
+};
+
+function useGet<T>({
+  url,
+  headers,
+}: Props): (params: Record<string, unknown>) => Promise<T> {
+  const fetchData = async (params: unknown) => {
+    const { data }: AxiosResponse<T> = await axiosInstance.get(url, {
+      headers,
+      params,
+    });
+
+    return data;
+  };
+
+  return fetchData;
+}
+export default useGet;

--- a/frontend/src/hooks/useAuth.tsx
+++ b/frontend/src/hooks/useAuth.tsx
@@ -1,0 +1,36 @@
+import { ENDPOINTS } from '@/constants/api';
+import {
+  IsLoggedInContext,
+  LogoutContext,
+  SetUserDataContext,
+} from '@/contexts/LoginContextProvider';
+import useGet from '@/hooks/api/useGet';
+import { useContext } from 'react';
+
+type Return = {
+  login: (githubCode: string) => Promise<void>;
+  logout: () => void;
+  isLoggedIn: boolean;
+};
+
+function useAuth(): Return {
+  const setUserData = useContext(SetUserDataContext);
+  const removeUserData = useContext(LogoutContext);
+  const isLoggedIn = useContext(IsLoggedInContext);
+
+  const fetchUserData = useGet<UserData>({ url: ENDPOINTS.LOGIN });
+
+  const login = async (githubCode: string) => {
+    const userData = await fetchUserData({ code: githubCode });
+
+    setUserData(userData);
+  };
+
+  const logout = () => {
+    removeUserData();
+  };
+
+  return { login, logout, isLoggedIn };
+}
+
+export default useAuth;

--- a/frontend/src/hooks/useSessionStorage.tsx
+++ b/frontend/src/hooks/useSessionStorage.tsx
@@ -1,0 +1,27 @@
+import { useMemo, useState } from 'react';
+
+type Return<T> = [T, (T) => void, () => void];
+
+function useSessionStorage<T>(key: string): Return<T> {
+  const initialData = useMemo(
+    () => (JSON.parse(window.sessionStorage.getItem(key)) as T) || null,
+    []
+  );
+  const [data, setData] = useState<T | null>(initialData);
+
+  const setStoredData = (newData: T) => {
+    window.sessionStorage.setItem(key, JSON.stringify(newData));
+
+    setData(newData);
+  };
+
+  const removeStoredData = () => {
+    window.sessionStorage.removeItem(key);
+
+    setData(null);
+  };
+
+  return [data, setStoredData, removeStoredData];
+}
+
+export default useSessionStorage;

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -5,6 +5,7 @@ import App from '@/App';
 import { ThemeProvider } from 'styled-components';
 import theme from '@/style/theme';
 import GlobalStyles from '@/style/GlobalStyles';
+import LoginContextProvider from '@/contexts/LoginContextProvider';
 
 /* eslint-disable */
 
@@ -33,7 +34,9 @@ root.render(
       <ResetCss />
       <GlobalStyles />
       <BrowserRouter>
-        <App />
+        <LoginContextProvider>
+          <App />
+        </LoginContextProvider>
       </BrowserRouter>
     </ThemeProvider>
   </>

--- a/frontend/src/mocks/data.ts
+++ b/frontend/src/mocks/data.ts
@@ -1,4 +1,5 @@
 import sampleProfile from '@/mocks/sample_profile.jpg';
+import sampleKeyboard from '@/mocks/sample_keyboard.jpg';
 
 export const products = [
   {

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -67,8 +67,15 @@ const postReviewByProductId = (req, res, ctx) => {
   return res(ctx.status(201));
 };
 
-BASE_URL;
-ENDPOINTS;
+// 로그인
+const getToken = (req, res, ctx) => {
+  const response = {
+    jobType: null,
+    career: null,
+    accessToken: 'ZaSw2312EsaCV',
+  };
+  return res(ctx.status(200), ctx.json(response));
+};
 
 export const handlers = [
   rest.get(`${BASE_URL}${ENDPOINTS.PRODUCTS}`, getKeyboards),
@@ -82,4 +89,5 @@ export const handlers = [
     `${BASE_URL}${ENDPOINTS.REVIEWS_BY_PRODUCT_ID(':id')}`,
     postReviewByProductId
   ),
+  rest.get(`${BASE_URL}${ENDPOINTS.LOGIN}`, getToken),
 ];

--- a/frontend/src/pages/Register/Register.style.tsx
+++ b/frontend/src/pages/Register/Register.style.tsx
@@ -1,0 +1,81 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2rem;
+`;
+
+export const Header = styled.header`
+  font-size: 1.5rem;
+`;
+
+export const Title = styled.div`
+  font-size: 1.2rem;
+  align-items: center;
+  justify-content: center;
+  margin: 1rem 0 1.5rem 0;
+`;
+
+export const FlexWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+export const FlexGapWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+`;
+
+export const SelectButton = styled.button`
+  background-color: #faf9f9;
+  width: 280px;
+  height: 50px;
+  border-radius: 8px;
+  border: 1px solid #cfcfcf;
+  font-size: 1rem;
+  cursor: pointer;
+  box-shadow: 8px 8px 3px -3px #cfcfcf;
+
+  &:focus {
+    background-color: #f6bebe;
+    transition: ease-in 0.2s;
+    box-shadow: none;
+  }
+`;
+
+export const ConfirmButton = styled.button`
+  background-color: #f6bebe;
+  width: 100px;
+  height: 50px;
+  border-radius: 8px;
+  border: 2px solid #f6bebe;
+  font-size: 1rem;
+  cursor: pointer;
+  box-shadow: 8px 8px 3px -3px #cfcfcf;
+`;
+
+export const EditButton = styled(ConfirmButton)`
+  background-color: #faf9f9;
+`;
+
+export const ConfirmInfo = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: #f6bebe;
+  width: 280px;
+  height: 50px;
+  border-radius: 8px;
+  border: 1px solid #cfcfcf;
+  font-size: 1rem;
+`;
+
+export const FlexRowWrapper = styled.div`
+  margin-top: 3rem;
+  display: flex;
+  gap: 1rem;
+`;

--- a/frontend/src/pages/Register/Register.tsx
+++ b/frontend/src/pages/Register/Register.tsx
@@ -1,0 +1,111 @@
+import Stepper from '@/components/common/Stepper/Stepper';
+import * as S from '@/pages/Register/Register.style';
+import { useState } from 'react';
+
+type Careers = ['경력 없음', '0-2년차', '3-5년차', '5년차 이상'];
+type JobGroups = ['프론트엔드', '백엔드', '모바일', '기타'];
+type UserInfo = {
+  career: string;
+  jobGroup: string;
+};
+
+const messages = {
+  1: '경력을 선택해주세요',
+  2: '직군을 선택해주세요',
+  3: '입력한 정보를 확인해주세요',
+};
+const careers: Careers = ['경력 없음', '0-2년차', '3-5년차', '5년차 이상'];
+const jobGroups: JobGroups = ['프론트엔드', '백엔드', '모바일', '기타'];
+
+function Register() {
+  const [step, setStep] = useState<number>(1);
+  const [additionalInfo, setAdditionalInfo] = useState<UserInfo>({
+    career: null,
+    jobGroup: null,
+  });
+
+  const renderSelectButton = (step: number) => {
+    switch (step) {
+      case 1:
+        return careers;
+      case 2:
+        return jobGroups;
+    }
+  };
+
+  const handleSelectButtonClick: React.MouseEventHandler<HTMLButtonElement> = (
+    e
+  ) => {
+    if (!(e.target instanceof HTMLElement)) return;
+
+    if (step === 1) {
+      setAdditionalInfo({
+        ...additionalInfo,
+        career: e.target.textContent,
+      });
+    } else {
+      setAdditionalInfo({
+        ...additionalInfo,
+        jobGroup: e.target.textContent,
+      });
+    }
+  };
+
+  const handleConfirmButtonClick = () => {
+    if (step === 1 && additionalInfo.career === null) {
+      alert('경력을 선택해주세요.');
+      return;
+    }
+    if (step === 2 && additionalInfo.jobGroup === null) {
+      alert('직군을 선택해주세요.');
+      return;
+    }
+    if (step === 1 || step === 2) {
+      setStep(step + 1);
+      return;
+    }
+    confirm(
+      `${additionalInfo.career}, ${additionalInfo.jobGroup} 개발자이신가요?`
+    );
+  };
+
+  const handleEditButtonClick = () => {
+    setStep(1);
+  };
+
+  return (
+    <S.Container>
+      <S.Header>추가 정보 입력하기</S.Header>
+      <Stepper step={step} />
+      <S.FlexWrapper>
+        <S.Title>{messages[step]}</S.Title>
+        <S.FlexGapWrapper>
+          {(step === 1 || step === 2) &&
+            renderSelectButton(step).map((content, index: number) => (
+              <S.SelectButton key={index} onClick={handleSelectButtonClick}>
+                {content}
+              </S.SelectButton>
+            ))}
+          {step === 3 && (
+            <>
+              <S.ConfirmInfo>{additionalInfo.career}</S.ConfirmInfo>
+              <S.ConfirmInfo>{additionalInfo.jobGroup}</S.ConfirmInfo>
+            </>
+          )}
+        </S.FlexGapWrapper>
+        <S.FlexRowWrapper>
+          {step === 3 && (
+            <S.EditButton onClick={handleEditButtonClick}>
+              수정하기
+            </S.EditButton>
+          )}
+          <S.ConfirmButton onClick={handleConfirmButtonClick}>
+            {step === 1 || step === 2 ? '선택 완료' : '제출하기'}
+          </S.ConfirmButton>
+        </S.FlexRowWrapper>
+      </S.FlexWrapper>
+    </S.Container>
+  );
+}
+
+export default Register;

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -2,6 +2,8 @@ import PageLayout from '@/pages/common/PageLayout/PageLayout';
 import Home from '@/pages/Home/Home';
 import Product from '@/pages/Product/Product';
 import Products from '@/pages/Products/Products';
+import Login from '@/components/Login/Login';
+import Register from './Register/Register';
 import ROUTES from '@/constants/routes';
 
 export const PAGES = [
@@ -11,6 +13,8 @@ export const PAGES = [
       { path: ROUTES.HOME, element: <Home /> },
       { path: ROUTES.PRODUCTS, element: <Products /> },
       { path: `${ROUTES.PRODUCT}/:productId`, element: <Product /> },
+      { path: ROUTES.LOGIN, element: <Login /> },
+      { path: ROUTES.REGISTER, element: <Register /> },
     ],
   },
 ];


### PR DESCRIPTION
# issue: #133 

# 작업 내용
- InventoryProduct의 id를 이용해서 대표 장비를 업데이트한다.
  - InventoryProduct는 MemberId를 간접 참조한다.
  - InventoryProduct는 Keyboard를 다대일 단방향 매핑한다.
  - 대표 장비를 업데이트할 때 selected로 들어온 요청은 모두 isSelected를 true로 변경하고, unselected로 들어온 요청은 모두 false로 변경한다. 
