### PR TITLE
[BE] 페이지 조회 시 중복되는 아이템 조회되는 이슈 피드백 반영완료

### DIFF
--- a/backend/src/test/java/com/woowacourse/f12/acceptance/ProductAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/acceptance/ProductAcceptanceTest.java
@@ -127,7 +127,7 @@ class ProductAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
-    void 리뷰_갯수가_같은_상태에서_제품_목록을_리뷰가_많은_순서로_페이징하여_조회하면_id_역순으로_조회된다() {
+    void 리뷰_개수가_같은_상태에서_제품_목록을_리뷰가_많은_순서로_페이징하여_조회하면_id_역순으로_조회된다() {
         // given
         Product product1 = 제품을_저장한다(KEYBOARD_1.생성());
         Product product2 = 제품을_저장한다(KEYBOARD_2.생성());
@@ -145,6 +145,27 @@ class ProductAcceptanceTest extends AcceptanceTest {
                 () -> assertThat(response.as(ProductPageResponse.class).getItems())
                         .extracting("id")
                         .containsExactly(product2.getId(), product1.getId()),
+                () -> assertThat(response.as(ProductPageResponse.class).isHasNext()).isFalse()
+        );
+    }
+
+    @Test
+    void 정렬_조건으로_id_역순으로_페이징하여_조회하면_id_역순으로_조회된다() {
+        // given
+        Product product1 = 제품을_저장한다(KEYBOARD_1.생성());
+        Product product2 = 제품을_저장한다(KEYBOARD_2.생성());
+        Product product3 = 제품을_저장한다(MOUSE_1.생성());
+
+        // when
+        ExtractableResponse<Response> response = GET_요청을_보낸다(
+                "/api/v1/products?page=0&size=3&sort=id,desc");
+
+        // then
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(response.as(ProductPageResponse.class).getItems())
+                        .extracting("id")
+                        .containsExactly(product3.getId(), product2.getId(), product1.getId()),
                 () -> assertThat(response.as(ProductPageResponse.class).isHasNext()).isFalse()
         );
     }


### PR DESCRIPTION
# issue: #331 

# 작업 내용
- id 역순에 대한 정렬조건으로 제품을 조회할 때 데이터가 잘나오는지에 대한 테스트 추가