### PR TITLE
[BE] 리뷰 삭제 기능 구현

### DIFF
--- a/backend/src/docs/asciidoc/reviews.adoc
+++ b/backend/src/docs/asciidoc/reviews.adoc
@@ -22,3 +22,7 @@ operation::reviews-by-product-page-get[snippets='http-request,http-response']
 - `rating,desc`(평점순)
 
 operation::reviews-page-get[snippets='http-request,http-response']
+
+=== 리뷰 삭제
+
+operation::reviews-delete[snippets='http-request,http-response']

--- a/backend/src/main/java/com/woowacourse/f12/application/ReviewService.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/ReviewService.java
@@ -34,7 +34,7 @@ public class ReviewService {
     }
 
     @Transactional
-    public Long save(final Long productId, final ReviewRequest reviewRequest, final Long memberId) {
+    public Long save(final Long productId, final Long memberId, final ReviewRequest reviewRequest) {
         final Keyboard keyboard = keyboardRepository.findById(productId)
                 .orElseThrow(KeyboardNotFoundException::new);
         final Member member = memberRepository.findById(memberId)

--- a/backend/src/main/java/com/woowacourse/f12/application/ReviewService.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/ReviewService.java
@@ -61,6 +61,7 @@ public class ReviewService {
         return ReviewWithProductPageResponse.from(page);
     }
 
+    @Transactional
     public void delete(final Long reviewId, final Long memberId) {
         final Member member = memberRepository.findById(memberId)
                 .orElseThrow(MemberNotFoundException::new);

--- a/backend/src/main/java/com/woowacourse/f12/application/ReviewService.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/ReviewService.java
@@ -11,6 +11,8 @@ import com.woowacourse.f12.dto.response.ReviewPageResponse;
 import com.woowacourse.f12.dto.response.ReviewWithProductPageResponse;
 import com.woowacourse.f12.exception.KeyboardNotFoundException;
 import com.woowacourse.f12.exception.MemberNotFoundException;
+import com.woowacourse.f12.exception.NotAuthorException;
+import com.woowacourse.f12.exception.ReviewNotFoundException;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -57,5 +59,16 @@ public class ReviewService {
     public ReviewWithProductPageResponse findPage(final Pageable pageable) {
         final Slice<Review> page = reviewRepository.findPageBy(pageable);
         return ReviewWithProductPageResponse.from(page);
+    }
+
+    public void delete(final Long reviewId, final Long memberId) {
+        final Member member = memberRepository.findById(memberId)
+                .orElseThrow(MemberNotFoundException::new);
+        final Review target = reviewRepository.findById(reviewId)
+                .orElseThrow(ReviewNotFoundException::new);
+        if (!target.isWrittenBy(member)) {
+            throw new NotAuthorException();
+        }
+        reviewRepository.delete(target);
     }
 }

--- a/backend/src/main/java/com/woowacourse/f12/domain/Keyboard.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/Keyboard.java
@@ -51,11 +51,11 @@ public class Keyboard {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (!(o instanceof Keyboard)) {
             return false;
         }
         final Keyboard keyboard = (Keyboard) o;
-        return Objects.equals(id, keyboard.id);
+        return Objects.equals(id, keyboard.getId());
     }
 
     @Override

--- a/backend/src/main/java/com/woowacourse/f12/domain/Member.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/Member.java
@@ -51,11 +51,11 @@ public class Member {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (!(o instanceof Member)) {
             return false;
         }
         final Member member = (Member) o;
-        return Objects.equals(id, member.id);
+        return Objects.equals(id, member.getId());
     }
 
     @Override

--- a/backend/src/main/java/com/woowacourse/f12/domain/Review.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/Review.java
@@ -83,6 +83,10 @@ public class Review {
         }
     }
 
+    public boolean isWrittenBy(final Member member) {
+        return this.member.equals(member);
+    }
+
     @Override
     public boolean equals(final Object o) {
         if (this == o) {

--- a/backend/src/main/java/com/woowacourse/f12/exception/ForbiddenMemberException.java
+++ b/backend/src/main/java/com/woowacourse/f12/exception/ForbiddenMemberException.java
@@ -1,0 +1,8 @@
+package com.woowacourse.f12.exception;
+
+public class ForbiddenMemberException extends RuntimeException {
+
+    public ForbiddenMemberException(final String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/exception/NotAuthorException.java
+++ b/backend/src/main/java/com/woowacourse/f12/exception/NotAuthorException.java
@@ -1,0 +1,8 @@
+package com.woowacourse.f12.exception;
+
+public class NotAuthorException extends ForbiddenMemberException {
+
+    public NotAuthorException() {
+        super("리뷰의 작성자가 아닙니다.");
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/exception/ReviewNotFoundException.java
+++ b/backend/src/main/java/com/woowacourse/f12/exception/ReviewNotFoundException.java
@@ -1,0 +1,8 @@
+package com.woowacourse.f12.exception;
+
+public class ReviewNotFoundException extends NotFoundException {
+
+    public ReviewNotFoundException() {
+        super("리뷰를 찾을 수 없습니다.");
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/presentation/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.woowacourse.f12.presentation;
 
 import com.woowacourse.f12.dto.response.ExceptionResponse;
+import com.woowacourse.f12.exception.ForbiddenMemberException;
 import com.woowacourse.f12.exception.InvalidValueException;
 import com.woowacourse.f12.exception.NotFoundException;
 import com.woowacourse.f12.exception.UnauthorizedException;
@@ -44,8 +45,13 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(UnauthorizedException.class)
-    public ResponseEntity<ExceptionResponse> handleUnAuthorizedException(final UnauthorizedException e) {
+    public ResponseEntity<ExceptionResponse> handleUnauthorizedException(final UnauthorizedException e) {
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ExceptionResponse.from(e));
+    }
+
+    @ExceptionHandler(ForbiddenMemberException.class)
+    public ResponseEntity<ExceptionResponse> handleForbiddenMemberException(final ForbiddenMemberException e) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ExceptionResponse.from(e));
     }
 
     @ExceptionHandler(Exception.class)

--- a/backend/src/main/java/com/woowacourse/f12/presentation/ReviewController.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/ReviewController.java
@@ -28,9 +28,9 @@ public class ReviewController {
     @PostMapping("/keyboards/{productId}/reviews")
     @LoginRequired
     public ResponseEntity<Void> create(@PathVariable final Long productId,
-                                       @Valid @RequestBody final ReviewRequest reviewRequest,
-                                       @VerifiedMember final Long memberId) {
-        final Long id = reviewService.save(productId, reviewRequest, memberId);
+                                       @VerifiedMember final Long memberId,
+                                       @Valid @RequestBody final ReviewRequest reviewRequest) {
+        final Long id = reviewService.save(productId, memberId, reviewRequest);
         return ResponseEntity.created(URI.create("/api/v1/reviews/" + id))
                 .build();
     }

--- a/backend/src/main/java/com/woowacourse/f12/presentation/ReviewController.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/ReviewController.java
@@ -8,6 +8,7 @@ import java.net.URI;
 import javax.validation.Valid;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -46,5 +47,12 @@ public class ReviewController {
     public ResponseEntity<ReviewWithProductPageResponse> showPage(final Pageable pageable) {
         final ReviewWithProductPageResponse reviewWithProductPageResponse = reviewService.findPage(pageable);
         return ResponseEntity.ok(reviewWithProductPageResponse);
+    }
+
+    @DeleteMapping("/reviews/{reviewId}")
+    @LoginRequired
+    public ResponseEntity<Void> delete(@PathVariable final Long reviewId, @VerifiedMember final Long memberId) {
+        reviewService.delete(reviewId, memberId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/test/java/com/woowacourse/f12/acceptance/support/RestAssuredRequestUtil.java
+++ b/backend/src/test/java/com/woowacourse/f12/acceptance/support/RestAssuredRequestUtil.java
@@ -30,4 +30,13 @@ public class RestAssuredRequestUtil {
                 .then().log().all()
                 .extract();
     }
+
+    public static ExtractableResponse<Response> 로그인된_상태로_DELETE_요청을_보낸다(final String url, final String token) {
+        return RestAssured.given().log().all()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                .when()
+                .delete(url)
+                .then().log().all()
+                .extract();
+    }
 }

--- a/backend/src/test/java/com/woowacourse/f12/application/ReviewServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/application/ReviewServiceTest.java
@@ -73,7 +73,7 @@ class ReviewServiceTest {
                 .willReturn(REVIEW_RATING_5.작성(1L, keyboard, member));
 
         // when
-        Long reviewId = reviewService.save(productId, reviewRequest, 1L);
+        Long reviewId = reviewService.save(productId, 1L, reviewRequest);
 
         // then
         assertAll(
@@ -94,7 +94,7 @@ class ReviewServiceTest {
 
         // when, then
         assertAll(
-                () -> assertThatThrownBy(() -> reviewService.save(1L, reviewRequest, 1L))
+                () -> assertThatThrownBy(() -> reviewService.save(1L, 1L, reviewRequest))
                         .isExactlyInstanceOf(KeyboardNotFoundException.class),
                 () -> verify(keyboardRepository).findById(productId),
                 () -> verify(reviewRepository, times(0)).save(any(Review.class))
@@ -115,7 +115,7 @@ class ReviewServiceTest {
                 .willReturn(Optional.empty());
 
         assertAll(
-                () -> assertThatThrownBy(() -> reviewService.save(keyboardId, reviewRequest, memberId)),
+                () -> assertThatThrownBy(() -> reviewService.save(keyboardId, memberId, reviewRequest)),
                 () -> verify(keyboardRepository).findById(keyboardId),
                 () -> verify(memberRepository).findById(memberId),
                 () -> verify(reviewRepository, times(0)).save(any(Review.class))

--- a/backend/src/test/java/com/woowacourse/f12/documentation/ReviewDocumentation.java
+++ b/backend/src/test/java/com/woowacourse/f12/documentation/ReviewDocumentation.java
@@ -59,7 +59,7 @@ public class ReviewDocumentation extends Documentation {
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn("1");
-        given(reviewService.save(anyLong(), any(ReviewRequest.class), anyLong()))
+        given(reviewService.save(anyLong(), anyLong(), any(ReviewRequest.class)))
                 .willReturn(1L);
         ReviewRequest reviewRequest = new ReviewRequest("content", 5);
 
@@ -86,7 +86,9 @@ public class ReviewDocumentation extends Documentation {
         Keyboard keyboard = KEYBOARD_1.생성(1L);
         Member member = CORINNE.생성(1L);
         ReviewPageResponse reviewPageResponse = ReviewPageResponse.from(
-                new SliceImpl<>(List.of(REVIEW_RATING_5.작성(1L, keyboard, member), REVIEW_RATING_4.작성(2L, keyboard, member)), pageable, false));
+                new SliceImpl<>(
+                        List.of(REVIEW_RATING_5.작성(1L, keyboard, member), REVIEW_RATING_4.작성(2L, keyboard, member)),
+                        pageable, false));
 
         given(reviewService.findPageByProductId(anyLong(), any(Pageable.class)))
                 .willReturn(reviewPageResponse);
@@ -113,7 +115,9 @@ public class ReviewDocumentation extends Documentation {
         Keyboard keyboard2 = KEYBOARD_2.생성(2L);
         Member member = CORINNE.생성(1L);
         ReviewWithProductPageResponse reviewWithProductPageResponse = ReviewWithProductPageResponse.from(
-                new SliceImpl<>(List.of(REVIEW_RATING_5.작성(1L, keyboard1, member), REVIEW_RATING_4.작성(2L, keyboard2, member)), pageable, false));
+                new SliceImpl<>(
+                        List.of(REVIEW_RATING_5.작성(1L, keyboard1, member), REVIEW_RATING_4.작성(2L, keyboard2, member)),
+                        pageable, false));
 
         given(reviewService.findPage(any(Pageable.class)))
                 .willReturn(reviewWithProductPageResponse);

--- a/backend/src/test/java/com/woowacourse/f12/documentation/ReviewDocumentation.java
+++ b/backend/src/test/java/com/woowacourse/f12/documentation/ReviewDocumentation.java
@@ -8,7 +8,9 @@ import static com.woowacourse.f12.support.ReviewFixtures.REVIEW_RATING_5;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -93,11 +95,9 @@ public class ReviewDocumentation extends Documentation {
         given(reviewService.findPageByProductId(anyLong(), any(Pageable.class)))
                 .willReturn(reviewPageResponse);
 
-        // when
+        // when, then
         ResultActions resultActions = mockMvc.perform(
-                        get("/api/v1/keyboards/1/reviews?page=0&size=10&sort=createdAt,desc"))
-                .andExpect(status().isOk())
-                .andDo(print());
+                get("/api/v1/keyboards/1/reviews?page=0&size=10&sort=createdAt,desc"));
 
         // then
         resultActions.andExpect(status().isOk())
@@ -123,15 +123,38 @@ public class ReviewDocumentation extends Documentation {
                 .willReturn(reviewWithProductPageResponse);
 
         // when
-        ResultActions resultActions = mockMvc.perform(get("/api/v1/reviews?page=0&size=10&sort=createdAt,desc"))
-                .andExpect(status().isOk())
-                .andDo(print());
+        ResultActions resultActions = mockMvc.perform(get("/api/v1/reviews?page=0&size=10&sort=createdAt,desc"));
 
         // then
         resultActions.andExpect(status().isOk())
                 .andDo(print())
                 .andDo(
                         document("reviews-page-get")
+                );
+    }
+
+    @Test
+    void 리뷰_삭제_API_문서화() throws Exception {
+        // given
+        Long reviewId = 1L;
+        Long memberId = 1L;
+        String authorizationHeader = "Bearer Token";
+        given(jwtProvider.validateToken(authorizationHeader))
+                .willReturn(true);
+        given(jwtProvider.getPayload(authorizationHeader))
+                .willReturn(memberId.toString());
+        willDoNothing().given(reviewService)
+                .delete(reviewId, memberId);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(delete("/api/v1/reviews/" + reviewId)
+                .header(HttpHeaders.AUTHORIZATION, authorizationHeader));
+
+        // then
+        resultActions.andExpect(status().isNoContent())
+                .andDo(print())
+                .andDo(
+                        document("reviews-delete")
                 );
     }
 }

--- a/backend/src/test/java/com/woowacourse/f12/domain/ReviewTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/domain/ReviewTest.java
@@ -8,6 +8,7 @@ import com.woowacourse.f12.exception.InvalidContentLengthException;
 import com.woowacourse.f12.exception.InvalidRatingValueException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.EmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -75,5 +76,28 @@ class ReviewTest {
                 .content(invalidContent)
                 .build())
                 .isExactlyInstanceOf(BlankContentException.class);
+    }
+
+    @ParameterizedTest
+    @CsvSource({"1, true", "2, false"})
+    void 리뷰의_작성자인지_반환한다(Long targetMemberId, boolean expected) {
+        // given
+        Member author = Member.builder()
+                .id(1L)
+                .build();
+        Member targetMember = Member.builder()
+                .id(targetMemberId)
+                .build();
+        Review review = Review.builder()
+                .member(author)
+                .content("내용")
+                .rating(5)
+                .build();
+
+        // when
+        boolean actual = review.isWrittenBy(targetMember);
+
+        // then
+        assertThat(actual).isEqualTo(expected);
     }
 }

--- a/backend/src/test/java/com/woowacourse/f12/presentation/AuthInterceptorTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/AuthInterceptorTest.java
@@ -48,7 +48,7 @@ class AuthInterceptorTest {
         String authorizationHeader = "Bearer Token";
         given(jwtProvider.validateToken(authorizationHeader))
                 .willReturn(false);
-        given(reviewService.save(anyLong(), any(ReviewRequest.class), anyLong()))
+        given(reviewService.save(anyLong(), anyLong(), any(ReviewRequest.class)))
                 .willReturn(1L);
         // when
         mockMvc.perform(
@@ -62,7 +62,7 @@ class AuthInterceptorTest {
         // then
         assertAll(
                 () -> verify(jwtProvider).validateToken(authorizationHeader),
-                () -> verify(reviewService, times(0)).save(eq(1L), any(ReviewRequest.class), eq(1L))
+                () -> verify(reviewService, times(0)).save(eq(1L), eq(1L), any(ReviewRequest.class))
         );
     }
 }

--- a/backend/src/test/java/com/woowacourse/f12/presentation/ReviewControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/ReviewControllerTest.java
@@ -72,7 +72,7 @@ class ReviewControllerTest {
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn("1");
-        given(reviewService.save(anyLong(), any(ReviewRequest.class), anyLong()))
+        given(reviewService.save(anyLong(), anyLong(), any(ReviewRequest.class)))
                 .willReturn(1L);
         // when
         mockMvc.perform(
@@ -87,7 +87,7 @@ class ReviewControllerTest {
         assertAll(
                 () -> verify(jwtProvider).validateToken(authorizationHeader),
                 () -> verify(jwtProvider).getPayload(authorizationHeader),
-                () -> verify(reviewService).save(eq(PRODUCT_ID), any(ReviewRequest.class), eq(1L))
+                () -> verify(reviewService).save(eq(PRODUCT_ID), eq(1L), any(ReviewRequest.class))
         );
     }
 
@@ -98,7 +98,7 @@ class ReviewControllerTest {
         String authorizationHeader = "Bearer Token";
         given(jwtProvider.validateToken(authorizationHeader))
                 .willReturn(true);
-        given(reviewService.save(anyLong(), any(ReviewRequest.class), anyLong()))
+        given(reviewService.save(anyLong(), anyLong(), any(ReviewRequest.class)))
                 .willThrow(new BlankContentException());
 
         // when
@@ -113,7 +113,7 @@ class ReviewControllerTest {
         // then
         assertAll(
                 () -> verify(jwtProvider).validateToken(authorizationHeader),
-                () -> verify(reviewService, times(0)).save(eq(PRODUCT_ID), any(ReviewRequest.class), eq(1L))
+                () -> verify(reviewService, times(0)).save(eq(PRODUCT_ID), eq(1L), any(ReviewRequest.class))
         );
     }
 
@@ -126,7 +126,7 @@ class ReviewControllerTest {
         reviewRequest.put("rating", "문자");
         given(jwtProvider.validateToken(authorizationHeader))
                 .willReturn(true);
-        given(reviewService.save(anyLong(), any(ReviewRequest.class), anyLong()))
+        given(reviewService.save(anyLong(), anyLong(), any(ReviewRequest.class)))
                 .willThrow(new BlankContentException());
 
         // when
@@ -141,7 +141,7 @@ class ReviewControllerTest {
         // then
         assertAll(
                 () -> verify(jwtProvider).validateToken(authorizationHeader),
-                () -> verify(reviewService, times(0)).save(eq(PRODUCT_ID), any(ReviewRequest.class), eq(1L))
+                () -> verify(reviewService, times(0)).save(eq(PRODUCT_ID), eq(1L), any(ReviewRequest.class))
         );
     }
 
@@ -154,7 +154,7 @@ class ReviewControllerTest {
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn("1");
-        given(reviewService.save(anyLong(), any(ReviewRequest.class), anyLong()))
+        given(reviewService.save(anyLong(), anyLong(), any(ReviewRequest.class)))
                 .willThrow(new BlankContentException());
 
         // when
@@ -170,7 +170,7 @@ class ReviewControllerTest {
         assertAll(
                 () -> verify(jwtProvider).validateToken(authorizationHeader),
                 () -> verify(jwtProvider).getPayload(authorizationHeader),
-                () -> verify(reviewService).save(eq(PRODUCT_ID), any(ReviewRequest.class), eq(1L))
+                () -> verify(reviewService).save(eq(PRODUCT_ID), eq(1L), any(ReviewRequest.class))
         );
     }
 
@@ -184,7 +184,7 @@ class ReviewControllerTest {
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn("1");
-        given(reviewService.save(anyLong(), any(ReviewRequest.class), anyLong()))
+        given(reviewService.save(anyLong(), anyLong(), any(ReviewRequest.class)))
                 .willThrow(new InvalidContentLengthException(1000));
 
         // when
@@ -200,7 +200,7 @@ class ReviewControllerTest {
         assertAll(
                 () -> verify(jwtProvider).validateToken(authorizationHeader),
                 () -> verify(jwtProvider).getPayload(authorizationHeader),
-                () -> verify(reviewService).save(eq(PRODUCT_ID), any(ReviewRequest.class), eq(1L))
+                () -> verify(reviewService).save(eq(PRODUCT_ID), eq(1L), any(ReviewRequest.class))
         );
     }
 
@@ -213,7 +213,7 @@ class ReviewControllerTest {
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn("1");
-        given(reviewService.save(anyLong(), any(ReviewRequest.class), anyLong()))
+        given(reviewService.save(anyLong(), anyLong(), any(ReviewRequest.class)))
                 .willThrow(new InvalidRatingValueException());
 
         // when
@@ -229,7 +229,7 @@ class ReviewControllerTest {
         assertAll(
                 () -> verify(jwtProvider).validateToken(authorizationHeader),
                 () -> verify(jwtProvider).getPayload(authorizationHeader),
-                () -> verify(reviewService).save(eq(PRODUCT_ID), any(ReviewRequest.class), eq(1L))
+                () -> verify(reviewService).save(eq(PRODUCT_ID), eq(1L), any(ReviewRequest.class))
         );
     }
 
@@ -242,7 +242,7 @@ class ReviewControllerTest {
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn("1");
-        given(reviewService.save(anyLong(), any(ReviewRequest.class), anyLong()))
+        given(reviewService.save(anyLong(), anyLong(), any(ReviewRequest.class)))
                 .willThrow(new KeyboardNotFoundException());
 
         // when
@@ -258,7 +258,7 @@ class ReviewControllerTest {
         assertAll(
                 () -> verify(jwtProvider).validateToken(authorizationHeader),
                 () -> verify(jwtProvider).getPayload(authorizationHeader),
-                () -> verify(reviewService).save(eq(0L), any(ReviewRequest.class), eq(1L))
+                () -> verify(reviewService).save(eq(0L), eq(1L), any(ReviewRequest.class))
         );
     }
 
@@ -282,7 +282,8 @@ class ReviewControllerTest {
     void 특정_상품의_리뷰_페이지_조회() throws Exception {
         // given
         given(reviewService.findPageByProductId(anyLong(), any(Pageable.class)))
-                .willReturn(ReviewPageResponse.from(new SliceImpl<>(List.of(REVIEW_RATING_5.작성(1L, KEYBOARD_1.생성(), CORINNE.생성(1L))))));
+                .willReturn(ReviewPageResponse.from(
+                        new SliceImpl<>(List.of(REVIEW_RATING_5.작성(1L, KEYBOARD_1.생성(), CORINNE.생성(1L))))));
 
         // when
         mockMvc.perform(get("/api/v1/keyboards/" + PRODUCT_ID + "/reviews?size=150&page=0&sort=rating,desc"))

--- a/backend/src/test/java/com/woowacourse/f12/support/MemberFixtures.java
+++ b/backend/src/test/java/com/woowacourse/f12/support/MemberFixtures.java
@@ -18,6 +18,10 @@ public enum MemberFixtures {
         this.imageUrl = imageUrl;
     }
 
+    public Member 생성() {
+        return 생성(null);
+    }
+
     public Member 생성(final Long id) {
         return Member.builder()
                 .id(id)


### PR DESCRIPTION
# issue: #143 

# 작업 내용
- 리뷰 삭제 요청 시 로그인한 회원과 리뷰 작성자가 동일하면 리뷰를 삭제하는 기능 구현
- 리뷰 - 회원이 지연 로딩으로 설정되어 있기 때문에 프록시로 인한 동등성 비교 문제가 발생
  - equals 재정의 방식을 변경하여 해결
- 리뷰 삭제 API에 대한 REST Docs 작성
