### PR TITLE
[BE] 회원을 검색할 때 대표장비가 아닌 다른 제품들도 나오는 오류 수정

### DIFF
--- a/backend/src/main/java/com/woowacourse/f12/domain/member/Member.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/member/Member.java
@@ -1,9 +1,11 @@
 package com.woowacourse.f12.domain.member;
 
 import com.woowacourse.f12.domain.inventoryproduct.InventoryProduct;
+import com.woowacourse.f12.domain.product.Product;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EntityListeners;
@@ -80,6 +82,13 @@ public class Member {
 
     public boolean isRegisterCompleted() {
         return Objects.nonNull(this.careerLevel) && Objects.nonNull(this.jobType);
+    }
+
+    public List<Product> findProfileProducts() {
+        return this.inventoryProducts.stream()
+                .filter(InventoryProduct::isSelected)
+                .map(InventoryProduct::getProduct)
+                .collect(Collectors.toList());
     }
 
     @Override

--- a/backend/src/main/java/com/woowacourse/f12/dto/response/member/MemberWithProfileProductResponse.java
+++ b/backend/src/main/java/com/woowacourse/f12/dto/response/member/MemberWithProfileProductResponse.java
@@ -36,9 +36,9 @@ public class MemberWithProfileProductResponse {
     }
 
     public static MemberWithProfileProductResponse from(final Member member) {
-        final List<ProductResponse> profileProducts = member.getInventoryProducts()
+        final List<ProductResponse> profileProducts = member.findProfileProducts()
                 .stream()
-                .map(inventoryProduct -> ProductResponse.from(inventoryProduct.getProduct()))
+                .map(ProductResponse::from)
                 .collect(Collectors.toList());
         return new MemberWithProfileProductResponse(member.getId(), member.getGitHubId(), member.getName(),
                 member.getImageUrl(), CareerLevelConstant.from(member.getCareerLevel()),

--- a/backend/src/test/java/com/woowacourse/f12/acceptance/MemberAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/acceptance/MemberAcceptanceTest.java
@@ -14,6 +14,8 @@ import static com.woowacourse.f12.support.GitHubProfileFixtures.MINCHO_GITHUB;
 import static com.woowacourse.f12.support.InventoryProductFixtures.SELECTED_INVENTORY_PRODUCT;
 import static com.woowacourse.f12.support.MemberFixtures.CORINNE;
 import static com.woowacourse.f12.support.ProductFixture.KEYBOARD_1;
+import static com.woowacourse.f12.support.ProductFixture.MOUSE_1;
+import static com.woowacourse.f12.support.ReviewFixtures.REVIEW_RATING_4;
 import static com.woowacourse.f12.support.ReviewFixtures.REVIEW_RATING_5;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -28,8 +30,11 @@ import com.woowacourse.f12.dto.response.auth.LoginResponse;
 import com.woowacourse.f12.dto.response.member.MemberPageResponse;
 import com.woowacourse.f12.dto.response.member.MemberResponse;
 import com.woowacourse.f12.dto.response.member.MemberWithProfileProductResponse;
+import com.woowacourse.f12.dto.response.product.ProductResponse;
+import com.woowacourse.f12.support.InventoryProductFixtures;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -192,9 +197,10 @@ public class MemberAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
-    void 회원정보를_키워드와_옵션으로_검색하여_조회한다() {
+    void 회원정보를_키워드와_옵션으로_검색하여_대표_장비와_함께_조회한다() {
         // given
-        Product product = 제품을_저장한다(KEYBOARD_1.생성());
+        Product keyboard = 제품을_저장한다(KEYBOARD_1.생성());
+        Product mouse = 제품을_저장한다(MOUSE_1.생성());
 
         MemberRequest memberRequest = new MemberRequest(SENIOR_CONSTANT, BACKEND_CONSTANT);
         LoginResponse firstLoginResponse = 로그인을_한다(MINCHO_GITHUB.getCode());
@@ -205,7 +211,9 @@ public class MemberAcceptanceTest extends AcceptanceTest {
         Long memberId = secondLoginResponse.getMember().getId();
         로그인된_상태로_PATCH_요청을_보낸다("/api/v1/members/me", token, memberRequest);
 
-        REVIEW_RATING_5.작성_요청을_보낸다(product.getId(), token);
+        REVIEW_RATING_5.작성_요청을_보낸다(keyboard.getId(), token);
+        REVIEW_RATING_4.작성_요청을_보낸다(mouse.getId(), token);
+        InventoryProductFixtures.대표_장비_업데이트_한다(List.of(keyboard), token);
 
         // when
         ExtractableResponse<Response> response = GET_요청을_보낸다(
@@ -213,18 +221,21 @@ public class MemberAcceptanceTest extends AcceptanceTest {
 
         // then
         MemberPageResponse memberPageResponse = response.as(MemberPageResponse.class);
-        InventoryProduct inventoryProduct = SELECTED_INVENTORY_PRODUCT.생성(1L, CORINNE.생성(memberId), product);
+        InventoryProduct inventoryProduct = SELECTED_INVENTORY_PRODUCT.생성(1L, CORINNE.생성(memberId), keyboard);
         Member member = CORINNE.대표장비를_추가해서_생성(memberId, inventoryProduct);
         MemberWithProfileProductResponse memberWithProfileProductResponse = MemberWithProfileProductResponse.from(
                 member);
         assertAll(
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
                 () -> assertThat(memberPageResponse.isHasNext()).isFalse(),
-                () -> assertThat(
-                        memberPageResponse.getItems()).usingRecursiveFieldByFieldElementComparatorIgnoringFields(
-                                "profileProducts")
+                () -> assertThat(memberPageResponse.getItems())
+                        .usingRecursiveFieldByFieldElementComparatorIgnoringFields("profileProducts")
                         .hasSize(1)
-                        .containsOnly(memberWithProfileProductResponse)
+                        .containsOnly(memberWithProfileProductResponse),
+                () -> assertThat(memberPageResponse.getItems().get(0).getProfileProducts())
+                        .usingRecursiveFieldByFieldElementComparatorIgnoringFields("reviewCount", "rating")
+                        .hasSize(1)
+                        .containsOnly(ProductResponse.from(keyboard))
         );
     }
 

--- a/backend/src/test/java/com/woowacourse/f12/support/InventoryProductFixtures.java
+++ b/backend/src/test/java/com/woowacourse/f12/support/InventoryProductFixtures.java
@@ -1,8 +1,14 @@
 package com.woowacourse.f12.support;
 
+import com.woowacourse.f12.acceptance.support.RestAssuredRequestUtil;
 import com.woowacourse.f12.domain.inventoryproduct.InventoryProduct;
 import com.woowacourse.f12.domain.member.Member;
 import com.woowacourse.f12.domain.product.Product;
+import com.woowacourse.f12.dto.request.inventoryproduct.ProfileProductRequest;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public enum InventoryProductFixtures {
 
@@ -27,5 +33,14 @@ public enum InventoryProductFixtures {
                 .member(member)
                 .product(product)
                 .build();
+    }
+
+    public static ExtractableResponse<Response> 대표_장비_업데이트_한다(final List<Product> selectedProducts,
+                                                              final String token) {
+        final List<Long> selectedProductIds = selectedProducts.stream()
+                .map(Product::getId)
+                .collect(Collectors.toList());
+        return RestAssuredRequestUtil.로그인된_상태로_PATCH_요청을_보낸다("/api/v1/members/inventoryProducts", token,
+                new ProfileProductRequest(selectedProductIds));
     }
 }


### PR DESCRIPTION
# issue: #316 

# 작업 내용
- Member 객체에서 인벤토리 제품에서 대표 제품을 찾는 책임을 부여
- 도메인에서 대표 제품 찾는 메서드 호출