### PR TITLE
[BE] 사용자 검색 기능 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -1,8 +1,15 @@
+buildscript {
+    ext {
+        queryDslVersion = "5.0.0"
+    }
+}
+
 plugins {
     id 'org.springframework.boot' version '2.7.1'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
     id 'java'
     id 'org.asciidoctor.jvm.convert' version '3.3.2'
+    id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
 }
 
 group = 'com.woowacourse'
@@ -11,6 +18,10 @@ sourceCompatibility = '11'
 
 configurations {
     asciidoctorExtensions
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
+    querydsl.extendsFrom compileClasspath
 }
 
 repositories {
@@ -22,6 +33,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+    implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
+    implementation "com.querydsl:querydsl-apt:${queryDslVersion}"
 
     runtimeOnly 'com.h2database:h2'
 
@@ -41,6 +55,21 @@ dependencies {
     // rest-docs
     asciidoctorExtensions 'org.springframework.restdocs:spring-restdocs-asciidoctor'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+}
+
+def querydslDir = "$buildDir/generated/querydsl"
+
+querydsl {
+    jpa = true
+    querydslSourcesDir = querydslDir
+}
+
+sourceSets {
+    main.java.srcDir querydslDir
+}
+
+compileQuerydsl {
+    options.annotationProcessorPath = configurations.querydsl
 }
 
 ext {

--- a/backend/src/docs/asciidoc/members.adoc
+++ b/backend/src/docs/asciidoc/members.adoc
@@ -12,3 +12,7 @@ operation::members-get-by-memberId[snippets='http-request,http-response']
 === 로그인된 상태로 나의 회원 정보 수정
 
 operation::members-update[snippets='http-request,http-response']
+
+=== 회원 검색
+
+operation::members-search[snippets='http-request,http-response']

--- a/backend/src/main/java/com/woowacourse/f12/application/member/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/member/MemberService.java
@@ -1,12 +1,21 @@
 package com.woowacourse.f12.application.member;
 
 
+import com.woowacourse.f12.domain.member.CareerLevel;
+import com.woowacourse.f12.domain.member.JobType;
 import com.woowacourse.f12.domain.member.Member;
 import com.woowacourse.f12.domain.member.MemberRepository;
+import com.woowacourse.f12.dto.CareerLevelConstant;
+import com.woowacourse.f12.dto.JobTypeConstant;
 import com.woowacourse.f12.dto.request.member.MemberRequest;
+import com.woowacourse.f12.dto.request.member.MemberSearchRequest;
+import com.woowacourse.f12.dto.response.member.MemberPageResponse;
 import com.woowacourse.f12.dto.response.member.MemberResponse;
 import com.woowacourse.f12.exception.badrequest.InvalidProfileArgumentException;
 import com.woowacourse.f12.exception.notfound.MemberNotFoundException;
+import java.util.Objects;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -38,5 +47,30 @@ public class MemberService {
     private Member findMember(final Long memberId) {
         return memberRepository.findById(memberId)
                 .orElseThrow(MemberNotFoundException::new);
+    }
+
+
+    public MemberPageResponse findByContains(final MemberSearchRequest memberSearchRequest, final Pageable pageable) {
+        final CareerLevel careerLevel = parseCareerLevel(memberSearchRequest);
+        final JobType jobType = parseJobType(memberSearchRequest);
+        final Slice<Member> slice = memberRepository.findByContains(memberSearchRequest.getQuery(), careerLevel,
+                jobType, pageable);
+        return MemberPageResponse.from(slice);
+    }
+
+    private JobType parseJobType(final MemberSearchRequest memberSearchRequest) {
+        final JobTypeConstant jobTypeConstant = memberSearchRequest.getJobType();
+        if (Objects.isNull(jobTypeConstant)) {
+            return null;
+        }
+        return jobTypeConstant.toJobType();
+    }
+
+    private CareerLevel parseCareerLevel(final MemberSearchRequest memberSearchRequest) {
+        final CareerLevelConstant careerLevelConstant = memberSearchRequest.getCareerLevel();
+        if (Objects.isNull(careerLevelConstant)) {
+            return null;
+        }
+        return careerLevelConstant.toCareerLevel();
     }
 }

--- a/backend/src/main/java/com/woowacourse/f12/application/member/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/member/MemberService.java
@@ -40,8 +40,8 @@ public class MemberService {
     @Transactional
     public void updateMember(final Long memberId, final MemberRequest memberRequest) {
         final Member member = findMember(memberId);
-        member.updateCareerLevel(memberRequest.getCareerLevel());
-        member.updateJobType(memberRequest.getJobType());
+        member.updateCareerLevel(memberRequest.getCareerLevel().toCareerLevel());
+        member.updateJobType(memberRequest.getJobType().toJobType());
     }
 
     private Member findMember(final Long memberId) {

--- a/backend/src/main/java/com/woowacourse/f12/config/JpaConfig.java
+++ b/backend/src/main/java/com/woowacourse/f12/config/JpaConfig.java
@@ -1,5 +1,9 @@
 package com.woowacourse.f12.config;
 
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
@@ -7,4 +11,11 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 @EnableJpaAuditing
 public class JpaConfig {
 
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
 }

--- a/backend/src/main/java/com/woowacourse/f12/config/WebConfig.java
+++ b/backend/src/main/java/com/woowacourse/f12/config/WebConfig.java
@@ -1,7 +1,10 @@
 package com.woowacourse.f12.config;
 
+import com.woowacourse.f12.presentation.ViewConstant;
 import java.util.List;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.format.FormatterRegistry;
 import org.springframework.http.HttpHeaders;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.HandlerInterceptor;
@@ -16,10 +19,13 @@ public class WebConfig implements WebMvcConfigurer {
 
     private final List<HandlerInterceptor> interceptors;
     private final List<HandlerMethodArgumentResolver> resolvers;
+    private final List<Converter<String, ViewConstant>> converters;
 
-    public WebConfig(List<HandlerInterceptor> interceptors, List<HandlerMethodArgumentResolver> resolvers) {
+    public WebConfig(final List<HandlerInterceptor> interceptors, final List<HandlerMethodArgumentResolver> resolvers,
+                     final List<Converter<String, ViewConstant>> converters) {
         this.interceptors = interceptors;
         this.resolvers = resolvers;
+        this.converters = converters;
     }
 
     @Override
@@ -37,5 +43,10 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addArgumentResolvers(final List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.addAll(this.resolvers);
+    }
+
+    @Override
+    public void addFormatters(final FormatterRegistry registry) {
+        converters.forEach(registry::addConverter);
     }
 }

--- a/backend/src/main/java/com/woowacourse/f12/domain/inventoryproduct/InventoryProduct.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/inventoryproduct/InventoryProduct.java
@@ -31,7 +31,7 @@ public class InventoryProduct {
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "keyboard_id")
     private Keyboard keyboard;
 

--- a/backend/src/main/java/com/woowacourse/f12/domain/member/CareerLevel.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/member/CareerLevel.java
@@ -1,18 +1,12 @@
 package com.woowacourse.f12.domain.member;
 
-import lombok.Getter;
-
-@Getter
 public enum CareerLevel {
 
-    NONE("경력 없음"),
-    JUNIOR("0~2년차"),
-    MID_LEVEL("3~5년차"),
-    SENIOR("5년차 이상");
+    NONE,
+    JUNIOR,
+    MID_LEVEL,
+    SENIOR;
 
-    private final String value;
-
-    CareerLevel(final String value) {
-        this.value = value;
+    CareerLevel() {
     }
 }

--- a/backend/src/main/java/com/woowacourse/f12/domain/member/JobType.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/member/JobType.java
@@ -5,14 +5,12 @@ import lombok.Getter;
 @Getter
 public enum JobType {
 
-    FRONT_END("프론트엔드"),
-    BACK_END("백엔드"),
-    MOBILE("모바일 (안드로이드, iOS)"),
-    ETC("기타");
+    FRONTEND,
+    BACKEND,
+    MOBILE,
+    ETC,
+    ;
 
-    private final String value;
-
-    JobType(final String value) {
-        this.value = value;
+    JobType() {
     }
 }

--- a/backend/src/main/java/com/woowacourse/f12/domain/member/Member.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/member/Member.java
@@ -16,6 +16,7 @@ import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import lombok.Builder;
 import lombok.Getter;
+import org.hibernate.annotations.BatchSize;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
@@ -45,6 +46,7 @@ public class Member {
     @Enumerated(EnumType.STRING)
     private JobType jobType;
 
+    @BatchSize(size = 150)
     @OneToMany(mappedBy = "member")
     private List<InventoryProduct> inventoryProducts = new ArrayList<>();
 
@@ -53,13 +55,15 @@ public class Member {
 
     @Builder
     private Member(final Long id, final String gitHubId, final String name, final String imageUrl,
-                   final CareerLevel careerLevel, final JobType jobType) {
+                   final CareerLevel careerLevel, final JobType jobType,
+                   final List<InventoryProduct> inventoryProducts) {
         this.id = id;
         this.gitHubId = gitHubId;
         this.name = name;
         this.imageUrl = imageUrl;
         this.careerLevel = careerLevel;
         this.jobType = jobType;
+        this.inventoryProducts = inventoryProducts;
     }
 
     public void updateName(final String name) {

--- a/backend/src/main/java/com/woowacourse/f12/domain/member/MemberRepository.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/member/MemberRepository.java
@@ -3,7 +3,7 @@ package com.woowacourse.f12.domain.member;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MemberRepository extends JpaRepository<Member, Long> {
+public interface MemberRepository extends JpaRepository<Member, Long>, MemberRepositoryCustom {
 
     Optional<Member> findByGitHubId(String gitHubId);
 }

--- a/backend/src/main/java/com/woowacourse/f12/domain/member/MemberRepositoryCustom.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/member/MemberRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.woowacourse.f12.domain.member;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+public interface MemberRepositoryCustom {
+
+    Slice<Member> findByContains(String keyword, CareerLevel careerLevel, JobType jobType, Pageable pageable);
+}

--- a/backend/src/main/java/com/woowacourse/f12/domain/member/MemberRepositoryCustomImpl.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/member/MemberRepositoryCustomImpl.java
@@ -1,0 +1,66 @@
+package com.woowacourse.f12.domain.member;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
+
+public class MemberRepositoryCustomImpl extends QuerydslRepositorySupport implements MemberRepositoryCustom {
+
+    private final QMember member = QMember.member;
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public MemberRepositoryCustomImpl(final JPAQueryFactory jpaQueryFactory) {
+        super(Member.class);
+        this.jpaQueryFactory = jpaQueryFactory;
+    }
+
+    public Slice<Member> findByContains(final String keyword, final CareerLevel careerLevel, final JobType jobType,
+                                        final Pageable pageable) {
+        final JPAQuery<Member> jpaQuery = jpaQueryFactory.select(member)
+                .from(member)
+                .where(
+                        containsKeyword(keyword),
+                        eqCareerLevel(careerLevel),
+                        eqJobType(jobType)
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize() + 1);
+        final List<Member> members = jpaQuery.fetch();
+        return toSlice(pageable, members);
+    }
+
+    private BooleanExpression containsKeyword(final String keyword) {
+        if (keyword == null || keyword.isBlank()) {
+            return null;
+        }
+        return member.gitHubId.contains(keyword);
+    }
+
+    public BooleanExpression eqCareerLevel(final CareerLevel careerLevel) {
+        if (careerLevel == null) {
+            return null;
+        }
+        return member.careerLevel.eq(careerLevel);
+    }
+
+    public BooleanExpression eqJobType(final JobType jobType) {
+        if (jobType == null) {
+            return null;
+        }
+        return member.jobType.eq(jobType);
+    }
+
+    private SliceImpl<Member> toSlice(final Pageable pageable, final List<Member> members) {
+        if (members.size() > pageable.getPageSize()) {
+            members.remove(members.size() - 1);
+            return new SliceImpl<>(members, pageable, true);
+        }
+
+        return new SliceImpl<>(members, pageable, false);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/domain/member/MemberRepositoryCustomImpl.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/member/MemberRepositoryCustomImpl.java
@@ -4,6 +4,7 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
+import java.util.Objects;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
@@ -42,14 +43,14 @@ public class MemberRepositoryCustomImpl extends QuerydslRepositorySupport implem
     }
 
     public BooleanExpression eqCareerLevel(final CareerLevel careerLevel) {
-        if (careerLevel == null) {
+        if (Objects.isNull(careerLevel)) {
             return null;
         }
         return member.careerLevel.eq(careerLevel);
     }
 
     public BooleanExpression eqJobType(final JobType jobType) {
-        if (jobType == null) {
+        if (Objects.isNull(jobType)) {
             return null;
         }
         return member.jobType.eq(jobType);

--- a/backend/src/main/java/com/woowacourse/f12/dto/CareerLevelConstant.java
+++ b/backend/src/main/java/com/woowacourse/f12/dto/CareerLevelConstant.java
@@ -1,10 +1,13 @@
 package com.woowacourse.f12.dto;
 
 import com.woowacourse.f12.domain.member.CareerLevel;
+import com.woowacourse.f12.exception.badrequest.InvalidCareerLevelException;
+import com.woowacourse.f12.presentation.ViewConstant;
+import java.util.Arrays;
 import lombok.Getter;
 
 @Getter
-public enum CareerLevelConstant {
+public enum CareerLevelConstant implements ViewConstant {
 
     NONE("none", CareerLevel.NONE),
     JUNIOR("junior", CareerLevel.JUNIOR),
@@ -19,7 +22,26 @@ public enum CareerLevelConstant {
         this.careerLevel = careerLevel;
     }
 
+    public static CareerLevelConstant findByViewValue(final String source) {
+        return Arrays.stream(values())
+                .filter(careerLevel -> careerLevel.value.equals(source))
+                .findFirst()
+                .orElseThrow(InvalidCareerLevelException::new);
+    }
+
+    public static CareerLevelConstant findByCareerLevel(final CareerLevel careerLevel) {
+        return Arrays.stream(values())
+                .filter(it -> it.careerLevel.equals(careerLevel))
+                .findFirst()
+                .orElseThrow(InvalidCareerLevelException::new);
+    }
+
     public CareerLevel toCareerLevel() {
         return this.careerLevel;
+    }
+
+    @Override
+    public String getViewValue() {
+        return this.value;
     }
 }

--- a/backend/src/main/java/com/woowacourse/f12/dto/CareerLevelConstant.java
+++ b/backend/src/main/java/com/woowacourse/f12/dto/CareerLevelConstant.java
@@ -1,0 +1,25 @@
+package com.woowacourse.f12.dto;
+
+import com.woowacourse.f12.domain.member.CareerLevel;
+import lombok.Getter;
+
+@Getter
+public enum CareerLevelConstant {
+
+    NONE("none", CareerLevel.NONE),
+    JUNIOR("junior", CareerLevel.JUNIOR),
+    MID_LEVEL("midlevel", CareerLevel.MID_LEVEL),
+    SENIOR("senior", CareerLevel.SENIOR);
+
+    private final String value;
+    private final CareerLevel careerLevel;
+
+    CareerLevelConstant(final String value, final CareerLevel careerLevel) {
+        this.value = value;
+        this.careerLevel = careerLevel;
+    }
+
+    public CareerLevel toCareerLevel() {
+        return this.careerLevel;
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/dto/JobTypeConstant.java
+++ b/backend/src/main/java/com/woowacourse/f12/dto/JobTypeConstant.java
@@ -1,10 +1,13 @@
 package com.woowacourse.f12.dto;
 
 import com.woowacourse.f12.domain.member.JobType;
+import com.woowacourse.f12.exception.badrequest.InvalidJobTypeException;
+import com.woowacourse.f12.presentation.ViewConstant;
+import java.util.Arrays;
 import lombok.Getter;
 
 @Getter
-public enum JobTypeConstant {
+public enum JobTypeConstant implements ViewConstant {
 
     FRONTEND("frontend", JobType.FRONTEND),
     BACKEND("backend", JobType.BACKEND),
@@ -19,7 +22,26 @@ public enum JobTypeConstant {
         this.jobType = jobType;
     }
 
+    public static JobTypeConstant findByViewValue(final String source) {
+        return Arrays.stream(values())
+                .filter(jobType -> jobType.value.equals(source))
+                .findFirst()
+                .orElseThrow(InvalidJobTypeException::new);
+    }
+
+    public static JobTypeConstant findByJobType(final JobType jobType) {
+        return Arrays.stream(values())
+                .filter(it -> it.jobType.equals(jobType))
+                .findFirst()
+                .orElseThrow(InvalidJobTypeException::new);
+    }
+
     public JobType toJobType() {
         return this.jobType;
+    }
+
+    @Override
+    public String getViewValue() {
+        return this.value;
     }
 }

--- a/backend/src/main/java/com/woowacourse/f12/dto/JobTypeConstant.java
+++ b/backend/src/main/java/com/woowacourse/f12/dto/JobTypeConstant.java
@@ -1,0 +1,25 @@
+package com.woowacourse.f12.dto;
+
+import com.woowacourse.f12.domain.member.JobType;
+import lombok.Getter;
+
+@Getter
+public enum JobTypeConstant {
+
+    FRONTEND("frontend", JobType.FRONTEND),
+    BACKEND("backend", JobType.BACKEND),
+    MOBILE("mobile", JobType.MOBILE),
+    ETC("etc", JobType.ETC);
+
+    private final String value;
+    private final JobType jobType;
+
+    JobTypeConstant(final String value, final JobType jobType) {
+        this.value = value;
+        this.jobType = jobType;
+    }
+
+    public JobType toJobType() {
+        return this.jobType;
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/dto/request/member/MemberRequest.java
+++ b/backend/src/main/java/com/woowacourse/f12/dto/request/member/MemberRequest.java
@@ -1,7 +1,7 @@
 package com.woowacourse.f12.dto.request.member;
 
-import com.woowacourse.f12.domain.member.CareerLevel;
-import com.woowacourse.f12.domain.member.JobType;
+import com.woowacourse.f12.dto.CareerLevelConstant;
+import com.woowacourse.f12.dto.JobTypeConstant;
 import javax.validation.constraints.NotNull;
 import lombok.Getter;
 
@@ -9,15 +9,15 @@ import lombok.Getter;
 public class MemberRequest {
 
     @NotNull(message = "직업 경력 내용이 없습니다.")
-    private CareerLevel careerLevel;
+    private CareerLevelConstant careerLevel;
 
     @NotNull(message = "직무 내용이 없습니다.")
-    private JobType jobType;
+    private JobTypeConstant jobType;
 
     private MemberRequest() {
     }
 
-    public MemberRequest(final CareerLevel careerLevel, final JobType jobType) {
+    public MemberRequest(final CareerLevelConstant careerLevel, final JobTypeConstant jobType) {
         this.careerLevel = careerLevel;
         this.jobType = jobType;
     }

--- a/backend/src/main/java/com/woowacourse/f12/dto/request/member/MemberSearchRequest.java
+++ b/backend/src/main/java/com/woowacourse/f12/dto/request/member/MemberSearchRequest.java
@@ -1,0 +1,23 @@
+package com.woowacourse.f12.dto.request.member;
+
+import com.woowacourse.f12.dto.CareerLevelConstant;
+import com.woowacourse.f12.dto.JobTypeConstant;
+import lombok.Getter;
+
+@Getter
+public class MemberSearchRequest {
+
+    private String query;
+    private CareerLevelConstant careerLevel;
+    private JobTypeConstant jobType;
+
+    private MemberSearchRequest() {
+    }
+
+    public MemberSearchRequest(final String query, final CareerLevelConstant careerLevel,
+                               final JobTypeConstant jobType) {
+        this.query = query;
+        this.careerLevel = careerLevel;
+        this.jobType = jobType;
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/dto/response/member/MemberPageResponse.java
+++ b/backend/src/main/java/com/woowacourse/f12/dto/response/member/MemberPageResponse.java
@@ -1,0 +1,30 @@
+package com.woowacourse.f12.dto.response.member;
+
+import com.woowacourse.f12.domain.member.Member;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.Getter;
+import org.springframework.data.domain.Slice;
+
+@Getter
+public class MemberPageResponse {
+
+    private boolean hasNext;
+    private List<MemberWithProfileProductResponse> items;
+
+    public MemberPageResponse() {
+    }
+
+    private MemberPageResponse(final boolean hasNext, final List<MemberWithProfileProductResponse> items) {
+        this.hasNext = hasNext;
+        this.items = items;
+    }
+
+    public static MemberPageResponse from(final Slice<Member> slice) {
+        final List<MemberWithProfileProductResponse> items = slice.getContent()
+                .stream()
+                .map(MemberWithProfileProductResponse::from)
+                .collect(Collectors.toList());
+        return new MemberPageResponse(slice.hasNext(), items);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/dto/response/member/MemberResponse.java
+++ b/backend/src/main/java/com/woowacourse/f12/dto/response/member/MemberResponse.java
@@ -1,6 +1,8 @@
 package com.woowacourse.f12.dto.response.member;
 
 import com.woowacourse.f12.domain.member.Member;
+import com.woowacourse.f12.dto.CareerLevelConstant;
+import com.woowacourse.f12.dto.JobTypeConstant;
 import lombok.Getter;
 
 @Getter
@@ -28,6 +30,7 @@ public class MemberResponse {
 
     public static MemberResponse from(final Member member) {
         return new MemberResponse(member.getId(), member.getGitHubId(), member.getName(), member.getImageUrl(),
-                member.getCareerLevel().name(), member.getJobType().name());
+                CareerLevelConstant.findByCareerLevel(member.getCareerLevel()).getViewValue(),
+                JobTypeConstant.findByJobType(member.getJobType()).getViewValue());
     }
 }

--- a/backend/src/main/java/com/woowacourse/f12/dto/response/member/MemberWithProfileProductResponse.java
+++ b/backend/src/main/java/com/woowacourse/f12/dto/response/member/MemberWithProfileProductResponse.java
@@ -1,6 +1,8 @@
 package com.woowacourse.f12.dto.response.member;
 
 import com.woowacourse.f12.domain.member.Member;
+import com.woowacourse.f12.dto.CareerLevelConstant;
+import com.woowacourse.f12.dto.JobTypeConstant;
 import com.woowacourse.f12.dto.response.product.KeyboardResponse;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -39,6 +41,7 @@ public class MemberWithProfileProductResponse {
                 .map(inventoryProduct -> KeyboardResponse.from(inventoryProduct.getKeyboard()))
                 .collect(Collectors.toList());
         return new MemberWithProfileProductResponse(member.getId(), member.getGitHubId(), member.getName(),
-                member.getImageUrl(), member.getCareerLevel().name(), member.getJobType().name(), profileProducts);
+                member.getImageUrl(), CareerLevelConstant.findByCareerLevel(member.getCareerLevel()).getViewValue(),
+                JobTypeConstant.findByJobType(member.getJobType()).getViewValue(), profileProducts);
     }
 }

--- a/backend/src/main/java/com/woowacourse/f12/dto/response/member/MemberWithProfileProductResponse.java
+++ b/backend/src/main/java/com/woowacourse/f12/dto/response/member/MemberWithProfileProductResponse.java
@@ -1,0 +1,44 @@
+package com.woowacourse.f12.dto.response.member;
+
+import com.woowacourse.f12.domain.member.Member;
+import com.woowacourse.f12.dto.response.product.KeyboardResponse;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.Getter;
+
+@Getter
+public class MemberWithProfileProductResponse {
+
+    private Long id;
+    private String gitHubId;
+    private String name;
+    private String imageUrl;
+    private String careerLevel;
+    private String jobType;
+    private List<KeyboardResponse> profileProducts;
+
+    private MemberWithProfileProductResponse() {
+    }
+
+
+    private MemberWithProfileProductResponse(final Long id, final String gitHubId, final String name,
+                                             final String imageUrl, final String careerLevel,
+                                             final String jobType, final List<KeyboardResponse> profileProducts) {
+        this.id = id;
+        this.gitHubId = gitHubId;
+        this.name = name;
+        this.imageUrl = imageUrl;
+        this.careerLevel = careerLevel;
+        this.jobType = jobType;
+        this.profileProducts = profileProducts;
+    }
+
+    public static MemberWithProfileProductResponse from(final Member member) {
+        final List<KeyboardResponse> profileProducts = member.getInventoryProducts()
+                .stream()
+                .map(inventoryProduct -> KeyboardResponse.from(inventoryProduct.getKeyboard()))
+                .collect(Collectors.toList());
+        return new MemberWithProfileProductResponse(member.getId(), member.getGitHubId(), member.getName(),
+                member.getImageUrl(), member.getCareerLevel().name(), member.getJobType().name(), profileProducts);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/exception/badrequest/InvalidCareerLevelException.java
+++ b/backend/src/main/java/com/woowacourse/f12/exception/badrequest/InvalidCareerLevelException.java
@@ -1,0 +1,8 @@
+package com.woowacourse.f12.exception.badrequest;
+
+public class InvalidCareerLevelException extends InvalidValueException {
+
+    public InvalidCareerLevelException() {
+        super("올바르지 않은 연차 입력입니다.");
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/exception/badrequest/InvalidJobTypeException.java
+++ b/backend/src/main/java/com/woowacourse/f12/exception/badrequest/InvalidJobTypeException.java
@@ -1,0 +1,8 @@
+package com.woowacourse.f12.exception.badrequest;
+
+public class InvalidJobTypeException extends InvalidValueException {
+
+    public InvalidJobTypeException() {
+        super("올바르지 않은 직군 입력입니다.");
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/presentation/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/GlobalExceptionHandler.java
@@ -1,14 +1,15 @@
 package com.woowacourse.f12.presentation;
 
 import com.woowacourse.f12.dto.response.ExceptionResponse;
-import com.woowacourse.f12.exception.forbidden.ForbiddenMemberException;
 import com.woowacourse.f12.exception.badrequest.InvalidValueException;
+import com.woowacourse.f12.exception.forbidden.ForbiddenMemberException;
 import com.woowacourse.f12.exception.notfound.NotFoundException;
 import com.woowacourse.f12.exception.unauthorized.UnauthorizedException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.BindException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -32,6 +33,11 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(HttpMessageNotReadableException.class)
     public ResponseEntity<ExceptionResponse> handleHttpMessageNotReadableException() {
+        return ResponseEntity.badRequest().body(ExceptionResponse.from(REQUEST_DATA_FORMAT_ERROR_MESSAGE));
+    }
+
+    @ExceptionHandler(BindException.class)
+    public ResponseEntity<ExceptionResponse> handleBindException() {
         return ResponseEntity.badRequest().body(ExceptionResponse.from(REQUEST_DATA_FORMAT_ERROR_MESSAGE));
     }
 

--- a/backend/src/main/java/com/woowacourse/f12/presentation/ViewConstant.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/ViewConstant.java
@@ -1,0 +1,9 @@
+package com.woowacourse.f12.presentation;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public interface ViewConstant {
+
+    @JsonValue
+    String getViewValue();
+}

--- a/backend/src/main/java/com/woowacourse/f12/presentation/member/CareerLevelParamConverter.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/member/CareerLevelParamConverter.java
@@ -1,0 +1,15 @@
+package com.woowacourse.f12.presentation.member;
+
+
+import com.woowacourse.f12.dto.CareerLevelConstant;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CareerLevelParamConverter implements Converter<String, CareerLevelConstant> {
+
+    @Override
+    public CareerLevelConstant convert(String source) {
+        return CareerLevelConstant.findByViewValue(source);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/presentation/member/JobTypeParamConverter.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/member/JobTypeParamConverter.java
@@ -1,0 +1,14 @@
+package com.woowacourse.f12.presentation.member;
+
+import com.woowacourse.f12.dto.JobTypeConstant;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JobTypeParamConverter implements Converter<String, JobTypeConstant> {
+
+    @Override
+    public JobTypeConstant convert(String source) {
+        return JobTypeConstant.findByViewValue(source);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/presentation/member/MemberController.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/member/MemberController.java
@@ -2,12 +2,16 @@ package com.woowacourse.f12.presentation.member;
 
 import com.woowacourse.f12.application.member.MemberService;
 import com.woowacourse.f12.dto.request.member.MemberRequest;
+import com.woowacourse.f12.dto.request.member.MemberSearchRequest;
+import com.woowacourse.f12.dto.response.member.MemberPageResponse;
 import com.woowacourse.f12.dto.response.member.MemberResponse;
 import com.woowacourse.f12.presentation.auth.LoginRequired;
 import com.woowacourse.f12.presentation.auth.VerifiedMember;
 import javax.validation.Valid;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -43,5 +47,12 @@ public class MemberController {
                                          @Valid @RequestBody final MemberRequest memberRequest) {
         memberService.updateMember(memberId, memberRequest);
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping
+    public ResponseEntity<MemberPageResponse> searchMembers(
+            @ModelAttribute final MemberSearchRequest memberSearchRequest, final Pageable pageable) {
+        final MemberPageResponse memberPageResponse = memberService.findByContains(memberSearchRequest, pageable);
+        return ResponseEntity.ok(memberPageResponse);
     }
 }

--- a/backend/src/test/java/com/woowacourse/f12/acceptance/MemberAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/acceptance/MemberAcceptanceTest.java
@@ -115,4 +115,110 @@ public class MemberAcceptanceTest extends AcceptanceTest {
                         .isEqualTo(MemberResponse.from(expectedMember))
         );
     }
+
+    @Test
+    void 회원정보를_검색하여_조회한다() {
+        // given
+        Keyboard keyboard = 키보드를_저장한다(KEYBOARD_1.생성());
+        MemberRequest memberRequest = new MemberRequest(SENIOR, BACKEND);
+        LoginResponse loginResponse1 = 로그인을_한다("1");
+        로그인된_상태로_PATCH_요청을_보낸다("/api/v1/members/me", loginResponse1.getToken(), memberRequest);
+        LoginResponse loginResponse = 로그인을_한다("hamcheeseburger");
+        String token = loginResponse.getToken();
+        Long memberId = loginResponse.getMember().getId();
+        로그인된_상태로_PATCH_요청을_보낸다("/api/v1/members/me", token, memberRequest);
+        REVIEW_RATING_5.작성_요청을_보낸다(keyboard.getId(), token);
+
+        // when
+        ExtractableResponse<Response> response = GET_요청을_보낸다(
+                "/api/v1/members?page=0&size=2");
+
+        // then
+        MemberPageResponse memberPageResponse = response.as(MemberPageResponse.class);
+        InventoryProduct inventoryProduct = SELECTED_INVENTORY_PRODUCT.생성(1L, CORINNE.생성(memberId), keyboard);
+        Member member = CORINNE.대표장비_추가(memberId, inventoryProduct);
+        MemberWithProfileProductResponse memberWithProfileProductResponse = MemberWithProfileProductResponse.from(
+                member);
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(memberPageResponse.isHasNext()).isFalse(),
+                () -> assertThat(
+                        memberPageResponse.getItems()).usingRecursiveFieldByFieldElementComparatorIgnoringFields(
+                                "profileProducts")
+                        .hasSize(2)
+                        .contains(memberWithProfileProductResponse)
+        );
+    }
+
+    @Test
+    void 회원정보를_옵션으로_검색하여_조회한다() {
+        // given
+        Keyboard keyboard = 키보드를_저장한다(KEYBOARD_1.생성());
+        MemberRequest memberRequest = new MemberRequest(SENIOR, BACKEND);
+        LoginResponse loginResponse1 = 로그인을_한다("1");
+        로그인된_상태로_PATCH_요청을_보낸다("/api/v1/members/me", loginResponse1.getToken(), memberRequest);
+        LoginResponse loginResponse = 로그인을_한다("hamcheeseburger");
+        String token = loginResponse.getToken();
+        Long memberId = loginResponse.getMember().getId();
+        로그인된_상태로_PATCH_요청을_보낸다("/api/v1/members/me", token, memberRequest);
+        REVIEW_RATING_5.작성_요청을_보낸다(keyboard.getId(), token);
+
+        // when
+        ExtractableResponse<Response> response = GET_요청을_보낸다(
+                "/api/v1/members?page=0&size=2&careerLevel=senior&jobType=backend");
+
+        // then
+        MemberPageResponse memberPageResponse = response.as(MemberPageResponse.class);
+        InventoryProduct inventoryProduct = SELECTED_INVENTORY_PRODUCT.생성(1L, CORINNE.생성(memberId), keyboard);
+        Member member = CORINNE.대표장비_추가(memberId, inventoryProduct);
+        MemberWithProfileProductResponse memberWithProfileProductResponse = MemberWithProfileProductResponse.from(
+                member);
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(memberPageResponse.isHasNext()).isFalse(),
+                () -> assertThat(
+                        memberPageResponse.getItems()).usingRecursiveFieldByFieldElementComparatorIgnoringFields(
+                                "profileProducts")
+                        .hasSize(2)
+                        .contains(memberWithProfileProductResponse)
+        );
+    }
+
+    @Test
+    void 회원정보를_키워드와_옵션으로_검색하여_조회한다() {
+        // given
+        Keyboard keyboard = 키보드를_저장한다(KEYBOARD_1.생성());
+        MemberRequest memberRequest = new MemberRequest(SENIOR, BACKEND);
+        LoginResponse loginResponse1 = 로그인을_한다("1");
+        로그인된_상태로_PATCH_요청을_보낸다("/api/v1/members/me", loginResponse1.getToken(), memberRequest);
+        LoginResponse loginResponse = 로그인을_한다("hamcheeseburger");
+        String token = loginResponse.getToken();
+        Long memberId = loginResponse.getMember().getId();
+        로그인된_상태로_PATCH_요청을_보낸다("/api/v1/members/me", token, memberRequest);
+        REVIEW_RATING_5.작성_요청을_보낸다(keyboard.getId(), token);
+
+        // when
+        ExtractableResponse<Response> response = GET_요청을_보낸다(
+                "/api/v1/members?page=0&size=2&query=cheese&careerLevel=senior&jobType=backend");
+
+        // then
+        MemberPageResponse memberPageResponse = response.as(MemberPageResponse.class);
+        InventoryProduct inventoryProduct = SELECTED_INVENTORY_PRODUCT.생성(1L, CORINNE.생성(memberId), keyboard);
+        Member member = CORINNE.대표장비_추가(memberId, inventoryProduct);
+        MemberWithProfileProductResponse memberWithProfileProductResponse = MemberWithProfileProductResponse.from(
+                member);
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(memberPageResponse.isHasNext()).isFalse(),
+                () -> assertThat(
+                        memberPageResponse.getItems()).usingRecursiveFieldByFieldElementComparatorIgnoringFields(
+                                "profileProducts")
+                        .hasSize(1)
+                        .containsOnly(memberWithProfileProductResponse)
+        );
+    }
+
+    private Keyboard 키보드를_저장한다(Keyboard keyboard) {
+        return keyboardRepository.save(keyboard);
+    }
 }

--- a/backend/src/test/java/com/woowacourse/f12/acceptance/MemberAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/acceptance/MemberAcceptanceTest.java
@@ -4,8 +4,9 @@ import static com.woowacourse.f12.acceptance.support.LoginUtil.로그인을_한�
 import static com.woowacourse.f12.acceptance.support.RestAssuredRequestUtil.GET_요청을_보낸다;
 import static com.woowacourse.f12.acceptance.support.RestAssuredRequestUtil.로그인된_상태로_GET_요청을_보낸다;
 import static com.woowacourse.f12.acceptance.support.RestAssuredRequestUtil.로그인된_상태로_PATCH_요청을_보낸다;
-import static com.woowacourse.f12.domain.member.CareerLevel.JUNIOR;
-import static com.woowacourse.f12.domain.member.JobType.BACKEND;
+import static com.woowacourse.f12.dto.CareerLevelConstant.JUNIOR;
+import static com.woowacourse.f12.dto.CareerLevelConstant.SENIOR;
+import static com.woowacourse.f12.dto.JobTypeConstant.BACKEND;
 import static com.woowacourse.f12.support.InventoryProductFixtures.SELECTED_INVENTORY_PRODUCT;
 import static com.woowacourse.f12.support.KeyboardFixtures.KEYBOARD_1;
 import static com.woowacourse.f12.support.MemberFixtures.CORINNE;
@@ -14,6 +15,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.woowacourse.f12.domain.inventoryproduct.InventoryProduct;
+import com.woowacourse.f12.domain.member.CareerLevel;
+import com.woowacourse.f12.domain.member.JobType;
 import com.woowacourse.f12.domain.member.Member;
 import com.woowacourse.f12.domain.product.Keyboard;
 import com.woowacourse.f12.domain.product.KeyboardRepository;
@@ -23,10 +26,8 @@ import com.woowacourse.f12.dto.response.auth.LoginResponse;
 import com.woowacourse.f12.dto.response.member.MemberPageResponse;
 import com.woowacourse.f12.dto.response.member.MemberResponse;
 import com.woowacourse.f12.dto.response.member.MemberWithProfileProductResponse;
-import com.woowacourse.f12.dto.response.product.KeyboardResponse;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
-import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -50,8 +51,8 @@ public class MemberAcceptanceTest extends AcceptanceTest {
 
         // then
         Member member = Member.builder()
-                .careerLevel(JUNIOR)
-                .jobType(BACKEND)
+                .careerLevel(CareerLevel.JUNIOR)
+                .jobType(JobType.BACKEND)
                 .build();
         assertAll(
                 () -> assertThat(memberGetResponse.as(MemberResponse.class)).usingRecursiveComparison()
@@ -76,8 +77,8 @@ public class MemberAcceptanceTest extends AcceptanceTest {
 
         // then
         Member expectedMember = loginMemberResponse.toMember();
-        expectedMember.updateCareerLevel(JUNIOR);
-        expectedMember.updateJobType(BACKEND);
+        expectedMember.updateCareerLevel(CareerLevel.JUNIOR);
+        expectedMember.updateJobType(JobType.BACKEND);
 
         assertAll(
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
@@ -105,8 +106,8 @@ public class MemberAcceptanceTest extends AcceptanceTest {
                 .name(loginMemberResponse.getName())
                 .gitHubId(loginMemberResponse.getGitHubId())
                 .imageUrl(loginMemberResponse.getImageUrl())
-                .careerLevel(JUNIOR)
-                .jobType(BACKEND)
+                .careerLevel(CareerLevel.JUNIOR)
+                .jobType(JobType.BACKEND)
                 .build();
         assertAll(
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),

--- a/backend/src/test/java/com/woowacourse/f12/acceptance/MemberAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/acceptance/MemberAcceptanceTest.java
@@ -5,28 +5,43 @@ import static com.woowacourse.f12.acceptance.support.RestAssuredRequestUtil.GET_
 import static com.woowacourse.f12.acceptance.support.RestAssuredRequestUtil.로그인된_상태로_GET_요청을_보낸다;
 import static com.woowacourse.f12.acceptance.support.RestAssuredRequestUtil.로그인된_상태로_PATCH_요청을_보낸다;
 import static com.woowacourse.f12.domain.member.CareerLevel.JUNIOR;
-import static com.woowacourse.f12.domain.member.JobType.BACK_END;
+import static com.woowacourse.f12.domain.member.JobType.BACKEND;
+import static com.woowacourse.f12.support.InventoryProductFixtures.SELECTED_INVENTORY_PRODUCT;
+import static com.woowacourse.f12.support.KeyboardFixtures.KEYBOARD_1;
+import static com.woowacourse.f12.support.MemberFixtures.CORINNE;
+import static com.woowacourse.f12.support.ReviewFixtures.REVIEW_RATING_5;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.woowacourse.f12.domain.inventoryproduct.InventoryProduct;
 import com.woowacourse.f12.domain.member.Member;
+import com.woowacourse.f12.domain.product.Keyboard;
+import com.woowacourse.f12.domain.product.KeyboardRepository;
 import com.woowacourse.f12.dto.request.member.MemberRequest;
 import com.woowacourse.f12.dto.response.auth.LoginMemberResponse;
 import com.woowacourse.f12.dto.response.auth.LoginResponse;
+import com.woowacourse.f12.dto.response.member.MemberPageResponse;
 import com.woowacourse.f12.dto.response.member.MemberResponse;
+import com.woowacourse.f12.dto.response.member.MemberWithProfileProductResponse;
+import com.woowacourse.f12.dto.response.product.KeyboardResponse;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 
 public class MemberAcceptanceTest extends AcceptanceTest {
+
+    @Autowired
+    private KeyboardRepository keyboardRepository;
 
     @Test
     void 로그인_된_상태에서_내_회원정보를_업데이트한다() {
         // given
         LoginResponse loginResponse = 로그인을_한다("1");
         String token = loginResponse.getToken();
-        MemberRequest memberRequest = new MemberRequest(JUNIOR, BACK_END);
+        MemberRequest memberRequest = new MemberRequest(JUNIOR, BACKEND);
 
         // when
         ExtractableResponse<Response> memberUpdatedResponse = 로그인된_상태로_PATCH_요청을_보낸다("/api/v1/members/me", token,
@@ -36,7 +51,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
         // then
         Member member = Member.builder()
                 .careerLevel(JUNIOR)
-                .jobType(BACK_END)
+                .jobType(BACKEND)
                 .build();
         assertAll(
                 () -> assertThat(memberGetResponse.as(MemberResponse.class)).usingRecursiveComparison()
@@ -53,7 +68,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
         String token = loginResponse.getToken();
         LoginMemberResponse loginMemberResponse = loginResponse.getMember();
 
-        MemberRequest memberRequest = new MemberRequest(JUNIOR, BACK_END);
+        MemberRequest memberRequest = new MemberRequest(JUNIOR, BACKEND);
         로그인된_상태로_PATCH_요청을_보낸다("/api/v1/members/me", token, memberRequest);
 
         // when
@@ -62,7 +77,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
         // then
         Member expectedMember = loginMemberResponse.toMember();
         expectedMember.updateCareerLevel(JUNIOR);
-        expectedMember.updateJobType(BACK_END);
+        expectedMember.updateJobType(BACKEND);
 
         assertAll(
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
@@ -78,7 +93,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
         String token = loginResponse.getToken();
         LoginMemberResponse loginMemberResponse = loginResponse.getMember();
 
-        MemberRequest memberRequest = new MemberRequest(JUNIOR, BACK_END);
+        MemberRequest memberRequest = new MemberRequest(JUNIOR, BACKEND);
         로그인된_상태로_PATCH_요청을_보낸다("/api/v1/members/me", token, memberRequest);
 
         // when
@@ -91,7 +106,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
                 .gitHubId(loginMemberResponse.getGitHubId())
                 .imageUrl(loginMemberResponse.getImageUrl())
                 .careerLevel(JUNIOR)
-                .jobType(BACK_END)
+                .jobType(BACKEND)
                 .build();
         assertAll(
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),

--- a/backend/src/test/java/com/woowacourse/f12/application/member/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/application/member/MemberServiceTest.java
@@ -1,7 +1,5 @@
 package com.woowacourse.f12.application.member;
 
-import static com.woowacourse.f12.domain.member.CareerLevel.JUNIOR;
-import static com.woowacourse.f12.domain.member.JobType.ETC;
 import static com.woowacourse.f12.dto.CareerLevelConstant.SENIOR;
 import static com.woowacourse.f12.dto.JobTypeConstant.BACKEND;
 import static com.woowacourse.f12.support.InventoryProductFixtures.SELECTED_INVENTORY_PRODUCT;
@@ -17,6 +15,8 @@ import com.woowacourse.f12.domain.member.CareerLevel;
 import com.woowacourse.f12.domain.member.JobType;
 import com.woowacourse.f12.domain.member.Member;
 import com.woowacourse.f12.domain.member.MemberRepository;
+import com.woowacourse.f12.dto.CareerLevelConstant;
+import com.woowacourse.f12.dto.JobTypeConstant;
 import com.woowacourse.f12.dto.request.member.MemberRequest;
 import com.woowacourse.f12.dto.request.member.MemberSearchRequest;
 import com.woowacourse.f12.dto.response.member.MemberPageResponse;
@@ -103,7 +103,7 @@ class MemberServiceTest {
                 .willReturn(Optional.of(CORINNE.생성(1L)));
 
         // when
-        memberService.updateMember(1L, new MemberRequest(JUNIOR, ETC));
+        memberService.updateMember(1L, new MemberRequest(CareerLevelConstant.JUNIOR, JobTypeConstant.ETC));
 
         // then
         verify(memberRepository).findById(1L);

--- a/backend/src/test/java/com/woowacourse/f12/documentation/member/MemberDocumentation.java
+++ b/backend/src/test/java/com/woowacourse/f12/documentation/member/MemberDocumentation.java
@@ -1,8 +1,8 @@
 package com.woowacourse.f12.documentation.member;
 
-import static com.woowacourse.f12.domain.member.CareerLevel.JUNIOR;
-import static com.woowacourse.f12.domain.member.JobType.BACKEND;
+import static com.woowacourse.f12.support.InventoryProductFixtures.SELECTED_INVENTORY_PRODUCT;
 import static com.woowacourse.f12.support.MemberFixtures.CORINNE;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
@@ -15,6 +15,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.woowacourse.f12.application.auth.JwtProvider;
 import com.woowacourse.f12.application.member.MemberService;
 import com.woowacourse.f12.documentation.Documentation;
+import com.woowacourse.f12.domain.inventoryproduct.InventoryProduct;
+import com.woowacourse.f12.domain.member.Member;
+import com.woowacourse.f12.dto.CareerLevelConstant;
+import com.woowacourse.f12.dto.JobTypeConstant;
 import com.woowacourse.f12.dto.request.member.MemberRequest;
 import com.woowacourse.f12.dto.response.member.MemberResponse;
 import com.woowacourse.f12.presentation.member.MemberController;
@@ -85,7 +89,7 @@ public class MemberDocumentation extends Documentation {
     @Test
     void 로그인된_상태에서_나의_회원정보를_수정_API_문서화() throws Exception {
         // given
-        MemberRequest memberRequest = new MemberRequest(JUNIOR, BACKEND);
+        MemberRequest memberRequest = new MemberRequest(CareerLevelConstant.JUNIOR, JobTypeConstant.BACKEND);
         String authorizationHeader = "Bearer Token";
         given(jwtProvider.validateToken(authorizationHeader))
                 .willReturn(true);

--- a/backend/src/test/java/com/woowacourse/f12/documentation/member/MemberDocumentation.java
+++ b/backend/src/test/java/com/woowacourse/f12/documentation/member/MemberDocumentation.java
@@ -1,7 +1,7 @@
 package com.woowacourse.f12.documentation.member;
 
 import static com.woowacourse.f12.domain.member.CareerLevel.JUNIOR;
-import static com.woowacourse.f12.domain.member.JobType.BACK_END;
+import static com.woowacourse.f12.domain.member.JobType.BACKEND;
 import static com.woowacourse.f12.support.MemberFixtures.CORINNE;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
@@ -85,7 +85,7 @@ public class MemberDocumentation extends Documentation {
     @Test
     void 로그인된_상태에서_나의_회원정보를_수정_API_문서화() throws Exception {
         // given
-        MemberRequest memberRequest = new MemberRequest(JUNIOR, BACK_END);
+        MemberRequest memberRequest = new MemberRequest(JUNIOR, BACKEND);
         String authorizationHeader = "Bearer Token";
         given(jwtProvider.validateToken(authorizationHeader))
                 .willReturn(true);

--- a/backend/src/test/java/com/woowacourse/f12/documentation/member/MemberDocumentation.java
+++ b/backend/src/test/java/com/woowacourse/f12/documentation/member/MemberDocumentation.java
@@ -20,12 +20,19 @@ import com.woowacourse.f12.domain.member.Member;
 import com.woowacourse.f12.dto.CareerLevelConstant;
 import com.woowacourse.f12.dto.JobTypeConstant;
 import com.woowacourse.f12.dto.request.member.MemberRequest;
+import com.woowacourse.f12.dto.request.member.MemberSearchRequest;
+import com.woowacourse.f12.dto.response.member.MemberPageResponse;
 import com.woowacourse.f12.dto.response.member.MemberResponse;
 import com.woowacourse.f12.presentation.member.MemberController;
+import com.woowacourse.f12.support.KeyboardFixtures;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
@@ -108,6 +115,27 @@ public class MemberDocumentation extends Documentation {
         // then
         resultActions.andExpect(status().isOk())
                 .andDo(document("members-update"))
+                .andDo(print());
+    }
+
+    @Test
+    void 키워드와_옵션으로_회원을_조회_API_문서화() throws Exception {
+        // given
+        Pageable pageable = PageRequest.of(0, 10);
+        InventoryProduct inventoryProduct = SELECTED_INVENTORY_PRODUCT.생성(CORINNE.생성(1L),
+                KeyboardFixtures.KEYBOARD_1.생성(1L));
+        Member member = CORINNE.대표장비_추가(1L, inventoryProduct);
+
+        MemberPageResponse memberPageResponse = MemberPageResponse.from(
+                new SliceImpl<>(List.of(member), pageable, false));
+        given(memberService.findByContains(any(MemberSearchRequest.class), any(PageRequest.class)))
+                .willReturn(memberPageResponse);
+
+        // when, then
+        mockMvc.perform(
+                        get("/api/v1/members?query=cheese&careerLevel=none&jobType=backend&page=0&size=10")
+                ).andExpect(status().isOk())
+                .andDo(document("members-search"))
                 .andDo(print());
     }
 }

--- a/backend/src/test/java/com/woowacourse/f12/domain/member/MemberRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/domain/member/MemberRepositoryTest.java
@@ -1,0 +1,111 @@
+package com.woowacourse.f12.domain.member;
+
+import static com.woowacourse.f12.support.MemberFixtures.CORINNE;
+import static com.woowacourse.f12.support.MemberFixtures.MINCHO;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.woowacourse.f12.config.JpaConfig;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+
+@DataJpaTest
+@Import({JpaConfig.class})
+class MemberRepositoryTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Test
+    void 키워드와_옵션을_입력하지않고_회원을_조회한다() {
+        // given
+        memberRepository.saveAll(List.of(CORINNE.생성(), MINCHO.생성()));
+
+        // when
+        Slice<Member> slice = memberRepository.findByContains(null, null, null, PageRequest.of(0, 2));
+
+        // then
+        assertAll(
+                () -> assertThat(slice.hasNext()).isFalse(),
+                () -> assertThat(slice.getContent()).usingRecursiveFieldByFieldElementComparatorIgnoringFields("id")
+                        .contains(CORINNE.생성(), MINCHO.생성())
+        );
+    }
+
+    @Test
+    void 회원의_깃허브_아이디를_키워드로_조회한다() {
+        // given
+        memberRepository.saveAll(List.of(CORINNE.생성(), MINCHO.생성()));
+
+        // when
+        Slice<Member> slice = memberRepository.findByContains("hamcheeseburger", null, null, PageRequest.of(0, 2));
+
+        // then
+        assertAll(
+                () -> assertThat(slice.hasNext()).isFalse(),
+                () -> assertThat(slice.getContent()).usingRecursiveFieldByFieldElementComparatorIgnoringFields("id")
+                        .containsOnly(CORINNE.생성())
+        );
+    }
+
+    @Test
+    void 회원의_깃허브_아이디_일부를_키워드로_조회한다() {
+        // given
+        memberRepository.saveAll(List.of(CORINNE.생성(), MINCHO.생성()));
+
+        // when
+        Slice<Member> slice = memberRepository.findByContains("cheese", null, null, PageRequest.of(0, 2));
+
+        // then
+        assertAll(
+                () -> assertThat(slice.hasNext()).isFalse(),
+                () -> assertThat(slice.getContent()).usingRecursiveFieldByFieldElementComparatorIgnoringFields("id")
+                        .containsOnly(CORINNE.생성())
+        );
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"cheese"})
+    void 회원의_연차를_옵션으로_조회한다(String keyword) {
+        // given
+        memberRepository.saveAll(List.of(CORINNE.생성(), MINCHO.생성()));
+
+        // when
+        Slice<Member> slice = memberRepository.findByContains(keyword, CareerLevel.SENIOR, null, PageRequest.of(0, 2));
+
+        // then
+        assertAll(
+                () -> assertThat(slice.hasNext()).isFalse(),
+                () -> assertThat(slice.getContent()).usingRecursiveFieldByFieldElementComparatorIgnoringFields("id")
+                        .containsOnly(CORINNE.생성())
+        );
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"cheese"})
+    void 회원의_직군을_옵션으로_조회한다(String keyword) {
+        // given
+        memberRepository.saveAll(List.of(CORINNE.생성(), MINCHO.생성()));
+
+        // when
+        Slice<Member> slice = memberRepository.findByContains(keyword, CareerLevel.SENIOR, JobType.BACK_END,
+                PageRequest.of(0, 2));
+
+        // then
+        assertAll(
+                () -> assertThat(slice.hasNext()).isFalse(),
+                () -> assertThat(slice.getContent()).usingRecursiveFieldByFieldElementComparatorIgnoringFields("id")
+                        .containsOnly(CORINNE.생성())
+        );
+    }
+}

--- a/backend/src/test/java/com/woowacourse/f12/domain/member/MemberRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/domain/member/MemberRepositoryTest.java
@@ -98,7 +98,7 @@ class MemberRepositoryTest {
         memberRepository.saveAll(List.of(CORINNE.생성(), MINCHO.생성()));
 
         // when
-        Slice<Member> slice = memberRepository.findByContains(keyword, CareerLevel.SENIOR, JobType.BACK_END,
+        Slice<Member> slice = memberRepository.findByContains(keyword, CareerLevel.SENIOR, JobType.BACKEND,
                 PageRequest.of(0, 2));
 
         // then

--- a/backend/src/test/java/com/woowacourse/f12/presentation/member/MemberControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/member/MemberControllerTest.java
@@ -1,11 +1,13 @@
 package com.woowacourse.f12.presentation.member;
 
-import static com.woowacourse.f12.domain.member.CareerLevel.JUNIOR;
-import static com.woowacourse.f12.domain.member.JobType.ETC;
+import static com.woowacourse.f12.dto.CareerLevelConstant.NONE;
+import static com.woowacourse.f12.dto.JobTypeConstant.BACKEND;
+import static com.woowacourse.f12.support.InventoryProductFixtures.SELECTED_INVENTORY_PRODUCT;
 import static com.woowacourse.f12.support.MemberFixtures.CORINNE;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.refEq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.times;
@@ -18,15 +20,27 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.woowacourse.f12.application.auth.JwtProvider;
 import com.woowacourse.f12.application.member.MemberService;
+import com.woowacourse.f12.domain.inventoryproduct.InventoryProduct;
+import com.woowacourse.f12.domain.member.Member;
+import com.woowacourse.f12.dto.CareerLevelConstant;
+import com.woowacourse.f12.dto.JobTypeConstant;
 import com.woowacourse.f12.dto.request.member.MemberRequest;
+import com.woowacourse.f12.dto.request.member.MemberSearchRequest;
+import com.woowacourse.f12.dto.response.member.MemberPageResponse;
 import com.woowacourse.f12.dto.response.member.MemberResponse;
 import com.woowacourse.f12.exception.notfound.MemberNotFoundException;
+import com.woowacourse.f12.support.KeyboardFixtures;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
@@ -108,7 +122,7 @@ class MemberControllerTest {
     @Test
     void 로그인된_상태에서_나의_회원정보를_수정_성공() throws Exception {
         // given
-        MemberRequest memberRequest = new MemberRequest(JUNIOR, ETC);
+        MemberRequest memberRequest = new MemberRequest(CareerLevelConstant.JUNIOR, JobTypeConstant.ETC);
         String authorizationHeader = "Bearer Token";
         given(jwtProvider.validateToken(authorizationHeader))
                 .willReturn(true);
@@ -138,8 +152,8 @@ class MemberControllerTest {
     void 로그인된_상태에서_나의_회원정보를_수정_성공_Enum의_name값으로_요청을_보낼때() throws Exception {
         // given
         Map<String, Object> memberRequest = new HashMap<>();
-        memberRequest.put("careerLevel", "SENIOR");
-        memberRequest.put("jobType", "BACKEND");
+        memberRequest.put("careerLevel", "senior");
+        memberRequest.put("jobType", "backend");
 
         String authorizationHeader = "Bearer Token";
         given(jwtProvider.validateToken(authorizationHeader))

--- a/backend/src/test/java/com/woowacourse/f12/presentation/member/MemberControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/member/MemberControllerTest.java
@@ -139,7 +139,7 @@ class MemberControllerTest {
         // given
         Map<String, Object> memberRequest = new HashMap<>();
         memberRequest.put("careerLevel", "SENIOR");
-        memberRequest.put("jobType", "BACK_END");
+        memberRequest.put("jobType", "BACKEND");
 
         String authorizationHeader = "Bearer Token";
         given(jwtProvider.validateToken(authorizationHeader))

--- a/backend/src/test/java/com/woowacourse/f12/support/FakeGitHubApiController.java
+++ b/backend/src/test/java/com/woowacourse/f12/support/FakeGitHubApiController.java
@@ -1,9 +1,12 @@
 package com.woowacourse.f12.support;
 
+import static com.woowacourse.f12.support.MemberFixtures.CORINNE;
+
 import com.woowacourse.f12.dto.request.auth.GitHubTokenRequest;
 import com.woowacourse.f12.dto.response.auth.GitHubProfileResponse;
 import com.woowacourse.f12.dto.response.auth.GitHubTokenResponse;
 import java.util.Map;
+import java.util.Objects;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
@@ -16,8 +19,16 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class FakeGitHubApiController {
 
-    private Map<String, String> codeAndToken = Map.of("1", "token1", "2", "token2");
-    private Map<String, String> tokenAndGitHubId = Map.of("token1", "gitHubId1", "token2", "gitHubId2");
+    private Map<String, String> codeAndToken = Map.of("1", "token1", "2", "token2", CORINNE.생성().getGitHubId(),
+            "token3");
+    private Map<String, String> tokenAndGitHubId = Map.of("token1", "gitHubId1", "token2", "gitHubId2", "token3",
+            CORINNE.생성().getGitHubId());
+
+    private Map<String, String> tokenAndName = Map.of("token1", "name", "token2", "name", "token3",
+            CORINNE.생성().getName());
+
+    private Map<String, String> tokenAndImageUrl = Map.of("token1", "url", "token2", "url", "token3",
+            CORINNE.생성().getImageUrl());
 
     private String clientId;
     private String clientSecret;
@@ -48,6 +59,9 @@ public class FakeGitHubApiController {
         if (splitValue.length != 2 || !splitValue[0].equals("token")) {
             return ResponseEntity.badRequest().build();
         }
-        return ResponseEntity.ok(new GitHubProfileResponse(tokenAndGitHubId.get(splitValue[1]), "name", "url"));
+
+        return ResponseEntity.ok(
+                new GitHubProfileResponse(tokenAndGitHubId.get(splitValue[1]), tokenAndName.get(splitValue[1]),
+                        tokenAndImageUrl.get(splitValue[1])));
     }
 }

--- a/backend/src/test/java/com/woowacourse/f12/support/FakeGitHubApiController.java
+++ b/backend/src/test/java/com/woowacourse/f12/support/FakeGitHubApiController.java
@@ -41,7 +41,7 @@ public class FakeGitHubApiController {
     @GetMapping("/user")
     public ResponseEntity<GitHubProfileResponse> showFakeProfile(
             @RequestHeader(value = HttpHeaders.AUTHORIZATION) final String authorizationHeaderValue) {
-        if (authorizationHeaderValue == null) {
+        if (Objects.isNull(authorizationHeaderValue)) {
             return ResponseEntity.badRequest().build();
         }
         final String[] splitValue = authorizationHeaderValue.split(" ");

--- a/backend/src/test/java/com/woowacourse/f12/support/MemberFixtures.java
+++ b/backend/src/test/java/com/woowacourse/f12/support/MemberFixtures.java
@@ -5,10 +5,12 @@ import static com.woowacourse.f12.domain.member.CareerLevel.SENIOR;
 import static com.woowacourse.f12.domain.member.JobType.BACKEND;
 import static com.woowacourse.f12.domain.member.JobType.FRONTEND;
 
+import com.woowacourse.f12.domain.inventoryproduct.InventoryProduct;
 import com.woowacourse.f12.domain.member.CareerLevel;
 import com.woowacourse.f12.domain.member.JobType;
 import com.woowacourse.f12.domain.member.Member;
 import com.woowacourse.f12.dto.response.auth.GitHubProfileResponse;
+import java.util.List;
 
 public enum MemberFixtures {
 
@@ -48,5 +50,17 @@ public enum MemberFixtures {
 
     public GitHubProfileResponse 깃허브_프로필() {
         return new GitHubProfileResponse(this.gitHubId, this.name, this.imageUrl);
+    }
+
+    public Member 대표장비_추가(final Long id, final InventoryProduct inventoryProduct) {
+        return Member.builder()
+                .id(id)
+                .gitHubId(this.gitHubId)
+                .name(this.name)
+                .imageUrl(this.imageUrl)
+                .careerLevel(this.careerLevel)
+                .jobType(this.jobType)
+                .inventoryProducts(List.of(inventoryProduct))
+                .build();
     }
 }

--- a/backend/src/test/java/com/woowacourse/f12/support/MemberFixtures.java
+++ b/backend/src/test/java/com/woowacourse/f12/support/MemberFixtures.java
@@ -2,8 +2,8 @@ package com.woowacourse.f12.support;
 
 import static com.woowacourse.f12.domain.member.CareerLevel.JUNIOR;
 import static com.woowacourse.f12.domain.member.CareerLevel.SENIOR;
-import static com.woowacourse.f12.domain.member.JobType.BACK_END;
-import static com.woowacourse.f12.domain.member.JobType.FRONT_END;
+import static com.woowacourse.f12.domain.member.JobType.BACKEND;
+import static com.woowacourse.f12.domain.member.JobType.FRONTEND;
 
 import com.woowacourse.f12.domain.member.CareerLevel;
 import com.woowacourse.f12.domain.member.JobType;
@@ -12,9 +12,9 @@ import com.woowacourse.f12.dto.response.auth.GitHubProfileResponse;
 
 public enum MemberFixtures {
 
-    CORINNE("hamcheeseburger", "유현지", "corinne_url", SENIOR, BACK_END),
-    MINCHO("jswith", "홍영민", "mincho_url", JUNIOR, FRONT_END),
-    CORINNE_UPDATED("hamcheeseburger", "괴물개발자", "corinne_url", SENIOR, BACK_END);
+    CORINNE("hamcheeseburger", "유현지", "corinne_url", SENIOR, BACKEND),
+    MINCHO("jswith", "홍영민", "mincho_url", JUNIOR, FRONTEND),
+    CORINNE_UPDATED("hamcheeseburger", "괴물개발자", "corinne_url", SENIOR, BACKEND);
 
     private final String gitHubId;
     private final String name;

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -10,6 +10,16 @@ spring:
 server:
   port: 8888
 
+logging:
+  level:
+    org:
+      hibernate:
+        sql: debug
+        type:
+          descriptor:
+            sql:
+              BasicBinder: trace
+
 github:
   client:
     id: clientId


### PR DESCRIPTION
# issue: #217

# 작업 내용
- querydsl 적용
- persistence Enum과 presentation Enum을 분리
- Member와 InventoryProduct의 연관관게에서 batchsize 적용
- InventoryProduct와 Product의 연관관계에서 FetchType EAGER 적용