### PR TITLE
[BE] GitHub Actions workflow에 테스트 리포트 추가

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -36,3 +36,15 @@ jobs:
       
       - name: gradle build
         run: ./gradlew build
+      
+      - name: publish unit test results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()
+        with:
+          files: build/test-results/**/*.xml
+      
+      - name: add comments to a pull request
+        uses: mikepenz/action-junit-report@v3
+        if: always()
+        with:
+          report_paths: build/test-results/test/*.xml


### PR DESCRIPTION
# issue: #296 

# 작업 내용
- `EnricoMi/publish-unit-test-result-action@v2`로 테스트 리포트 추가
- mikepenz/action-junit-report@v3로 PR에 테스트 실패에 대한 comment를 남기도록 설정