### PR TITLE
[Hotfix, FE] 빌드 스크립트에 따라 API URL 주소를 다르게 빌드하게 설정

### DIFF
--- a/frontend/.eslintignore
+++ b/frontend/.eslintignore
@@ -1,3 +1,5 @@
 webpack.config.js
 webpack.prod.js
+webpack.dev.js
+webpack.test.js
 mocks

--- a/frontend/.eslintignore
+++ b/frontend/.eslintignore
@@ -1,5 +1,2 @@
-webpack.config.js
-webpack.prod.js
-webpack.dev.js
-webpack.test.js
+webpack.*.js
 mocks

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "build": "npx webpack build --config webpack.prod.js",
-    "start": "npx webpack serve",
+    "build-release": "npx webpack build --config webpack.test.js",
+    "start": "npx webpack serve --config webpack.dev.js",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook"
   },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "build": "npx webpack build --config webpack.prod.js",
+    "build-main": "npx webpack build --config webpack.prod.js",
     "build-release": "npx webpack build --config webpack.test.js",
     "start": "npx webpack serve --config webpack.dev.js",
     "storybook": "start-storybook -p 6006",

--- a/frontend/src/constants/api.ts
+++ b/frontend/src/constants/api.ts
@@ -1,4 +1,4 @@
-export const BASE_URL = 'http://3.34.47.160:8080/api/v1';
+export const BASE_URL = __API_URL__;
 
 export const GITHUB_AUTH_URL =
   'https://github.com/login/oauth/authorize?client_id=f1e73a9ac502f1b6712a';

--- a/frontend/src/custom.d.ts
+++ b/frontend/src/custom.d.ts
@@ -51,3 +51,5 @@ declare type ReviewInput = {
   content: string;
   rating: number;
 };
+
+declare const __API_URL__: string;

--- a/frontend/webpack.common.js
+++ b/frontend/webpack.common.js
@@ -3,10 +3,9 @@ const path = require('path');
 
 module.exports = {
   entry: './src/index.tsx',
-  mode: process.env.production === 'true' ? 'production' : 'development',
   output: {
     path: path.resolve(__dirname, 'dist'),
-    filename: 'main.[hash].js',
+    filename: 'main.[fullhash].js',
     clean: true,
     publicPath: '/',
   },
@@ -47,17 +46,9 @@ module.exports = {
   plugins: [
     new HtmlWebpackPlugin({
       template: path.resolve(__dirname, './public/index.html'),
+      favicon: path.resolve(__dirname, './public/favicon.ico'),
     }),
   ],
-  devServer: {
-    static: {
-      directory: path.join(__dirname, 'public'),
-    },
-    open: true,
-    historyApiFallback: true,
-    compress: true,
-    port: 3000,
-  },
   resolve: {
     extensions: ['.js', '.ts', '.jsx', '.tsx'],
     alias: {

--- a/frontend/webpack.dev.js
+++ b/frontend/webpack.dev.js
@@ -1,0 +1,22 @@
+const { merge } = require('webpack-merge');
+const common = require('./webpack.common.js');
+const path = require('path');
+const { DefinePlugin } = require('webpack');
+
+module.exports = merge(common, {
+  mode: 'development',
+  devServer: {
+    static: {
+      directory: path.join(__dirname, 'public'),
+    },
+    open: true,
+    historyApiFallback: true,
+    compress: true,
+    port: 3000,
+  },
+  plugins: [
+    new DefinePlugin({
+      __API_URL__: JSON.stringify('http://3.34.47.160:8080/api/v1'),
+    }),
+  ],
+});

--- a/frontend/webpack.dev.js
+++ b/frontend/webpack.dev.js
@@ -16,7 +16,7 @@ module.exports = merge(common, {
   },
   plugins: [
     new DefinePlugin({
-      __API_URL__: JSON.stringify('http://3.34.47.160:8080/api/v1'),
+      __API_URL__: JSON.stringify('https://dev.f12.app/api/v1'),
     }),
   ],
 });

--- a/frontend/webpack.prod.js
+++ b/frontend/webpack.prod.js
@@ -7,7 +7,7 @@ module.exports = merge(common, {
   mode: 'production',
   plugins: [
     new DefinePlugin({
-      __API_URL__: JSON.stringify('main 서버 API 주소'),
+      __API_URL__: JSON.stringify('https://prod.f12.app/api/v1'),
     }),
   ],
 });

--- a/frontend/webpack.test.js
+++ b/frontend/webpack.test.js
@@ -3,11 +3,10 @@ const { merge } = require('webpack-merge');
 const common = require('./webpack.common.js');
 
 module.exports = merge(common, {
-  entry: './src/index.tsx',
   mode: 'production',
   plugins: [
     new DefinePlugin({
-      __API_URL__: JSON.stringify('main 서버 API 주소'),
+      __API_URL__: JSON.stringify('http://3.34.47.160:8080/api/v1'),
     }),
   ],
 });

--- a/frontend/webpack.test.js
+++ b/frontend/webpack.test.js
@@ -6,7 +6,7 @@ module.exports = merge(common, {
   mode: 'production',
   plugins: [
     new DefinePlugin({
-      __API_URL__: JSON.stringify('http://3.34.47.160:8080/api/v1'),
+      __API_URL__: JSON.stringify('https://dev.f12.app/api/v1'),
     }),
   ],
 });


### PR DESCRIPTION
# issue: #303

# 작업 내용
- webpack 설정 분리
  - `webpack.common.js`: 공통 설정
  - `webpack.dev.js`: 개발 서버 설정
  - `webpack.test.js`: 테스트 서버 설정
  - `webpack.prod.js`: 실 서버 설정
- 스크립트 추가
  - `npm run build-release`: 테스트 서버용 빌드 스크립트
  - `npm run build-main`: 실 서버용 빌드 스크립트 
