### PR TITLE
[BE] 서브모듈로 분리한 h2 설정 파일 ignore

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -38,3 +38,4 @@ out/
 
 ### auth ###
 application-auth.yml
+application-h2.yml


### PR DESCRIPTION
# issue: #268 

# 작업 내용
- 서브모듈로 분리한 h2 설정 파일을 git ignore