### PR TITLE
[Bugfix] jar 파일 생성 시 RESTDocs가 포함되지 않는 오류 수정

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -79,7 +79,7 @@ asciidoctor {
 task copyDocument(type: Copy) {
     dependsOn asciidoctor
     from file("${asciidoctor.outputDir}")
-    into file("build/resources/static")
+    into file("build/resources/main/static")
 }
 
 bootJar {

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -79,7 +79,7 @@ asciidoctor {
 task copyDocument(type: Copy) {
     dependsOn asciidoctor
     from file("${asciidoctor.outputDir}")
-    into file("src/main/resources/static")
+    into file("build/resources/static")
 }
 
 bootJar {

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -54,9 +54,11 @@ ext {
 }
 
 task copySubmodule(type: Copy) {
-    from 'security'
-    include "*.yml"
-    into 'src/main/resources'
+    copy {
+        from 'security'
+        include "*.yml"
+        into 'src/main/resources'
+    }
 }
 
 tasks.named('test') {

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -68,6 +68,14 @@ asciidoctor {
     dependsOn test
 }
 
+task copyDocument(type: Copy) {
+    dependsOn asciidoctor
+    copy {
+        from file("${asciidoctor.outputDir}")
+        into file("src/main/resources/static")
+    }
+}
+
 task copySubmodule(type: Copy) {
     copy {
         from 'security'
@@ -77,9 +85,6 @@ task copySubmodule(type: Copy) {
 }
 
 bootJar {
-    dependsOn asciidoctor
-    copy {
-        from file("${asciidoctor.outputDir}")
-        into file("src/main/resources/static")
-    }
+    dependsOn copyDocument
+    dependsOn copySubmodule
 }

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -53,6 +53,12 @@ ext {
     set('snippetsDir', file("build/generated-snippets"))
 }
 
+task copySubmodule(type: Copy) {
+    from 'security'
+    include "*.yml"
+    into 'src/main/resources'
+}
+
 tasks.named('test') {
     outputs.dir snippetsDir
     useJUnitPlatform()
@@ -74,13 +80,6 @@ task copyDocument(type: Copy) {
     into file("src/main/resources/static")
 }
 
-task copySubmodule(type: Copy) {
-    from 'security'
-    include "*.yml"
-    into 'src/main/resources'
-}
-
 bootJar {
     dependsOn copyDocument
-    dependsOn copySubmodule
 }

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -70,18 +70,14 @@ asciidoctor {
 
 task copyDocument(type: Copy) {
     dependsOn asciidoctor
-    copy {
-        from file("${asciidoctor.outputDir}")
-        into file("src/main/resources/static")
-    }
+    from file("${asciidoctor.outputDir}")
+    into file("src/main/resources/static")
 }
 
 task copySubmodule(type: Copy) {
-    copy {
-        from 'security'
-        include "*.yml"
-        into 'src/main/resources'
-    }
+    from 'security'
+    include "*.yml"
+    into 'src/main/resources'
 }
 
 bootJar {

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -61,7 +61,7 @@ task copySubmodule(type: Copy) {
     }
 }
 
-tasks.named('test') {
+test {
     outputs.dir snippetsDir
     useJUnitPlatform()
 }


### PR DESCRIPTION
# issue: #283 

# 작업 내용
- gradle 빌드의 `copyDocument` 태스크의 목표 경로를 `build` 디렉토리 아래로 옮겨서 `bootJar` 태스크 실행 시 RESTDocs 파일이 Jar에 포함되도록 설정
