### PR TITLE
[Bugfix] 원격 레포지토리의 submodule 버전이 최신화되지 않는 오류 수정

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -38,4 +38,3 @@ out/
 
 ### submodules ###
 submodules/
-security/


### PR DESCRIPTION
# issue: closes #386 

# 작업 내용
- submodule gitignore 제거
- `security` 디렉토리 커밋
