### PR TITLE
[BE] 대표 장비를 업데이트 하는 기능 구현

### DIFF
--- a/backend/src/docs/asciidoc/index.adoc
+++ b/backend/src/docs/asciidoc/index.adoc
@@ -6,5 +6,6 @@
 = F12
 
 include::auth.adoc[]
+include::members.adoc[]
 include::keyboards.adoc[]
 include::reviews.adoc[]

--- a/backend/src/docs/asciidoc/members.adoc
+++ b/backend/src/docs/asciidoc/members.adoc
@@ -1,0 +1,6 @@
+[[Member]]
+== Member API
+
+=== Member 대표 장비 업데이트
+
+operation::member-inventoryProduct-update[snippets='http-request,http-response']

--- a/backend/src/main/java/com/woowacourse/f12/application/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/MemberService.java
@@ -27,10 +27,10 @@ public class MemberService {
     public void updateProfileProducts(final Long memberId, final ProfileProductRequest profileProductRequest) {
         validateMember(memberId);
         if (!Objects.isNull(profileProductRequest.getSelectedInventoryProductId())) {
-            updateProfileProduct(profileProductRequest.getSelectedInventoryProductId());
+            updateProfileProduct(profileProductRequest.getSelectedInventoryProductId(), true);
         }
         if (!Objects.isNull(profileProductRequest.getUnselectedInventoryProductId())) {
-            updateProfileProduct(profileProductRequest.getUnselectedInventoryProductId());
+            updateProfileProduct(profileProductRequest.getUnselectedInventoryProductId(), false);
         }
     }
 
@@ -39,9 +39,9 @@ public class MemberService {
                 .orElseThrow(MemberNotFoundException::new);
     }
 
-    private void updateProfileProduct(final Long inventoryItemId) {
+    private void updateProfileProduct(final Long inventoryItemId, final boolean isSelected) {
         final InventoryProduct inventoryProduct = inventoryProductRepository.findById(inventoryItemId)
                 .orElseThrow(InventoryItemNotFoundException::new);
-        inventoryProduct.updateIsSelected();
+        inventoryProduct.updateIsSelected(isSelected);
     }
 }

--- a/backend/src/main/java/com/woowacourse/f12/application/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/MemberService.java
@@ -1,0 +1,47 @@
+package com.woowacourse.f12.application;
+
+import com.woowacourse.f12.domain.InventoryProduct;
+import com.woowacourse.f12.domain.InventoryProductRepository;
+import com.woowacourse.f12.domain.MemberRepository;
+import com.woowacourse.f12.dto.request.ProfileProductRequest;
+import com.woowacourse.f12.exception.InventoryItemNotFoundException;
+import com.woowacourse.f12.exception.MemberNotFoundException;
+import java.util.Objects;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+    private final InventoryProductRepository inventoryProductRepository;
+
+    public MemberService(final MemberRepository memberRepository,
+                         final InventoryProductRepository inventoryProductRepository) {
+        this.memberRepository = memberRepository;
+        this.inventoryProductRepository = inventoryProductRepository;
+    }
+
+    @Transactional
+    public void updateProfileProducts(final Long memberId, final ProfileProductRequest profileProductRequest) {
+        validateMember(memberId);
+        if (!Objects.isNull(profileProductRequest.getSelectedInventoryProductId())) {
+            updateProfileProduct(profileProductRequest.getSelectedInventoryProductId());
+        }
+        if (!Objects.isNull(profileProductRequest.getUnselectedInventoryProductId())) {
+            updateProfileProduct(profileProductRequest.getUnselectedInventoryProductId());
+        }
+    }
+
+    private void validateMember(final Long memberId) {
+        memberRepository.findById(memberId)
+                .orElseThrow(MemberNotFoundException::new);
+    }
+
+    private void updateProfileProduct(final Long inventoryItemId) {
+        final InventoryProduct inventoryProduct = inventoryProductRepository.findById(inventoryItemId)
+                .orElseThrow(InventoryItemNotFoundException::new);
+        inventoryProduct.updateIsSelected();
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/domain/InventoryProduct.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/InventoryProduct.java
@@ -33,8 +33,8 @@ public class InventoryProduct {
     protected InventoryProduct() {
     }
 
-    public void updateIsSelected() {
-        this.isSelected = !this.isSelected;
+    public void updateIsSelected(boolean isSelected) {
+        this.isSelected = isSelected;
     }
 
     @Builder

--- a/backend/src/main/java/com/woowacourse/f12/domain/InventoryProduct.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/InventoryProduct.java
@@ -1,0 +1,47 @@
+package com.woowacourse.f12.domain;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import lombok.Builder;
+import lombok.Getter;
+
+@Entity
+@Table(name = "inventroy_product")
+@Getter
+public class InventoryProduct {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "is_selected")
+    private boolean isSelected;
+
+    @Column(name = "member_id")
+    private Long memberId;
+
+    @ManyToOne
+    @JoinColumn(name = "keyboard_id")
+    private Keyboard keyboard;
+
+    protected InventoryProduct() {
+    }
+
+    public void updateIsSelected() {
+        this.isSelected = !this.isSelected;
+    }
+
+    @Builder
+    private InventoryProduct(final Long id, final boolean isSelected, final Long memberId, final Keyboard keyboard) {
+        this.id = id;
+        this.isSelected = isSelected;
+        this.memberId = memberId;
+        this.keyboard = keyboard;
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/domain/InventoryProductRepository.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/InventoryProductRepository.java
@@ -1,0 +1,7 @@
+package com.woowacourse.f12.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface InventoryProductRepository extends JpaRepository<InventoryProduct, Long> {
+
+}

--- a/backend/src/main/java/com/woowacourse/f12/domain/Member.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/Member.java
@@ -25,7 +25,7 @@ public class Member {
     @Column(name = "github_id", nullable = false)
     private String gitHubId;
 
-    @Column(name = "name", nullable = false)
+    @Column(name = "name")
     private String name;
 
     @Column(name = "image_url", nullable = false)

--- a/backend/src/main/java/com/woowacourse/f12/dto/request/ProfileProductRequest.java
+++ b/backend/src/main/java/com/woowacourse/f12/dto/request/ProfileProductRequest.java
@@ -1,0 +1,18 @@
+package com.woowacourse.f12.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class ProfileProductRequest {
+
+    private Long selectedInventoryProductId;
+    private Long unselectedInventoryProductId;
+
+    private ProfileProductRequest() {
+    }
+
+    public ProfileProductRequest(final Long selectedInventoryProductId, final Long unselectedInventoryProductId) {
+        this.selectedInventoryProductId = selectedInventoryProductId;
+        this.unselectedInventoryProductId = unselectedInventoryProductId;
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/exception/InventoryItemNotFoundException.java
+++ b/backend/src/main/java/com/woowacourse/f12/exception/InventoryItemNotFoundException.java
@@ -1,0 +1,8 @@
+package com.woowacourse.f12.exception;
+
+public class InventoryItemNotFoundException extends NotFoundException {
+
+    public InventoryItemNotFoundException() {
+        super("등록 장비를 찾을 수 없습니다.");
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/presentation/MemberController.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/MemberController.java
@@ -1,0 +1,28 @@
+package com.woowacourse.f12.presentation;
+
+import com.woowacourse.f12.application.MemberService;
+import com.woowacourse.f12.dto.request.ProfileProductRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/members")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    public MemberController(final MemberService memberService) {
+        this.memberService = memberService;
+    }
+
+    @PatchMapping("/inventoryProducts")
+    @LoginRequired
+    public ResponseEntity<Void> updateProfileProducts(@RequestBody final ProfileProductRequest profileProductRequest,
+                                                      @VerifiedMember final Long memberId) {
+        memberService.updateProfileProducts(memberId, profileProductRequest);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/backend/src/test/java/com/woowacourse/f12/acceptance/MemberAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/acceptance/MemberAcceptanceTest.java
@@ -1,0 +1,54 @@
+package com.woowacourse.f12.acceptance;
+
+import static com.woowacourse.f12.acceptance.support.RestAssuredRequestUtil.GET_요청을_보낸다;
+import static com.woowacourse.f12.acceptance.support.RestAssuredRequestUtil.로그인된_상태로_PATCH_요청을_보낸다;
+import static com.woowacourse.f12.support.KeyboardFixtures.KEYBOARD_1;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.woowacourse.f12.domain.InventoryProduct;
+import com.woowacourse.f12.domain.InventoryProductRepository;
+import com.woowacourse.f12.domain.Keyboard;
+import com.woowacourse.f12.domain.KeyboardRepository;
+import com.woowacourse.f12.dto.request.ProfileProductRequest;
+import com.woowacourse.f12.dto.response.LoginResponse;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+
+public class MemberAcceptanceTest extends AcceptanceTest {
+
+    @Autowired
+    private KeyboardRepository keyboardRepository;
+
+    @Autowired
+    private InventoryProductRepository inventoryProductRepository;
+
+    @Test
+    void 대표_장비가_없는_상태에서_대표_장비를_등록한다() {
+        // given
+        Keyboard keyboard = 키보드를_저장한다(KEYBOARD_1.생성());
+        ExtractableResponse<Response> response = GET_요청을_보낸다("/api/v1/login?code=dkasjbdkjas");
+        String token = response.as(LoginResponse.class).getToken();
+        Long memberId = response.as(LoginResponse.class).getMember().getId();
+
+        InventoryProduct inventoryProduct = InventoryProduct.builder()
+                .memberId(memberId)
+                .keyboard(keyboard)
+                .build();
+        InventoryProduct savedInventoryProduct = inventoryProductRepository.save(inventoryProduct);
+
+        // when
+        ExtractableResponse<Response> saveProfileProductResponse = 로그인된_상태로_PATCH_요청을_보낸다(
+                "api/v1/members/inventoryProducts", token,
+                new ProfileProductRequest(savedInventoryProduct.getId(), null));
+
+        // then
+        assertThat(saveProfileProductResponse.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
+
+    private Keyboard 키보드를_저장한다(Keyboard keyboard) {
+        return keyboardRepository.save(keyboard);
+    }
+}

--- a/backend/src/test/java/com/woowacourse/f12/acceptance/support/RestAssuredRequestUtil.java
+++ b/backend/src/test/java/com/woowacourse/f12/acceptance/support/RestAssuredRequestUtil.java
@@ -30,4 +30,16 @@ public class RestAssuredRequestUtil {
                 .then().log().all()
                 .extract();
     }
+
+    public static ExtractableResponse<Response> 로그인된_상태로_PATCH_요청을_보낸다(final String url, final String token,
+                                                                       final Object requestBody) {
+        return RestAssured.given().log().all()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(requestBody)
+                .when()
+                .patch(url)
+                .then().log().all()
+                .extract();
+    }
 }

--- a/backend/src/test/java/com/woowacourse/f12/application/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/application/MemberServiceTest.java
@@ -1,0 +1,66 @@
+package com.woowacourse.f12.application;
+
+import static com.woowacourse.f12.support.KeyboardFixtures.KEYBOARD_1;
+import static com.woowacourse.f12.support.KeyboardFixtures.KEYBOARD_2;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.verify;
+
+import com.woowacourse.f12.domain.InventoryProduct;
+import com.woowacourse.f12.domain.InventoryProductRepository;
+import com.woowacourse.f12.domain.MemberRepository;
+import com.woowacourse.f12.dto.request.ProfileProductRequest;
+import com.woowacourse.f12.support.MemberFixtures;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MemberServiceTest {
+
+    @Mock
+    private InventoryProductRepository inventoryProductRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @InjectMocks
+    private MemberService memberService;
+
+    @Test
+    void 대표_장비를_등록한다() {
+        // given
+        ProfileProductRequest profileProductRequest = new ProfileProductRequest(1L, 2L);
+        InventoryProduct selectInventoryProduct = InventoryProduct.builder()
+                .id(1L)
+                .memberId(1L)
+                .keyboard(KEYBOARD_1.생성())
+                .isSelected(false)
+                .build();
+        InventoryProduct unselectInventoryProduct = InventoryProduct.builder()
+                .id(2L)
+                .memberId(1L)
+                .keyboard(KEYBOARD_2.생성())
+                .isSelected(true)
+                .build();
+        given(memberRepository.findById(1L))
+                .willReturn(Optional.of(MemberFixtures.CORINNE.생성(1L)));
+        given(inventoryProductRepository.findById(1L))
+                .willReturn(Optional.of(selectInventoryProduct));
+        given(inventoryProductRepository.findById(2L))
+                .willReturn(Optional.of(unselectInventoryProduct));
+
+        // when
+        memberService.updateProfileProducts(1L, profileProductRequest);
+
+        // then
+        assertAll(
+                () -> verify(memberRepository).findById(1L),
+                () -> verify(inventoryProductRepository).findById(1L),
+                () -> verify(inventoryProductRepository).findById(2L)
+        );
+    }
+}

--- a/backend/src/test/java/com/woowacourse/f12/documentation/MemberDocumentation.java
+++ b/backend/src/test/java/com/woowacourse/f12/documentation/MemberDocumentation.java
@@ -1,0 +1,65 @@
+package com.woowacourse.f12.documentation;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.woowacourse.f12.application.JwtProvider;
+import com.woowacourse.f12.application.MemberService;
+import com.woowacourse.f12.dto.request.ProfileProductRequest;
+import com.woowacourse.f12.presentation.MemberController;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@WebMvcTest(MemberController.class)
+class MemberDocumentation extends Documentation {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private MemberService memberService;
+
+    @MockBean
+    private JwtProvider jwtProvider;
+
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void 대표_장비를_등록하는_API_문서화() throws Exception {
+        // given
+        String authorizationHeader = "Bearer Token";
+        given(jwtProvider.validateToken(authorizationHeader))
+                .willReturn(true);
+        given(jwtProvider.getPayload(authorizationHeader))
+                .willReturn("1");
+        Long memberId = 1L;
+        ProfileProductRequest profileProductRequest = new ProfileProductRequest(1L, 2L);
+        willDoNothing().given(memberService).updateProfileProducts(memberId, profileProductRequest);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                patch("/api/v1/members/inventoryProducts")
+                        .header(HttpHeaders.AUTHORIZATION, authorizationHeader)
+                        .content(objectMapper.writeValueAsString(profileProductRequest))
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        );
+
+        // then
+        resultActions.andExpect(status().isOk())
+                .andDo(print())
+                .andDo(
+                        document("member-inventoryProduct-update")
+                );
+    }
+}

--- a/backend/src/test/java/com/woowacourse/f12/presentation/MemberControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/MemberControllerTest.java
@@ -1,0 +1,99 @@
+package com.woowacourse.f12.presentation;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.woowacourse.f12.application.JwtProvider;
+import com.woowacourse.f12.application.MemberService;
+import com.woowacourse.f12.dto.request.ProfileProductRequest;
+import com.woowacourse.f12.exception.InventoryItemNotFoundException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(MemberController.class)
+class MemberControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private MemberService memberService;
+
+    @MockBean
+    private JwtProvider jwtProvider;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void 대표_장비_등록_성공() throws Exception {
+        // given
+        String authorizationHeader = "Bearer Token";
+        given(jwtProvider.validateToken(authorizationHeader))
+                .willReturn(true);
+        given(jwtProvider.getPayload(authorizationHeader))
+                .willReturn("1");
+        ProfileProductRequest profileProductRequest = new ProfileProductRequest(1L, 2L);
+        willDoNothing().given(memberService).updateProfileProducts(1L, profileProductRequest);
+
+        // when
+        mockMvc.perform(
+                        patch("/api/v1/members/inventoryProducts")
+                                .header(HttpHeaders.AUTHORIZATION, authorizationHeader)
+                                .content(objectMapper.writeValueAsString(profileProductRequest))
+                                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                )
+                .andExpect(status().isOk())
+                .andDo(print());
+
+        // then
+        assertAll(
+                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).getPayload(authorizationHeader),
+                () -> verify(memberService).updateProfileProducts(anyLong(), any(ProfileProductRequest.class))
+        );
+    }
+
+    @Test
+    void 대표_장비_등록_실패_인벤토리_상품_id가_없는_경우() throws Exception {
+        // given
+        String authorizationHeader = "Bearer Token";
+        given(jwtProvider.validateToken(authorizationHeader))
+                .willReturn(true);
+        given(jwtProvider.getPayload(authorizationHeader))
+                .willReturn("1");
+        ProfileProductRequest profileProductRequest = new ProfileProductRequest(1L, 2L);
+        willThrow(new InventoryItemNotFoundException()).given(memberService)
+                .updateProfileProducts(anyLong(), any(ProfileProductRequest.class));
+
+        // when
+        mockMvc.perform(
+                        patch("/api/v1/members/inventoryProducts")
+                                .header(HttpHeaders.AUTHORIZATION, authorizationHeader)
+                                .content(objectMapper.writeValueAsString(profileProductRequest))
+                                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                )
+                .andExpect(status().isNotFound())
+                .andDo(print());
+
+        // then
+        assertAll(
+                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).getPayload(authorizationHeader),
+                () -> verify(memberService).updateProfileProducts(anyLong(), any(ProfileProductRequest.class))
+        );
+    }
+}


### PR DESCRIPTION
# issue: #133 

# 작업 내용
- InventoryProduct의 id를 이용해서 대표 장비를 업데이트한다.
  - InventoryProduct는 MemberId를 간접 참조한다.
  - InventoryProduct는 Keyboard를 다대일 단방향 매핑한다.
  - 대표 장비를 업데이트할 때 selected로 들어온 요청은 모두 isSelected를 true로 변경하고, unselected로 들어온 요청은 모두 false로 변경한다.