### PR TITLE
[BugFix] 인기 많은 상품 페이지에 존재하는 새로고침 오류 수정

### DIFF
--- a/frontend/src/pages/Products/Products.tsx
+++ b/frontend/src/pages/Products/Products.tsx
@@ -25,7 +25,9 @@ const DefaultSort = options[1];
 
 function Products() {
   const location = useLocation();
-  const [sort, setSort] = useState<Sort>(DefaultSort.value);
+  const [sort, setSort] = useState<Sort>(
+    location.hash === '#popular' ? PopularSort.value : DefaultSort.value
+  );
   const [keyboards, getNextPage] = useProducts({
     size: 12,
     sort,


### PR DESCRIPTION
# issue: #212

# 작업 내용
- 초기 렌더 시에는 state가 무조건 리뷰 많은 순으로 되어 있어서 발생한 오류
- useState에서도 hash에 따라 초기 상태를 변경하도록 처리
