### PR TITLE
[BugFix] 등록된 장비가 1개일 때 발생하던 오류를 수정

### DIFF
--- a/frontend/src/components/common/ProductSelect/ProductSelect.tsx
+++ b/frontend/src/components/common/ProductSelect/ProductSelect.tsx
@@ -49,48 +49,42 @@ function ProductSelect({ submitHandler }: Props) {
   };
 
   return (
-    otherProducts &&
-    otherProducts.length !== 0 && (
-      <S.Container>
-        <S.EditButton onClick={handleEditDone}>
-          {isEditMode ? '수정 완료' : '수정하기'}
-        </S.EditButton>
-        {isEditMode ? (
-          <>
-            <S.Selected>
-              <S.PseudoButton onClick={setOptionOpen}>
-                {selectedProduct !== undefined ? (
-                  <ProductBar
-                    name={selectedProduct.product.name}
-                    barType="selected"
-                  />
-                ) : (
-                  <ProductBar.AddButton />
-                )}
-                <DownArrow stroke={theme.colors.black} />
-              </S.PseudoButton>
-            </S.Selected>
-            {isOptionsOpen && (
-              <S.OptionsList>
-                <OptionListItems
-                  options={otherProducts}
-                  handleSelect={handleProductSelect}
+    <S.Container>
+      <S.EditButton onClick={handleEditDone}>
+        {isEditMode ? '수정 완료' : '수정하기'}
+      </S.EditButton>
+      {isEditMode ? (
+        <>
+          <S.Selected>
+            <S.PseudoButton onClick={setOptionOpen}>
+              {selectedProduct !== undefined ? (
+                <ProductBar
+                  name={selectedProduct.product.name}
+                  barType="selected"
                 />
-              </S.OptionsList>
-            )}
-          </>
-        ) : selectedProduct ? (
-          <ProductBar
-            name={selectedProduct.product.name}
-            barType={'selected'}
-          />
-        ) : (
-          <S.NoContentMessage>
-            등록된 장비가 없어요! 수정하기로 대표 장비를 등록해주세요!
-          </S.NoContentMessage>
-        )}
-      </S.Container>
-    )
+              ) : (
+                <ProductBar.AddButton />
+              )}
+              <DownArrow stroke={theme.colors.black} />
+            </S.PseudoButton>
+          </S.Selected>
+          {isOptionsOpen && (
+            <S.OptionsList>
+              <OptionListItems
+                options={otherProducts}
+                handleSelect={handleProductSelect}
+              />
+            </S.OptionsList>
+          )}
+        </>
+      ) : selectedProduct ? (
+        <ProductBar name={selectedProduct.product.name} barType={'selected'} />
+      ) : (
+        <S.NoContentMessage>
+          등록된 장비가 없어요! 수정하기로 대표 장비를 등록해주세요!
+        </S.NoContentMessage>
+      )}
+    </S.Container>
   );
 }
 


### PR DESCRIPTION
# 오류
- 등록된 장비가 1개인 경우, 대표 장비 등록 선택을 하면 선택창이 삭제되는 현상
# 원인
- useInventory의 otherProducts가 없을 경우 오류를 발생 시키던 때가 있어서 이를 방지하기 위해 배열의 길이가 0이면 컴포넌트를 렌더링 하지 않도록 설정
- 등록 장비 자체가 1개인 경우 선택하고 나면 otherProducts가 없기 때문에 문제 상황이 아닌데도 불구하고 컴포넌트가 렌더링 되지 않음
# 수정
- 해당 조건부 렌더링 삭제, 코드가 수정돼서 더 이상 오류를 발생시키지 않음 
