### PR TITLE
[BugFix/BE] 페이지 조회 시 중복되는 아이템 조회되는 이슈 해결

### DIFF
--- a/backend/src/main/java/com/woowacourse/f12/presentation/CustomPageableArgumentResolver.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/CustomPageableArgumentResolver.java
@@ -7,7 +7,9 @@ import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.springframework.core.MethodParameter;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
@@ -32,7 +34,13 @@ public class CustomPageableArgumentResolver extends PageableHandlerMethodArgumen
         validatePage(pageArgument);
         final String sizeArgument = webRequest.getParameter("size");
         validateSize(sizeArgument);
-        return super.resolveArgument(methodParameter, mavContainer, webRequest, binderFactory);
+        final Pageable pageable = super.resolveArgument(methodParameter, mavContainer, webRequest, binderFactory);
+        return addSecondarySortById(pageable);
+    }
+
+    private Pageable addSecondarySortById(final Pageable pageable) {
+        final Sort sort = pageable.getSort().and(Sort.by("id").descending());
+        return PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), sort);
     }
 
     private void validatePage(final String pageArgument) {

--- a/backend/src/test/java/com/woowacourse/f12/acceptance/ProductAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/acceptance/ProductAcceptanceTest.java
@@ -127,7 +127,7 @@ class ProductAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
-    void 리뷰_갯수가_같은_상태에서_제품_목록을_리뷰가_많은_순서로_페이징하여_조회하면_id_역순으로_조회된다() {
+    void 리뷰_개수가_같은_상태에서_제품_목록을_리뷰가_많은_순서로_페이징하여_조회하면_id_역순으로_조회된다() {
         // given
         Product product1 = 제품을_저장한다(KEYBOARD_1.생성());
         Product product2 = 제품을_저장한다(KEYBOARD_2.생성());
@@ -145,6 +145,27 @@ class ProductAcceptanceTest extends AcceptanceTest {
                 () -> assertThat(response.as(ProductPageResponse.class).getItems())
                         .extracting("id")
                         .containsExactly(product2.getId(), product1.getId()),
+                () -> assertThat(response.as(ProductPageResponse.class).isHasNext()).isFalse()
+        );
+    }
+
+    @Test
+    void 정렬_조건으로_id_역순으로_페이징하여_조회하면_id_역순으로_조회된다() {
+        // given
+        Product product1 = 제품을_저장한다(KEYBOARD_1.생성());
+        Product product2 = 제품을_저장한다(KEYBOARD_2.생성());
+        Product product3 = 제품을_저장한다(MOUSE_1.생성());
+
+        // when
+        ExtractableResponse<Response> response = GET_요청을_보낸다(
+                "/api/v1/products?page=0&size=3&sort=id,desc");
+
+        // then
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(response.as(ProductPageResponse.class).getItems())
+                        .extracting("id")
+                        .containsExactly(product3.getId(), product2.getId(), product1.getId()),
                 () -> assertThat(response.as(ProductPageResponse.class).isHasNext()).isFalse()
         );
     }

--- a/backend/src/test/java/com/woowacourse/f12/acceptance/ProductAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/acceptance/ProductAcceptanceTest.java
@@ -65,8 +65,8 @@ class ProductAcceptanceTest extends AcceptanceTest {
     @Test
     void 모든_제품_목록을_페이징하여_조회한다() {
         // given
-        Product product = 제품을_저장한다(KEYBOARD_1.생성());
-        제품을_저장한다(MOUSE_1.생성());
+        제품을_저장한다(KEYBOARD_1.생성());
+        Product product = 제품을_저장한다(MOUSE_1.생성());
 
         // when
         ExtractableResponse<Response> response = GET_요청을_보낸다("/api/v1/products?page=0&size=1");
@@ -84,19 +84,19 @@ class ProductAcceptanceTest extends AcceptanceTest {
     @Test
     void 특정_카테고리_목록을_페이징하여_조회한다() {
         // given
-        제품을_저장한다(KEYBOARD_1.생성());
-        제품을_저장한다(KEYBOARD_2.생성());
-        Product product = 제품을_저장한다(MOUSE_1.생성());
+        Product keyboard1 = 제품을_저장한다(KEYBOARD_1.생성());
+        Product keyboard2 = 제품을_저장한다(KEYBOARD_2.생성());
+        제품을_저장한다(MOUSE_1.생성());
 
         // when
-        ExtractableResponse<Response> response = GET_요청을_보낸다("/api/v1/products?category=mouse&page=0&size=1");
+        ExtractableResponse<Response> response = GET_요청을_보낸다("/api/v1/products?category=keyboard&page=0&size=2");
 
         // then
         assertAll(
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
                 () -> assertThat(response.as(ProductPageResponse.class).getItems())
                         .extracting("id")
-                        .containsExactly(product.getId()),
+                        .containsExactly(keyboard2.getId(), keyboard1.getId()),
                 () -> assertThat(response.as(ProductPageResponse.class).isHasNext()).isFalse()
         );
     }
@@ -106,22 +106,46 @@ class ProductAcceptanceTest extends AcceptanceTest {
         // given
         Product product1 = 제품을_저장한다(KEYBOARD_1.생성());
         Product product2 = 제품을_저장한다(KEYBOARD_2.생성());
-        String token = 로그인을_한다(CORINNE_GITHUB.getCode()).getToken();
-        REVIEW_RATING_5.작성_요청을_보낸다(product1.getId(), token);
-        REVIEW_RATING_4.작성_요청을_보낸다(product1.getId(), token);
-        REVIEW_RATING_3.작성_요청을_보낸다(product2.getId(), token);
+        String corinneToken = 로그인을_한다(CORINNE_GITHUB.getCode()).getToken();
+        String minchoToken = 로그인을_한다(MINCHO_GITHUB.getCode()).getToken();
+        REVIEW_RATING_5.작성_요청을_보낸다(product1.getId(), corinneToken);
+        REVIEW_RATING_4.작성_요청을_보낸다(product1.getId(), minchoToken);
+        REVIEW_RATING_3.작성_요청을_보낸다(product2.getId(), minchoToken);
 
         // when
         ExtractableResponse<Response> response = GET_요청을_보낸다(
-                "/api/v1/products?category=keyboard&page=0&size=1&sort=reviewCount,desc");
+                "/api/v1/products?category=keyboard&page=0&size=2&sort=reviewCount,desc");
 
         // then
         assertAll(
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
                 () -> assertThat(response.as(ProductPageResponse.class).getItems())
                         .extracting("id")
-                        .containsExactly(product1.getId()),
-                () -> assertThat(response.as(ProductPageResponse.class).isHasNext()).isTrue()
+                        .containsExactly(product1.getId(), product2.getId()),
+                () -> assertThat(response.as(ProductPageResponse.class).isHasNext()).isFalse()
+        );
+    }
+
+    @Test
+    void 리뷰_갯수가_같은_상태에서_제품_목록을_리뷰가_많은_순서로_페이징하여_조회하면_id_역순으로_조회된다() {
+        // given
+        Product product1 = 제품을_저장한다(KEYBOARD_1.생성());
+        Product product2 = 제품을_저장한다(KEYBOARD_2.생성());
+        String token = 로그인을_한다(CORINNE_GITHUB.getCode()).getToken();
+        REVIEW_RATING_5.작성_요청을_보낸다(product1.getId(), token);
+        REVIEW_RATING_3.작성_요청을_보낸다(product2.getId(), token);
+
+        // when
+        ExtractableResponse<Response> response = GET_요청을_보낸다(
+                "/api/v1/products?category=keyboard&page=0&size=2&sort=reviewCount,desc");
+
+        // then
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(response.as(ProductPageResponse.class).getItems())
+                        .extracting("id")
+                        .containsExactly(product2.getId(), product1.getId()),
+                () -> assertThat(response.as(ProductPageResponse.class).isHasNext()).isFalse()
         );
     }
 

--- a/backend/src/test/java/com/woowacourse/f12/presentation/CustomPageableArgumentResolverTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/CustomPageableArgumentResolverTest.java
@@ -98,6 +98,6 @@ public class CustomPageableArgumentResolverTest {
 
         // then
         verify(productService)
-                .findPage(null, PageRequest.of(0, 20));
+                .findPage(null, PageRequest.of(0, 20, Sort.by("id").descending()));
     }
 }

--- a/backend/src/test/java/com/woowacourse/f12/presentation/member/MemberControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/member/MemberControllerTest.java
@@ -40,6 +40,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.SliceImpl;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
@@ -244,7 +245,7 @@ class MemberControllerTest {
     void 키워드와_옵션으로_회원을_조회한다() throws Exception {
         // given
         MemberSearchRequest memberSearchRequest = new MemberSearchRequest("cheese", NONE_CONSTANT, BACKEND_CONSTANT);
-        Pageable pageable = PageRequest.of(0, 10);
+        Pageable pageable = PageRequest.of(0, 10, Sort.by("id").descending());
         InventoryProduct inventoryProduct = SELECTED_INVENTORY_PRODUCT.생성(CORINNE.생성(1L),
                 KEYBOARD_1.생성(1L));
         Member member = CORINNE.대표장비를_추가해서_생성(1L, inventoryProduct);
@@ -280,7 +281,7 @@ class MemberControllerTest {
     void 회원_조회_성공_키워드와_옵션값이_주어지지_않을때() throws Exception {
         // given
         MemberSearchRequest memberSearchRequest = new MemberSearchRequest(null, null, null);
-        Pageable pageable = PageRequest.of(0, 10);
+        Pageable pageable = PageRequest.of(0, 10, Sort.by("id").descending());
         InventoryProduct inventoryProduct = SELECTED_INVENTORY_PRODUCT.생성(CORINNE.생성(1L),
                 KEYBOARD_1.생성(1L));
         Member member = CORINNE.대표장비를_추가해서_생성(1L, inventoryProduct);

--- a/backend/src/test/java/com/woowacourse/f12/presentation/product/ProductControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/product/ProductControllerTest.java
@@ -64,7 +64,8 @@ class ProductControllerTest {
                 .andDo(print());
 
         // then
-        verify(productService).findPage(KEYBOARD_CONSTANT, PageRequest.of(0, 150, Sort.by("rating").descending()));
+        verify(productService).findPage(KEYBOARD_CONSTANT,
+                PageRequest.of(0, 150, Sort.by("rating", "id").descending()));
     }
 
     @Test
@@ -79,7 +80,7 @@ class ProductControllerTest {
                 .andDo(print());
 
         // then
-        verify(productService).findPage(null, PageRequest.of(0, 150, Sort.by("rating").descending()));
+        verify(productService).findPage(null, PageRequest.of(0, 150, Sort.by("rating", "id").descending()));
     }
 
     @Test

--- a/backend/src/test/java/com/woowacourse/f12/presentation/review/ReviewControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/review/ReviewControllerTest.java
@@ -351,7 +351,7 @@ class ReviewControllerTest {
                 .andDo(print());
 
         // then
-        verify(reviewService).findPage(PageRequest.of(0, 150, Sort.by("rating").descending()));
+        verify(reviewService).findPage(PageRequest.of(0, 150, Sort.by("rating", "id").descending()));
     }
 
     @Test
@@ -367,7 +367,8 @@ class ReviewControllerTest {
                 .andDo(print());
 
         // then
-        verify(reviewService).findPageByProductId(PRODUCT_ID, PageRequest.of(0, 150, Sort.by("rating").descending()));
+        verify(reviewService).findPageByProductId(PRODUCT_ID,
+                PageRequest.of(0, 150, Sort.by("rating", "id").descending()));
     }
 
     @Test
@@ -382,7 +383,9 @@ class ReviewControllerTest {
                 .andDo(print());
 
         // then
-        verify(reviewService).findPageByProductId(0L, PageRequest.of(0, 150, Sort.by("rating").descending()));
+        PageRequest pageable = PageRequest.of(0, 150,
+                Sort.by("rating", "id").descending());
+        verify(reviewService).findPageByProductId(0L, pageable);
     }
 
     @Test


### PR DESCRIPTION
# issue: #311 

# 작업 내용
- 기본 정렬 기준 적용 (id 역순)