### PR TITLE
[FE] API 요청의 Error 처리 통일, Error UI 구현

### DIFF
--- a/frontend/src/components/ProductListSection/ProductListSection.tsx
+++ b/frontend/src/components/ProductListSection/ProductListSection.tsx
@@ -16,6 +16,7 @@ type Props = {
   data: Product[];
   isLoading: boolean;
   isReady: boolean;
+  isError: boolean;
   getNextPage?: () => void;
 };
 
@@ -25,6 +26,7 @@ function ProductListSection({
   data,
   isLoading,
   isReady,
+  isError,
   getNextPage,
 }: Props) {
   const ProductCardList = (data: Product[]) => {
@@ -42,18 +44,25 @@ function ProductListSection({
         {addOn}
       </SectionHeader>
       <S.Wrapper>
-        <AsyncWrapper fallback={<Loading />} isReady={isReady}>
-          {getNextPage !== undefined ? (
+        {getNextPage !== undefined ? (
+          <AsyncWrapper fallback={<Loading />} isReady={isReady}>
             <InfiniteScroll
               handleContentLoad={getNextPage}
               isLoading={isLoading}
+              isError={isError}
             >
               <Masonry columnCount={4}>{ProductCardList(data)}</Masonry>
             </InfiniteScroll>
-          ) : (
+          </AsyncWrapper>
+        ) : (
+          <AsyncWrapper
+            fallback={<Loading />}
+            isReady={isReady}
+            isError={isError}
+          >
             <Masonry columnCount={4}>{ProductCardList(data)}</Masonry>
-          )}
-        </AsyncWrapper>
+          </AsyncWrapper>
+        )}
       </S.Wrapper>
     </S.Container>
   );

--- a/frontend/src/components/ReviewListSection/ReviewListSection.tsx
+++ b/frontend/src/components/ReviewListSection/ReviewListSection.tsx
@@ -12,6 +12,7 @@ type Props = {
   data: Review[];
   isLoading: boolean;
   isReady: boolean;
+  isError: boolean;
   getNextPage: () => void;
   handleDelete?: (id: number) => void;
   handleEdit?: (reviewInput: ReviewInput, id: number) => void;
@@ -25,6 +26,7 @@ function ReviewListSection({
   handleEdit,
   isLoading,
   isReady,
+  isError,
 }: Props) {
   const userData = useContext(UserDataContext);
   const loginUserGithubId = userData?.member.gitHubId;
@@ -52,7 +54,11 @@ function ReviewListSection({
       </SectionHeader>
       <S.Wrapper columns={columns}>
         <AsyncWrapper fallback={<Loading />} isReady={isReady}>
-          <InfiniteScroll handleContentLoad={getNextPage} isLoading={isLoading}>
+          <InfiniteScroll
+            handleContentLoad={getNextPage}
+            isLoading={isLoading}
+            isError={isError}
+          >
             {reviewCardList}
           </InfiniteScroll>
         </AsyncWrapper>

--- a/frontend/src/components/common/AsyncWrapper/AsyncWrapper.tsx
+++ b/frontend/src/components/common/AsyncWrapper/AsyncWrapper.tsx
@@ -1,10 +1,19 @@
+import ErrorPlaceholder from '@/components/common/ErrorPlaceholder/ErrorPlaceholder';
 import React from 'react';
+
+type Props = {
+  fallback: JSX.Element;
+  isReady: boolean;
+  isError?: boolean;
+};
 
 function AsyncWrapper({
   children,
   fallback,
   isReady,
-}: React.PropsWithChildren<{ fallback: JSX.Element; isReady: boolean }>) {
+  isError,
+}: React.PropsWithChildren<Props>) {
+  if (isError) return <ErrorPlaceholder />;
   return isReady ? <>{children}</> : fallback;
 }
 

--- a/frontend/src/components/common/ErrorPlaceholder/ErrorPlaceholder.tsx
+++ b/frontend/src/components/common/ErrorPlaceholder/ErrorPlaceholder.tsx
@@ -1,0 +1,19 @@
+import { Player } from '@lottiefiles/react-lottie-player';
+
+function ErrorPlaceholder() {
+  return (
+    <>
+      <Player
+        autoplay
+        loop
+        src="https://assets2.lottiefiles.com/datafiles/AP6eAJ4K8cbfOl9/data.json"
+        style={{ height: '200px', width: '200px' }}
+      />
+      <div style={{ width: '100%', textAlign: 'center' }}>
+        오류가 발생했어요..
+      </div>
+    </>
+  );
+}
+
+export default ErrorPlaceholder;

--- a/frontend/src/components/common/InfiniteScroll/InfiniteScroll.tsx
+++ b/frontend/src/components/common/InfiniteScroll/InfiniteScroll.tsx
@@ -4,11 +4,13 @@ import { PropsWithChildren, useEffect, useMemo, useRef } from 'react';
 type Props = {
   handleContentLoad: () => void;
   isLoading: boolean;
+  isError: boolean;
 };
 
 function InfiniteScroll({
   handleContentLoad,
   isLoading,
+  isError,
   children,
 }: PropsWithChildren<Props>) {
   const endRef = useRef<HTMLDivElement>(null);
@@ -17,7 +19,6 @@ function InfiniteScroll({
     () =>
       new IntersectionObserver((entries) => {
         if (entries[0].isIntersecting) {
-          console.log(1);
           handleContentLoad();
         }
       }),
@@ -26,8 +27,12 @@ function InfiniteScroll({
 
   useEffect(() => {
     if (!endRef.current) return;
+    if (isError) {
+      endOfContentObserver.unobserve(endRef.current);
+      return;
+    }
     endOfContentObserver.observe(endRef.current);
-  }, []);
+  }, [isError]);
 
   return (
     <>

--- a/frontend/src/hooks/api/useAxios.tsx
+++ b/frontend/src/hooks/api/useAxios.tsx
@@ -10,13 +10,24 @@ type ErrorResponseBody = {
   errorCode: keyof typeof API_ERROR_MESSAGES;
 };
 
-function useAxios(): [AxiosInstance, boolean] {
+type Return = {
+  axiosInstance: AxiosInstance;
+  isLoading: boolean;
+  isError: boolean;
+};
+
+function useAxios(): Return {
   const [isLoading, setLoading] = useState(false);
+  const [isError, setError] = useState(false);
 
   const axiosInstance = axios.create({ baseURL: BASE_URL });
 
   const handleAPIError = (error: AxiosError<ErrorResponseBody>) => {
     const errorResponseBody = error.response.data;
+
+    setError(true);
+    setLoading(false);
+
     if (!('errorCode' in errorResponseBody)) {
       throw new Error(API_ERROR_CODE_EXCEPTION_MESSAGES.NO_CODE);
     }
@@ -29,6 +40,7 @@ function useAxios(): [AxiosInstance, boolean] {
   };
 
   axiosInstance.interceptors.request.use((request) => {
+    setError(false);
     setLoading(true);
     return request;
   });
@@ -38,7 +50,7 @@ function useAxios(): [AxiosInstance, boolean] {
     return response;
   }, handleAPIError);
 
-  return [axiosInstance, isLoading];
+  return { axiosInstance, isLoading, isError };
 }
 
 export default useAxios;

--- a/frontend/src/hooks/api/useDelete.tsx
+++ b/frontend/src/hooks/api/useDelete.tsx
@@ -1,5 +1,6 @@
 import { AxiosRequestHeaders } from 'axios';
-import axiosInstance from '@/hooks/api/axiosInstance';
+import useAxios from '@/hooks/api/useAxios';
+import handleError from '@/utils/handleError';
 
 type Props = {
   url: string;
@@ -7,10 +8,16 @@ type Props = {
 };
 
 function useDelete({ url, headers }: Props): (id: number) => Promise<void> {
+  const { axiosInstance } = useAxios();
+
   const deleteData = async (id: number) => {
-    await axiosInstance.delete(`${url}/${id}`, {
-      headers,
-    });
+    try {
+      await axiosInstance.delete(`${url}/${id}`, {
+        headers,
+      });
+    } catch (error) {
+      handleError(error as Error, `token: ${headers.Authorization.toString()}`);
+    }
   };
 
   return deleteData;

--- a/frontend/src/hooks/api/useGet.tsx
+++ b/frontend/src/hooks/api/useGet.tsx
@@ -1,5 +1,6 @@
 import { AxiosRequestHeaders, AxiosResponse } from 'axios';
-import axiosInstance from '@/hooks/api/axiosInstance';
+import handleError from '@/utils/handleError';
+import useAxios from '@/hooks/api/useAxios';
 
 type Props = {
   url: string;
@@ -10,13 +11,18 @@ function useGet<T>({
   url,
   headers,
 }: Props): (params: Record<string, unknown>) => Promise<T> {
-  const fetchData = async (params: unknown) => {
-    const { data }: AxiosResponse<T> = await axiosInstance.get(url, {
-      headers,
-      params,
-    });
+  const { axiosInstance } = useAxios();
 
-    return data;
+  const fetchData = async (params: unknown) => {
+    try {
+      const { data }: AxiosResponse<T> = await axiosInstance.get(url, {
+        headers,
+        params,
+      });
+      return data;
+    } catch (error) {
+      handleError(error as Error);
+    }
   };
 
   return fetchData;

--- a/frontend/src/hooks/api/useGetOne.tsx
+++ b/frontend/src/hooks/api/useGetOne.tsx
@@ -10,7 +10,7 @@ type Props = {
 function useGetOne<T>({ url, headers }: Props): [T, () => void, boolean] {
   const [data, setData] = useState<null | T>(null);
   const [refetchTrigger, setRefetchTrigger] = useState(0);
-  const [axiosInstance, isLoading] = useAxios();
+  const { axiosInstance, isLoading } = useAxios();
   const fetchData = async () => {
     const { data }: AxiosResponse<T> = await axiosInstance.get(url, {
       headers,

--- a/frontend/src/hooks/api/usePatch.tsx
+++ b/frontend/src/hooks/api/usePatch.tsx
@@ -1,5 +1,6 @@
 import { AxiosRequestHeaders, AxiosResponse } from 'axios';
-import axiosInstance from '@/hooks/api/axiosInstance';
+import useAxios from '@/hooks/api/useAxios';
+import handleError from '@/utils/handleError';
 
 type Props = {
   url: string;
@@ -10,12 +11,24 @@ function usePatch<T>({
   url,
   headers,
 }: Props): (data: Record<string, unknown>) => Promise<AxiosResponse<T>> {
-  const patchData = async (data: Record<string, unknown>) => {
-    const response: AxiosResponse<T> = await axiosInstance.patch(url, data, {
-      headers,
-    });
+  const { axiosInstance } = useAxios();
 
-    return response;
+  const patchData = async (data: Record<string, unknown>) => {
+    try {
+      const response: AxiosResponse<T> = await axiosInstance.patch(url, data, {
+        headers,
+      });
+      return response;
+    } catch (error) {
+      const requestBodyString = Object.entries(data).reduce<string>(
+        (string, [key, value]) => `${string}\n${key}: ${value as string}`,
+        ''
+      );
+      handleError(
+        error as Error,
+        `data: ${requestBodyString},\n    token: ${headers.Authorization.toString()}`
+      );
+    }
   };
 
   return patchData;

--- a/frontend/src/hooks/api/usePost.tsx
+++ b/frontend/src/hooks/api/usePost.tsx
@@ -1,7 +1,8 @@
 import { AxiosRequestHeaders } from 'axios';
-import axiosInstance from '@/hooks/api/axiosInstance';
 import { useContext } from 'react';
 import { UserDataContext } from '@/contexts/LoginContextProvider';
+import handleError from '@/utils/handleError';
+import useAxios from '@/hooks/api/useAxios';
 
 type Props = {
   url: string;
@@ -11,14 +12,28 @@ type Props = {
 function usePost<T>({ url, headers }: Props): (input: T) => Promise<void> {
   const userData = useContext(UserDataContext);
 
+  const { axiosInstance } = useAxios();
+
   const postData = async (body: T) => {
     if (!userData || !userData.token) {
       alert('로그인이 필요합니다.');
       return;
     }
-    await axiosInstance.post(url, body, {
-      headers,
-    });
+
+    try {
+      await axiosInstance.post(url, body, {
+        headers,
+      });
+    } catch (error) {
+      const requestBodyString = Object.entries(body).reduce<string>(
+        (string, [key, value]) => `${string}\n${key}: ${value as string}`,
+        ''
+      );
+      handleError(
+        error as Error,
+        `body: ${requestBodyString},\n    token: ${userData.token}`
+      );
+    }
   };
 
   return postData;

--- a/frontend/src/hooks/api/usePut.tsx
+++ b/frontend/src/hooks/api/usePut.tsx
@@ -1,7 +1,8 @@
 import { AxiosRequestHeaders } from 'axios';
-import axiosInstance from '@/hooks/api/axiosInstance';
 import { useContext } from 'react';
 import { UserDataContext } from '@/contexts/LoginContextProvider';
+import useAxios from '@/hooks/api/useAxios';
+import handleError from '@/utils/handleError';
 
 type Props = {
   url: string;
@@ -14,15 +15,28 @@ function usePut<T>({
 }: Props): (input: T, id: number) => Promise<void> {
   const userData = useContext(UserDataContext);
 
+  const { axiosInstance } = useAxios();
+
   const putData = async (body: T, id: number) => {
     if (!userData || !userData.token) {
       alert('로그인이 필요합니다.');
       return;
     }
 
-    await axiosInstance.put(`${url}/${id}`, body, {
-      headers,
-    });
+    try {
+      await axiosInstance.put(`${url}/${id}`, body, {
+        headers,
+      });
+    } catch (error) {
+      const requestBodyString = Object.entries(body).reduce<string>(
+        (string, [key, value]) => `${string}\n${key}: ${value as string}`,
+        ''
+      );
+      handleError(
+        error as Error,
+        `body: ${requestBodyString},\n    token: ${userData.token}`
+      );
+    }
   };
 
   return putData;

--- a/frontend/src/hooks/useInventory.tsx
+++ b/frontend/src/hooks/useInventory.tsx
@@ -11,20 +11,25 @@ type InventoryResponse = {
 type Return = {
   keyboards: InventoryProduct[];
   isReady: boolean;
+  isError: boolean;
   selectedProduct: InventoryProduct | null;
   setSelectedProduct: React.Dispatch<React.SetStateAction<InventoryProduct>>;
   otherProducts: InventoryProduct[];
-  refetchInventoryProducts: () => void;
+  refetch: () => void;
   updateProfileProduct: () => Promise<void>;
 };
 
 function useInventory(): Return {
   const userData = useContext(UserDataContext);
-  const [inventoryProducts, refetchInventoryProducts, isReady] =
-    useGetOne<InventoryResponse>({
-      url: ENDPOINTS.INVENTORY_PRODUCTS,
-      headers: { Authorization: `Bearer ${userData?.token}` },
-    });
+  const {
+    data: inventoryProducts,
+    refetch,
+    isReady,
+    isError,
+  } = useGetOne<InventoryResponse>({
+    url: ENDPOINTS.INVENTORY_PRODUCTS,
+    headers: { Authorization: `Bearer ${userData?.token}` },
+  });
 
   const [selectedProduct, setSelectedProduct] =
     useState<InventoryProduct | null>(null);
@@ -76,10 +81,11 @@ function useInventory(): Return {
   return {
     keyboards: inventoryProducts?.keyboards,
     isReady,
+    isError,
     selectedProduct,
     setSelectedProduct,
     otherProducts,
-    refetchInventoryProducts,
+    refetch,
     updateProfileProduct,
   };
 }

--- a/frontend/src/hooks/useProduct.tsx
+++ b/frontend/src/hooks/useProduct.tsx
@@ -5,12 +5,16 @@ type Props = {
   productId: number;
 };
 
-function useProduct({ productId }: Props): [Product, boolean] {
-  const [product, _, isReady] = useGetOne<Product>({
+function useProduct({ productId }: Props): [Product, boolean, boolean] {
+  const {
+    data: product,
+    isReady,
+    isError,
+  } = useGetOne<Product>({
     url: `${ENDPOINTS.PRODUCT(productId)}`,
   });
 
-  return [product, isReady];
+  return [product, isReady, isError];
 }
 
 export default useProduct;

--- a/frontend/src/hooks/useProducts.tsx
+++ b/frontend/src/hooks/useProducts.tsx
@@ -14,6 +14,7 @@ type ReturnType = {
   getNextPage: () => void;
   isLoading: boolean;
   isReady: boolean;
+  isError: boolean;
 };
 
 function useProducts({ size, sort, category }: Props): ReturnType {
@@ -23,12 +24,13 @@ function useProducts({ size, sort, category }: Props): ReturnType {
     getNextPage,
     isLoading,
     isReady,
+    isError,
   } = useGetMany<Product>({
     url: `${ENDPOINTS.PRODUCTS}`,
     params,
   });
 
-  return { products, getNextPage, isLoading, isReady };
+  return { products, getNextPage, isLoading, isReady, isError };
 }
 
 export default useProducts;

--- a/frontend/src/hooks/useReviews.tsx
+++ b/frontend/src/hooks/useReviews.tsx
@@ -18,6 +18,7 @@ type ReturnTypeWithoutProductId = {
   reviews: Review[];
   isReady: boolean;
   isLoading: boolean;
+  isError: boolean;
   getNextPage: () => void;
   refetch: () => void;
 };
@@ -43,6 +44,7 @@ function useReviews({ size, productId }: Props): ReturnType {
     refetch,
     isReady,
     isLoading,
+    isError,
   } = useGetMany<Review>({
     url:
       productId !== undefined
@@ -73,6 +75,7 @@ function useReviews({ size, productId }: Props): ReturnType {
     reviews,
     isReady,
     isLoading,
+    isError,
     getNextPage,
     refetch,
     postReview,

--- a/frontend/src/pages/Home/Home.tsx
+++ b/frontend/src/pages/Home/Home.tsx
@@ -8,6 +8,7 @@ import useReviews from '@/hooks/useReviews';
 function Home() {
   const {
     products,
+    isError: isProductError,
     isLoading: isProductLoading,
     isReady: isProductReady,
   } = useProducts({
@@ -19,6 +20,7 @@ function Home() {
     getNextPage,
     isLoading: isReviewLoading,
     isReady: isReviewReady,
+    isError: isReviewError,
   } = useReviews({ size: '6' });
 
   const moreProductsLink = (
@@ -32,6 +34,7 @@ function Home() {
         data={products}
         isLoading={isProductLoading}
         isReady={isProductReady}
+        isError={isProductError}
         addOn={moreProductsLink}
       />
       <ReviewListSection
@@ -40,6 +43,7 @@ function Home() {
         getNextPage={getNextPage}
         isLoading={isReviewLoading}
         isReady={isReviewReady}
+        isError={isReviewError}
       />
     </>
   );

--- a/frontend/src/pages/Product/Product.tsx
+++ b/frontend/src/pages/Product/Product.tsx
@@ -25,6 +25,7 @@ function Product() {
     reviews,
     isLoading: isReviewLoading,
     isReady: isReviewReady,
+    isError: isReviewError,
     getNextPage,
     refetch: refetchReview,
     postReview,
@@ -97,6 +98,7 @@ function Product() {
             handleEdit={handleReviewEdit}
             isLoading={isReviewLoading}
             isReady={isReviewReady}
+            isError={isReviewError}
           />
           {isSheetOpen && isLoggedIn && (
             <ReviewBottomSheet

--- a/frontend/src/pages/Product/Product.tsx
+++ b/frontend/src/pages/Product/Product.tsx
@@ -20,7 +20,9 @@ function Product() {
   const { productId: id } = useParams();
   const productId = Number(id);
 
-  const [product, isReady] = useProduct({ productId: Number(productId) });
+  const [product, isProductReady, isProductError] = useProduct({
+    productId: Number(productId),
+  });
   const {
     reviews,
     isLoading: isReviewLoading,
@@ -80,7 +82,11 @@ function Product() {
     <>
       <S.Container>
         <StickyWrapper>
-          <AsyncWrapper fallback={<Loading />} isReady={isReady}>
+          <AsyncWrapper
+            fallback={<Loading />}
+            isReady={isProductReady}
+            isError={isProductError}
+          >
             <ProductDetail product={product} />
           </AsyncWrapper>
         </StickyWrapper>

--- a/frontend/src/pages/Products/Products.tsx
+++ b/frontend/src/pages/Products/Products.tsx
@@ -31,7 +31,7 @@ function Products() {
   );
   const [searchParams] = useSearchParams();
   const category = searchParams.get('category');
-  const { products, getNextPage, isLoading, isReady } = useProducts({
+  const { products, getNextPage, isLoading, isReady, isError } = useProducts({
     size: '12',
     sort,
     category,
@@ -58,6 +58,7 @@ function Products() {
       addOn={<Select value={sort} setValue={setSort} options={options} />}
       isLoading={isLoading}
       isReady={isReady}
+      isError={isError}
     />
   );
 }

--- a/frontend/src/pages/Profile/Profile.tsx
+++ b/frontend/src/pages/Profile/Profile.tsx
@@ -25,13 +25,17 @@ function Profile() {
   const {
     keyboards,
     isReady: isInventoryProductsReady,
-    refetchInventoryProducts,
+    refetch: refetchInventoryProducts,
     selectedProduct,
     setSelectedProduct,
     otherProducts,
     updateProfileProduct,
   } = useInventory();
-  const [myData, , isMyDataReady] = useGetOne<Member>({
+  const {
+    data: myData,
+    isReady: isMyDataReady,
+    isError: isMyDataError,
+  } = useGetOne<Member>({
     url: ENDPOINTS.ME,
     headers: { Authorization: `Bearer ${userData?.token}` },
   });
@@ -39,7 +43,11 @@ function Profile() {
   return (
     <S.Container>
       <S.ProfileSection>
-        <AsyncWrapper fallback={<Loading />} isReady={isMyDataReady}>
+        <AsyncWrapper
+          fallback={<Loading />}
+          isReady={isMyDataReady}
+          isError={isMyDataError}
+        >
           <UserInfo userData={myData} />
         </AsyncWrapper>
         <ProductSelect
@@ -54,7 +62,11 @@ function Profile() {
         <SectionHeader>
           <S.Title>보유한 장비 목록</S.Title>
         </SectionHeader>
-        <AsyncWrapper fallback={<Loading />} isReady={isInventoryProductsReady}>
+        <AsyncWrapper
+          fallback={<Loading />}
+          isReady={isInventoryProductsReady}
+          isError={isMyDataError}
+        >
           <InventoryProductList products={keyboards} />
         </AsyncWrapper>
       </S.InventorySection>

--- a/frontend/src/utils/handleError.ts
+++ b/frontend/src/utils/handleError.ts
@@ -1,0 +1,13 @@
+import logError from '@/utils/logError';
+
+const handleError = (error: Error, additionalMessage?: string) => {
+  if (!(error instanceof Error)) {
+    alert('알 수 없는 오류 발생');
+    console.log(error);
+  }
+
+  logError(error, additionalMessage);
+  alert('사용자에게 표시할 오류 메시지');
+};
+
+export default handleError;

--- a/frontend/src/utils/logError.ts
+++ b/frontend/src/utils/logError.ts
@@ -1,4 +1,4 @@
-const logError = (error: Error, additionalMessage) => {
+const logError = (error: Error, additionalMessage?: string) => {
   console.error(error.message, '\n', additionalMessage);
   console.groupCollapsed('실제 오류');
   console.error(error.stack);

--- a/frontend/src/utils/logError.ts
+++ b/frontend/src/utils/logError.ts
@@ -1,0 +1,8 @@
+const logError = (error: Error, additionalMessage) => {
+  console.error(error.message, '\n', additionalMessage);
+  console.groupCollapsed('실제 오류');
+  console.error(error.stack);
+  console.groupEnd();
+};
+
+export default logError;


### PR DESCRIPTION
# issue: #291 

# 작업 내용
- API 요청의 Error 처리 통일
  - get과 나머지로 나뉨
  - get은 오류 상태를 화면에 표현해야 하므로 isError라는 상태를 로딩과 유사하게 활용
  - 나머지는 액션에 대한 리액션이기 때문에 사용자에게 alert 해주는 방식
  - UI적으로 사용자에게 표현하는 것 외에도 디버깅을 위해서 콘솔 창에 바로 현재의 상태를 표시해주도록 오류 메시지 설정
- Error 시 UI 구현