### PR TITLE
[BE] 회원 정보를 조회할 때 id에 대한 역순으로 정렬이 안되는 오류 수정

### DIFF
--- a/backend/src/main/java/com/woowacourse/f12/domain/member/MemberRepositoryCustomImpl.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/member/MemberRepositoryCustomImpl.java
@@ -73,14 +73,14 @@ public class MemberRepositoryCustomImpl extends QuerydslRepositorySupport implem
         return member.gitHubId.contains(keyword);
     }
 
-    public BooleanExpression eqCareerLevel(final CareerLevel careerLevel) {
+    private BooleanExpression eqCareerLevel(final CareerLevel careerLevel) {
         if (Objects.isNull(careerLevel)) {
             return null;
         }
         return member.careerLevel.eq(careerLevel);
     }
 
-    public BooleanExpression eqJobType(final JobType jobType) {
+    private BooleanExpression eqJobType(final JobType jobType) {
         if (Objects.isNull(jobType)) {
             return null;
         }

--- a/backend/src/test/java/com/woowacourse/f12/acceptance/MemberAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/acceptance/MemberAcceptanceTest.java
@@ -1,9 +1,26 @@
 package com.woowacourse.f12.acceptance;
 
+import com.woowacourse.f12.domain.inventoryproduct.InventoryProduct;
+import com.woowacourse.f12.domain.member.Member;
+import com.woowacourse.f12.domain.product.Product;
+import com.woowacourse.f12.domain.product.ProductRepository;
+import com.woowacourse.f12.dto.request.member.MemberRequest;
+import com.woowacourse.f12.dto.response.auth.LoginMemberResponse;
+import com.woowacourse.f12.dto.response.auth.LoginResponse;
+import com.woowacourse.f12.dto.response.member.MemberPageResponse;
+import com.woowacourse.f12.dto.response.member.MemberResponse;
+import com.woowacourse.f12.dto.response.member.MemberWithProfileProductResponse;
+import com.woowacourse.f12.dto.response.product.ProductResponse;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+
+import java.util.List;
+
 import static com.woowacourse.f12.acceptance.support.LoginUtil.로그인을_한다;
-import static com.woowacourse.f12.acceptance.support.RestAssuredRequestUtil.GET_요청을_보낸다;
-import static com.woowacourse.f12.acceptance.support.RestAssuredRequestUtil.로그인된_상태로_GET_요청을_보낸다;
-import static com.woowacourse.f12.acceptance.support.RestAssuredRequestUtil.로그인된_상태로_PATCH_요청을_보낸다;
+import static com.woowacourse.f12.acceptance.support.RestAssuredRequestUtil.*;
 import static com.woowacourse.f12.domain.member.CareerLevel.JUNIOR;
 import static com.woowacourse.f12.domain.member.JobType.BACKEND;
 import static com.woowacourse.f12.presentation.member.CareerLevelConstant.JUNIOR_CONSTANT;
@@ -20,26 +37,6 @@ import static com.woowacourse.f12.support.ReviewFixtures.REVIEW_RATING_4;
 import static com.woowacourse.f12.support.ReviewFixtures.REVIEW_RATING_5;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
-
-import com.woowacourse.f12.domain.inventoryproduct.InventoryProduct;
-import com.woowacourse.f12.domain.member.Member;
-import com.woowacourse.f12.domain.product.Product;
-import com.woowacourse.f12.domain.product.ProductRepository;
-import com.woowacourse.f12.dto.request.member.MemberRequest;
-import com.woowacourse.f12.dto.response.auth.LoginMemberResponse;
-import com.woowacourse.f12.dto.response.auth.LoginResponse;
-import com.woowacourse.f12.dto.response.member.MemberPageResponse;
-import com.woowacourse.f12.dto.response.member.MemberResponse;
-import com.woowacourse.f12.dto.response.member.MemberWithProfileProductResponse;
-import com.woowacourse.f12.dto.response.product.ProductResponse;
-import com.woowacourse.f12.dto.response.product.ProductResponse;
-import com.woowacourse.f12.support.InventoryProductFixtures;
-import io.restassured.response.ExtractableResponse;
-import io.restassured.response.Response;
-import java.util.List;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
 
 public class MemberAcceptanceTest extends AcceptanceTest {
 
@@ -238,6 +235,35 @@ public class MemberAcceptanceTest extends AcceptanceTest {
                         .usingRecursiveFieldByFieldElementComparatorIgnoringFields("reviewCount", "rating")
                         .hasSize(1)
                         .containsOnly(ProductResponse.from(keyboard))
+        );
+    }
+
+    @Test
+    void 회원정보_목록은_id의_역순으로_조회된다() {
+        // given
+        MemberRequest memberRequest = new MemberRequest(SENIOR_CONSTANT, BACKEND_CONSTANT);
+
+        LoginResponse firstLoginResponse = 로그인을_한다(MINCHO_GITHUB.getCode());
+        로그인된_상태로_PATCH_요청을_보낸다("/api/v1/members/me", firstLoginResponse.getToken(), memberRequest);
+
+        LoginResponse secondLoginResponse = 로그인을_한다(CORINNE_GITHUB.getCode());
+        로그인된_상태로_PATCH_요청을_보낸다("/api/v1/members/me", secondLoginResponse.getToken(), memberRequest);
+
+        // when
+        ExtractableResponse<Response> response = GET_요청을_보낸다("/api/v1/members?page=0&size=2");
+
+        // then
+        MemberPageResponse memberPageResponse = response.as(MemberPageResponse.class);
+
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(memberPageResponse.isHasNext()).isFalse(),
+                () -> assertThat(memberPageResponse.getItems()
+                        .stream()
+                        .map(MemberWithProfileProductResponse::getId))
+                        .usingRecursiveFieldByFieldElementComparatorOnFields("id")
+                        .hasSize(2)
+                        .containsExactly(secondLoginResponse.getMember().getId(), firstLoginResponse.getMember().getId())
         );
     }
 


### PR DESCRIPTION
# issue: #366 

# 작업 내용
- 회원 정보를 조회할 때 id에 대한 역순으로 정렬이 안되는 오류 수정
- 특정 메소드의 접근제어자 private으로 수정