### PR TITLE
[FE] 카테고리 별 상품 목록 조회 페이지 구현 및 API 설정

### DIFF
--- a/frontend/src/components/common/CategoryNav/CategoryNav.tsx
+++ b/frontend/src/components/common/CategoryNav/CategoryNav.tsx
@@ -7,7 +7,20 @@ type Props = {
   triggerAnimation: boolean;
 };
 
+const CATEGORY = {
+  KEYBOARD: { key: 'keyboard', name: '키보드' },
+  MOUSE: { key: 'mouse', name: '마우스' },
+  MONITOR: { key: 'monitor', name: '모니터' },
+  STAND: { key: 'stand', name: '거치대' },
+  SOFTWARE: { key: 'software', name: '소프트웨어' },
+} as const;
+
 function CategoryNav({ handleTransitionEnd, triggerAnimation }: Props) {
+  const CategoryLinks = Object.values(CATEGORY).map(({ key, name }) => (
+    <Link key={key} to={`${ROUTES.PRODUCTS}?category=${key}`}>
+      {name}
+    </Link>
+  ));
   return (
     <S.Container
       onTransitionEnd={handleTransitionEnd}
@@ -15,11 +28,7 @@ function CategoryNav({ handleTransitionEnd, triggerAnimation }: Props) {
     >
       <S.Wrapper>
         <Link to={ROUTES.PRODUCTS}>전체 상품</Link>
-        <Link to={`${ROUTES.PRODUCTS}?category=keyboard`}>키보드</Link>
-        <Link to={`${ROUTES.PRODUCTS}?category=mouse`}>마우스</Link>
-        <Link to={`${ROUTES.PRODUCTS}?category=monitor`}>모니터</Link>
-        <Link to={`${ROUTES.PRODUCTS}?category=stand`}>거치대</Link>
-        <Link to={`${ROUTES.PRODUCTS}?category=software`}>소프트웨어</Link>
+        {CategoryLinks}
       </S.Wrapper>
     </S.Container>
   );

--- a/frontend/src/components/common/CategoryNav/CategoryNav.tsx
+++ b/frontend/src/components/common/CategoryNav/CategoryNav.tsx
@@ -15,11 +15,11 @@ function CategoryNav({ handleTransitionEnd, triggerAnimation }: Props) {
     >
       <S.Wrapper>
         <Link to={ROUTES.PRODUCTS}>전체 상품</Link>
-        <Link to={ROUTES.PRODUCTS}>키보드</Link>
-        <Link to={ROUTES.PRODUCTS}>마우스</Link>
-        <Link to={ROUTES.PRODUCTS}>모니터</Link>
-        <Link to={ROUTES.PRODUCTS}>거치대</Link>
-        <Link to={ROUTES.PRODUCTS}>소프트웨어</Link>
+        <Link to={`${ROUTES.PRODUCTS}?category=keyboard`}>키보드</Link>
+        <Link to={`${ROUTES.PRODUCTS}?category=mouse`}>마우스</Link>
+        <Link to={`${ROUTES.PRODUCTS}?category=monitor`}>모니터</Link>
+        <Link to={`${ROUTES.PRODUCTS}?category=stand`}>거치대</Link>
+        <Link to={`${ROUTES.PRODUCTS}?category=software`}>소프트웨어</Link>
       </S.Wrapper>
     </S.Container>
   );

--- a/frontend/src/constants/api.ts
+++ b/frontend/src/constants/api.ts
@@ -8,10 +8,10 @@ const githubClientId =
 export const GITHUB_AUTH_URL = `https://github.com/login/oauth/authorize?client_id=${githubClientId}`;
 
 export const ENDPOINTS = {
-  PRODUCTS: '/keyboards',
-  PRODUCT: (id: number | ':id') => `/keyboards/${id}`,
+  PRODUCTS: '/products',
+  PRODUCT: (id: number | ':id') => `/products/${id}`,
   REVIEWS: '/reviews',
-  REVIEWS_BY_PRODUCT_ID: (id: number | ':id') => `/keyboards/${id}/reviews`,
+  REVIEWS_BY_PRODUCT_ID: (id: number | ':id') => `/products/${id}/reviews`,
   REVIEWS_BY_REVIEW_ID: (reviewId: number | ':id') => `/reviews/${reviewId}`,
   LOGIN: '/login',
   INVENTORY_PRODUCTS: '/members/inventoryProducts',

--- a/frontend/src/hooks/api/useGetMany.tsx
+++ b/frontend/src/hooks/api/useGetMany.tsx
@@ -2,11 +2,13 @@ import { AxiosRequestHeaders, AxiosResponse } from 'axios';
 import { useState, useEffect } from 'react';
 import axiosInstance from '@/hooks/api/axiosInstance';
 
+type SearchParams = Record<string, string>;
+
+type GetManyParams = SearchParams & { size: string };
+
 type Props = {
   url: string;
-  size: number;
-  sort?: string;
-  category?: string;
+  params?: GetManyParams;
   body?: null | object;
   headers?: null | AxiosRequestHeaders;
 };
@@ -18,9 +20,7 @@ type Data<T> = {
 
 function useGetMany<T>({
   url,
-  size,
-  sort,
-  category,
+  params,
   body,
   headers,
 }: Props): [T[], () => void, () => void] {
@@ -41,10 +41,8 @@ function useGetMany<T>({
       data: body,
       headers,
       params: {
-        size,
         page,
-        sort,
-        category,
+        ...params,
       },
     });
 
@@ -87,9 +85,11 @@ function useGetMany<T>({
       });
   }, [nextPageTrigger, refetchTrigger]);
 
+  const searchParams = new URLSearchParams(params);
+
   useEffect(() => {
     refetch();
-  }, [sort, category]);
+  }, [searchParams.toString()]);
 
   return [data, getNextPage, refetch];
 }

--- a/frontend/src/hooks/api/useGetMany.tsx
+++ b/frontend/src/hooks/api/useGetMany.tsx
@@ -6,6 +6,7 @@ type Props = {
   url: string;
   size: number;
   sort?: string;
+  category?: string;
   body?: null | object;
   headers?: null | AxiosRequestHeaders;
 };
@@ -19,6 +20,7 @@ function useGetMany<T>({
   url,
   size,
   sort,
+  category,
   body,
   headers,
 }: Props): [T[], () => void, () => void] {
@@ -42,6 +44,7 @@ function useGetMany<T>({
         size,
         page,
         sort,
+        category,
       },
     });
 
@@ -86,7 +89,7 @@ function useGetMany<T>({
 
   useEffect(() => {
     refetch();
-  }, [sort]);
+  }, [sort, category]);
 
   return [data, getNextPage, refetch];
 }

--- a/frontend/src/hooks/useProducts.tsx
+++ b/frontend/src/hooks/useProducts.tsx
@@ -1,10 +1,10 @@
 import useGetMany from '@/hooks/api/useGetMany';
 import { ENDPOINTS } from '@/constants/api';
 
-type Sort = 'default' | 'rating,desc' | 'reviewCount,desc';
+type Sort = 'rating,desc' | 'reviewCount,desc';
 
 type Props = {
-  size: number;
+  size: string;
   sort?: Sort;
   category?: string;
 };
@@ -12,11 +12,10 @@ type Props = {
 type ReturnType = [Product[], () => void];
 
 function useProducts({ size, sort, category }: Props): ReturnType {
+  const params = { size, sort, category };
   const [products, getNextPage] = useGetMany<Product>({
     url: `${ENDPOINTS.PRODUCTS}`,
-    size,
-    sort: sort === 'default' ? undefined : sort,
-    category,
+    params,
   });
 
   return [products, getNextPage];

--- a/frontend/src/hooks/useProducts.tsx
+++ b/frontend/src/hooks/useProducts.tsx
@@ -6,15 +6,17 @@ type Sort = 'default' | 'rating,desc' | 'reviewCount,desc';
 type Props = {
   size: number;
   sort?: Sort;
+  category?: string;
 };
 
 type ReturnType = [Product[], () => void];
 
-function useProducts({ size, sort }: Props): ReturnType {
+function useProducts({ size, sort, category }: Props): ReturnType {
   const [products, getNextPage] = useGetMany<Product>({
     url: `${ENDPOINTS.PRODUCTS}`,
     size,
     sort: sort === 'default' ? undefined : sort,
+    category,
   });
 
   return [products, getNextPage];

--- a/frontend/src/pages/Home/Home.tsx
+++ b/frontend/src/pages/Home/Home.tsx
@@ -6,7 +6,7 @@ import useProducts from '@/hooks/useProducts';
 import useReviews from '@/hooks/useReviews';
 
 function Home() {
-  const [keyboards] = useProducts({ size: 4, sort: 'rating,desc' });
+  const [keyboards] = useProducts({ size: '4', sort: 'rating,desc' });
   const [reviews, getNextPage] = useReviews({ size: 6 });
 
   const moreProductsLink = (

--- a/frontend/src/pages/Products/Products.tsx
+++ b/frontend/src/pages/Products/Products.tsx
@@ -29,7 +29,7 @@ function Products() {
   const [searchParams] = useSearchParams();
   const category = searchParams.get('category');
   const [products, getNextPage] = useProducts({
-    size: 12,
+    size: '12',
     sort,
     category,
   });

--- a/frontend/src/pages/Products/Products.tsx
+++ b/frontend/src/pages/Products/Products.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react';
 import ProductListSection from '@/components/ProductListSection/ProductListSection';
 import Select from '@/components/common/Select/Select';
 import useProducts from '@/hooks/useProducts';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useSearchParams } from 'react-router-dom';
 
 type Option = { value: string; text: string };
 
@@ -26,9 +26,12 @@ const DefaultSort = options[1];
 function Products() {
   const location = useLocation();
   const [sort, setSort] = useState<Sort>(DefaultSort.value);
-  const [keyboards, getNextPage] = useProducts({
+  const [searchParams] = useSearchParams();
+  const category = searchParams.get('category');
+  const [products, getNextPage] = useProducts({
     size: 12,
     sort,
+    category,
   });
 
   useEffect(() => {
@@ -40,7 +43,7 @@ function Products() {
   return (
     <ProductListSection
       title={location.hash === '#popular' ? '인기 상품 목록' : '모든 상품 목록'}
-      data={!!keyboards && keyboards}
+      data={!!products && products}
       getNextPage={getNextPage}
       addOn={<Select value={sort} setValue={setSort} options={options} />}
     />


### PR DESCRIPTION
# issue: Closed #240

# 작업 내용
- products 페이지를 재사용, searchparams를 이용해서 카테고리를 분류
- category를 변경할 때 마다 refetch 하도록 설정
- useGetMany 훅의 params 전달 부분 코드 일부 수정