### PR TITLE
[BE] 회원 관련 기능 리팩토링

### DIFF
--- a/backend/src/docs/asciidoc/members.adoc
+++ b/backend/src/docs/asciidoc/members.adoc
@@ -3,7 +3,7 @@
 
 === 로그인된 상태로 나의 회원 정보 조회
 
-operation::members-get-me[snippets='http-request,http-response']
+operation::members-get-mine[snippets='http-request,http-response']
 
 === 비로그인 상태로 회원 정보 조회
 

--- a/backend/src/main/java/com/woowacourse/f12/application/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/MemberService.java
@@ -5,6 +5,7 @@ import com.woowacourse.f12.domain.Member;
 import com.woowacourse.f12.domain.MemberRepository;
 import com.woowacourse.f12.dto.request.MemberRequest;
 import com.woowacourse.f12.dto.response.MemberResponse;
+import com.woowacourse.f12.exception.InvalidProfileArgumentException;
 import com.woowacourse.f12.exception.MemberNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,6 +22,9 @@ public class MemberService {
 
     public MemberResponse findById(final Long memberId) {
         final Member member = findMember(memberId);
+        if (!member.isRegisterCompleted()) {
+            throw new InvalidProfileArgumentException();
+        }
         return MemberResponse.from(member);
     }
 

--- a/backend/src/main/java/com/woowacourse/f12/exception/InvalidProfileArgumentException.java
+++ b/backend/src/main/java/com/woowacourse/f12/exception/InvalidProfileArgumentException.java
@@ -1,0 +1,9 @@
+package com.woowacourse.f12.exception;
+
+
+public class InvalidProfileArgumentException extends InvalidValueException {
+
+    public InvalidProfileArgumentException() {
+        super("추가 정보가 등록되지 않았습니다.");
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/presentation/MemberController.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/MemberController.java
@@ -3,6 +3,7 @@ package com.woowacourse.f12.presentation;
 import com.woowacourse.f12.application.MemberService;
 import com.woowacourse.f12.dto.request.MemberRequest;
 import com.woowacourse.f12.dto.response.MemberResponse;
+import javax.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -37,7 +38,7 @@ public class MemberController {
     @PatchMapping("/me")
     @LoginRequired
     public ResponseEntity<Void> updateMe(@VerifiedMember final Long memberId,
-                                         @RequestBody final MemberRequest memberRequest) {
+                                         @Valid @RequestBody final MemberRequest memberRequest) {
         memberService.updateMember(memberId, memberRequest);
         return ResponseEntity.ok().build();
     }

--- a/backend/src/test/java/com/woowacourse/f12/acceptance/MemberAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/acceptance/MemberAcceptanceTest.java
@@ -27,11 +27,27 @@ public class MemberAcceptanceTest extends AcceptanceTest {
                 .as(LoginResponse.class);
         String token = loginResponse.getToken();
         MemberRequest memberRequest = new MemberRequest(JUNIOR, BACK_END);
+
         // when
-        ExtractableResponse<Response> response = 로그인된_상태로_PATCH_요청을_보낸다("/api/v1/members/me", token, memberRequest);
+        ExtractableResponse<Response> memberUpdatedResponse = 로그인된_상태로_PATCH_요청을_보낸다("/api/v1/members/me", token,
+                memberRequest);
+        ExtractableResponse<Response> memberGetResponse = 로그인된_상태로_GET_요청을_보낸다("/api/v1/members/me", token);
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        Member member = Member.builder()
+                .id(null)
+                .imageUrl(null)
+                .name(null)
+                .gitHubId(null)
+                .careerLevel(JUNIOR)
+                .jobType(BACK_END)
+                .build();
+        assertAll(
+                () -> assertThat(memberGetResponse.as(MemberResponse.class)).usingRecursiveComparison()
+                        .comparingOnlyFields("careerLevel", "jobType")
+                        .isEqualTo(MemberResponse.from(member)),
+                () -> assertThat(memberUpdatedResponse.statusCode()).isEqualTo(HttpStatus.OK.value())
+        );
     }
 
     @Test

--- a/backend/src/test/java/com/woowacourse/f12/application/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/application/MemberServiceTest.java
@@ -9,9 +9,11 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.verify;
 
+import com.woowacourse.f12.domain.Member;
 import com.woowacourse.f12.domain.MemberRepository;
 import com.woowacourse.f12.dto.request.MemberRequest;
 import com.woowacourse.f12.dto.response.MemberResponse;
+import com.woowacourse.f12.exception.InvalidProfileArgumentException;
 import com.woowacourse.f12.exception.MemberNotFoundException;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -56,6 +58,26 @@ class MemberServiceTest {
         assertAll(
                 () -> assertThatThrownBy(() -> memberService.findById(1L))
                         .isExactlyInstanceOf(MemberNotFoundException.class),
+                () -> verify(memberRepository).findById(1L)
+        );
+    }
+
+    @Test
+    void 추가_정보가_입력되지_않은_멤버_아이디로_회원정보를_조회하면_예외가_발생한다() {
+        // given
+        Member member = Member.builder()
+                .id(1L)
+                .gitHubId("gitHubId")
+                .name("name")
+                .imageUrl("url")
+                .build();
+        given(memberRepository.findById(1L))
+                .willReturn(Optional.of(member));
+
+        // when, then
+        assertAll(
+                () -> assertThatThrownBy(() -> memberService.findById(1L))
+                        .isExactlyInstanceOf(InvalidProfileArgumentException.class),
                 () -> verify(memberRepository).findById(1L)
         );
     }

--- a/backend/src/test/java/com/woowacourse/f12/documentation/MemberDocumentation.java
+++ b/backend/src/test/java/com/woowacourse/f12/documentation/MemberDocumentation.java
@@ -59,7 +59,7 @@ public class MemberDocumentation extends Documentation {
 
         // then
         resultActions.andExpect(status().isOk())
-                .andDo(document("members-get-me"))
+                .andDo(document("members-get-mine"))
                 .andDo(print());
     }
 

--- a/backend/src/test/java/com/woowacourse/f12/presentation/MemberControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/MemberControllerTest.java
@@ -8,6 +8,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
@@ -164,4 +165,34 @@ class MemberControllerTest {
                 () -> verify(memberService).updateMember(eq(1L), any(MemberRequest.class))
         );
     }
+
+    @Test
+    void 로그인된_상태에서_나의_회원정보를_수정_실패_DTO_필드가_null인_경우() throws Exception {
+        // given
+        MemberRequest memberRequest = new MemberRequest(null, null);
+        String authorizationHeader = "Bearer Token";
+        given(jwtProvider.validateToken(authorizationHeader))
+                .willReturn(true);
+        given(jwtProvider.getPayload(authorizationHeader))
+                .willReturn("1");
+        willDoNothing().given(memberService).updateMember(1L, memberRequest);
+
+        // when
+        mockMvc.perform(
+                        patch("/api/v1/members/me")
+                                .header(HttpHeaders.AUTHORIZATION, authorizationHeader)
+                                .content(objectMapper.writeValueAsString(memberRequest))
+                                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                )
+                .andExpect(status().isBadRequest())
+                .andDo(print());
+
+        // then
+        assertAll(
+                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).getPayload(authorizationHeader),
+                () -> verify(memberService, times(0)).updateMember(eq(1L), any(MemberRequest.class))
+        );
+    }
+
 }

--- a/backend/src/test/java/com/woowacourse/f12/presentation/MemberControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/MemberControllerTest.java
@@ -167,6 +167,38 @@ class MemberControllerTest {
     }
 
     @Test
+    void 로그인된_상태에서_나의_회원정보를_수정_실패_Enum의_name값과_다른_요청일_경우() throws Exception {
+        // given
+        Map<String, Object> memberRequest = new HashMap<>();
+        memberRequest.put("careerLevel", "invalid");
+        memberRequest.put("jobType", "invalid");
+
+        String authorizationHeader = "Bearer Token";
+        given(jwtProvider.validateToken(authorizationHeader))
+                .willReturn(true);
+        given(jwtProvider.getPayload(authorizationHeader))
+                .willReturn("1");
+        willDoNothing().given(memberService).updateMember(eq(1L), any(MemberRequest.class));
+
+        // when
+        mockMvc.perform(
+                        patch("/api/v1/members/me")
+                                .header(HttpHeaders.AUTHORIZATION, authorizationHeader)
+                                .content(objectMapper.writeValueAsString(memberRequest))
+                                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                )
+                .andExpect(status().isBadRequest())
+                .andDo(print());
+
+        // then
+        assertAll(
+                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).getPayload(authorizationHeader),
+                () -> verify(memberService, times(0)).updateMember(eq(1L), any(MemberRequest.class))
+        );
+    }
+
+    @Test
     void 로그인된_상태에서_나의_회원정보를_수정_실패_DTO_필드가_null인_경우() throws Exception {
         // given
         MemberRequest memberRequest = new MemberRequest(null, null);


### PR DESCRIPTION
# issue: #182 

# 작업 내용
- 테스트 추가
  - 회원정보 수정시 요청값이 유효하지 않은 테스트 케이스 추가
  - 인수테스트에서 회원정보 수정한뒤 회원정보를 조회하여 검증하도록 수정
- 회원정보를 찾을 경우 추가정보가 없는 회원일 경우 예외 발생하도록 수정
- 회원정보 수정 요청에 대한 값 검증 추가 

