### PR TITLE
[BugFix] github client ID를 배포용으로 변경

### DIFF
--- a/frontend/src/constants/api.ts
+++ b/frontend/src/constants/api.ts
@@ -2,7 +2,7 @@ export const BASE_URL =
   'http://ec2-52-78-192-78.ap-northeast-2.compute.amazonaws.com:8080/api/v1';
 
 export const GITHUB_AUTH_URL =
-  'https://github.com/login/oauth/authorize?client_id=404072c5857d705db2d9';
+  'https://github.com/login/oauth/authorize?client_id=f1e73a9ac502f1b6712a';
 
 export const ENDPOINTS = {
   PRODUCTS: '/keyboards',


### PR DESCRIPTION
github client ID를 배포용으로 변경
