### PR TITLE
[BE] 장비가 인벤토리에 중복 추가되는 버그가 발생한다

### DIFF
--- a/backend/src/main/java/com/woowacourse/f12/application/ReviewService.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/ReviewService.java
@@ -65,6 +65,9 @@ public class ReviewService {
     }
 
     private void saveInventoryProduct(final Long memberId, final Keyboard keyboard) {
+        if (inventoryProductRepository.existsByMemberIdAndKeyboard(memberId, keyboard)) {
+            return;
+        }
         final InventoryProduct inventoryProduct = InventoryProduct.builder()
                 .memberId(memberId)
                 .keyboard(keyboard)

--- a/backend/src/main/java/com/woowacourse/f12/domain/InventoryProductRepository.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/InventoryProductRepository.java
@@ -5,5 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface InventoryProductRepository extends JpaRepository<InventoryProduct, Long> {
 
-    List<InventoryProduct> findByMemberId(final Long memberId);
+    List<InventoryProduct> findByMemberId(Long memberId);
+
+    boolean existsByMemberIdAndKeyboard(Long memberId, Keyboard keyboard);
 }

--- a/backend/src/test/java/com/woowacourse/f12/application/ReviewServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/application/ReviewServiceTest.java
@@ -78,6 +78,8 @@ class ReviewServiceTest {
                 .willReturn(Optional.of(member));
         given(keyboardRepository.findById(productId))
                 .willReturn(Optional.of(keyboard));
+        given(inventoryProductRepository.existsByMemberIdAndKeyboard(memberId, keyboard))
+                .willReturn(false);
         given(inventoryProductRepository.save(inventoryProduct))
                 .willReturn(inventoryProduct);
         given(reviewRepository.save(reviewRequest.toReview(keyboard, member)))
@@ -92,6 +94,7 @@ class ReviewServiceTest {
                 () -> verify(keyboardRepository).findById(productId),
                 () -> verify(memberRepository).findById(memberId),
                 () -> verify(reviewRepository).save(any(Review.class)),
+                () -> verify(inventoryProductRepository).existsByMemberIdAndKeyboard(memberId, keyboard),
                 () -> verify(inventoryProductRepository).save(inventoryProduct)
         );
     }

--- a/backend/src/test/java/com/woowacourse/f12/domain/InventoryProductRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/domain/InventoryProductRepositoryTest.java
@@ -40,6 +40,21 @@ class InventoryProductRepositoryTest {
         assertThat(inventoryProducts).containsOnly(inventoryProduct1);
     }
 
+    @Test
+    void 멤버_아이디와_상품으로_인벤토리_상품_목록을_조회한다() {
+        // given
+        Long memberId = 1L;
+        Keyboard keyboard = 키보드를_저장한다(KEYBOARD_1.생성(1L));
+        InventoryProduct inventoryProduct = SELECTED_INVENTORY_PRODUCT.생성(memberId, keyboard);
+        inventoryProductRepository.save(inventoryProduct);
+
+        // when
+        boolean actual = inventoryProductRepository.existsByMemberIdAndKeyboard(memberId, keyboard);
+
+        // then
+        assertThat(actual).isTrue();
+    }
+
     private Keyboard 키보드를_저장한다(Keyboard keyboard) {
         return keyboardRepository.save(keyboard);
     }


### PR DESCRIPTION
# issue: #196 

# 작업 내용
- 리뷰를 작성했을 때 장비가 인벤토리에 중복으로 추가되지 않도록 구현했다.
  - 이미 존재하는 장비라면 예외를 던지는 것이아니라, 저장이 되지 않도록 했다.