### PR TITLE
[Hotfix/FE] 추가정보 입력하지 않은 사용자의 경로 이동 방지 추가

### DIFF
--- a/frontend/src/components/common/UserInfo/UserInfo.tsx
+++ b/frontend/src/components/common/UserInfo/UserInfo.tsx
@@ -33,14 +33,16 @@ function UserInfo({ userData }: Props) {
         <S.ProfileImage src={imageUrl} alt="" />
       </S.ImageWrapper>
       <S.Username>{`@${gitHubId}`}</S.Username>
-      <S.ChipWrapper>
-        <Chip paddingTopBottom={0.5} paddingLeftRight={0.5}>
-          {chipMapper[jobType]}
-        </Chip>
-        <Chip paddingTopBottom={0.5} paddingLeftRight={0.8}>
-          {chipMapper[careerLevel]}
-        </Chip>
-      </S.ChipWrapper>
+      {jobType && careerLevel && (
+        <S.ChipWrapper>
+          <Chip paddingTopBottom={0.5} paddingLeftRight={0.5}>
+            {chipMapper[jobType]}
+          </Chip>
+          <Chip paddingTopBottom={0.5} paddingLeftRight={0.8}>
+            {chipMapper[careerLevel]}
+          </Chip>
+        </S.ChipWrapper>
+      )}
     </S.Container>
   );
 }

--- a/frontend/src/hooks/useOtherInventory.tsx
+++ b/frontend/src/hooks/useOtherInventory.tsx
@@ -23,6 +23,7 @@ function useOtherInventory({ memberId }: Prop): Return {
   } = useGetOne<InventoryResponse>({
     url: ENDPOINTS.OTHER_INVENTORY_PRODUCTS(memberId),
   });
+  console.log(isError);
 
   return {
     items: inventoryProducts?.items,

--- a/frontend/src/hooks/useOtherInventory.tsx
+++ b/frontend/src/hooks/useOtherInventory.tsx
@@ -23,7 +23,6 @@ function useOtherInventory({ memberId }: Prop): Return {
   } = useGetOne<InventoryResponse>({
     url: ENDPOINTS.OTHER_INVENTORY_PRODUCTS(memberId),
   });
-  console.log(isError);
 
   return {
     items: inventoryProducts?.items,

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -173,6 +173,10 @@ const submitAdditionalInfo = (req, res, ctx) => {
   return res(ctx.status(200));
 };
 
+const getOtherMemberInfo = (req, res, ctx) => {
+  return res(ctx.json({ ...myData, jobType: null, careerLevel: null }));
+};
+
 export const handlers = [
   rest.get(`${BASE_URL}${ENDPOINTS.PRODUCTS}`, getKeyboards),
   rest.get(`${BASE_URL}${ENDPOINTS.PRODUCT(':id')}`, getKeyboard),
@@ -202,4 +206,5 @@ export const handlers = [
   ),
   rest.get(`${BASE_URL}${ENDPOINTS.ME}`, getMyInfo),
   rest.patch(`${BASE_URL}${ENDPOINTS.ME}`, submitAdditionalInfo),
+  rest.get(`${BASE_URL}${ENDPOINTS.MEMBERS}/:memberId`, getOtherMemberInfo),
 ];

--- a/frontend/src/pages/OtherProfile/OtherProfile.tsx
+++ b/frontend/src/pages/OtherProfile/OtherProfile.tsx
@@ -22,7 +22,11 @@ type Member = {
 function OtherProfile() {
   const { memberId } = useParams();
 
-  const { items, isReady: isInventoryProductsReady } = useOtherInventory({
+  const {
+    items,
+    isReady: isInventoryProductsReady,
+    isError: isInventoryProductsError,
+  } = useOtherInventory({
     memberId,
   });
 
@@ -66,7 +70,7 @@ function OtherProfile() {
         <AsyncWrapper
           fallback={<Loading />}
           isReady={isInventoryProductsReady}
-          isError={isMyDataError}
+          isError={isInventoryProductsError}
         >
           <ProductSelect inventoryList={inventoryList} editable={false} />
         </AsyncWrapper>
@@ -79,7 +83,7 @@ function OtherProfile() {
         <AsyncWrapper
           fallback={<Loading />}
           isReady={isInventoryProductsReady}
-          isError={isMyDataError}
+          isError={isInventoryProductsError}
         >
           <div>키보드</div>
           <InventoryProductList products={keyboardItems} />

--- a/frontend/src/pages/common/ClosedRoutes/ClosedRoutes.tsx
+++ b/frontend/src/pages/common/ClosedRoutes/ClosedRoutes.tsx
@@ -1,0 +1,18 @@
+import ROUTES from '@/constants/routes';
+import { Navigate, Outlet } from 'react-router-dom';
+
+type Routes = keyof typeof ROUTES;
+type Props = {
+  when: boolean;
+  redirectPath?: typeof ROUTES[Routes];
+};
+
+function ClosedRoute({ when, redirectPath = ROUTES.HOME }: Props) {
+  if (when) {
+    return <Navigate to={redirectPath} replace />;
+  }
+
+  return <Outlet />;
+}
+
+export default ClosedRoute;

--- a/frontend/src/pages/common/RegisterIncompleteRoute/RegisterCompleteRoute.tsx
+++ b/frontend/src/pages/common/RegisterIncompleteRoute/RegisterCompleteRoute.tsx
@@ -1,0 +1,21 @@
+import ROUTES from '@/constants/routes';
+import { UserDataContext } from '@/contexts/LoginContextProvider';
+import useAuth from '@/hooks/useAuth';
+import useModal from '@/hooks/useModal';
+import ClosedRoute from '@/pages/common/ClosedRoutes/ClosedRoutes';
+import { useContext } from 'react';
+
+function RegisterCompleteRoute() {
+  const { isLoggedIn } = useAuth();
+  const userData = useContext(UserDataContext);
+  const { showAlert } = useModal();
+
+  const isRegistered =
+    !isLoggedIn || (isLoggedIn && userData?.registerCompleted);
+
+  if (!isRegistered) showAlert('추가 정보 입력 후 이용해주세요.');
+
+  return <ClosedRoute when={!isRegistered} redirectPath={ROUTES.REGISTER} />;
+}
+
+export default RegisterCompleteRoute;

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -11,12 +11,12 @@ import ProfileSearch from '@/pages/ProfileSearch/ProfileSearch';
 import UserRoutes from '@/pages/common/UserRoutes/UserRoutes';
 import NonUserRoutes from '@/pages/common/NonUserRoutes/NonUserRoutes';
 import NotFound from '@/pages/NotFound/NotFound';
+import RegisterCompleteRoute from '@/pages/common/RegisterIncompleteRoute/RegisterCompleteRoute';
 
 const USER_ROUTES = [
   {
     element: <UserRoutes />,
     children: [
-      { path: ROUTES.REGISTER, element: <Register /> },
       {
         path: ROUTES.PROFILE,
         element: <Profile />,
@@ -36,15 +36,24 @@ export const PAGES = [
   {
     element: <PageLayout />,
     children: [
-      { path: ROUTES.HOME, element: <Home /> },
-      { path: ROUTES.PRODUCTS, element: <Products /> },
-      { path: `${ROUTES.PRODUCT}/:productId`, element: <Product /> },
-      { path: `${ROUTES.PROFILE_SEARCH}`, element: <ProfileSearch /> },
-      ...NON_USER_ROUTES,
-      ...USER_ROUTES,
       {
-        path: `${ROUTES.PROFILE}/:memberId`,
-        element: <OtherProfile />,
+        element: <RegisterCompleteRoute />,
+        children: [
+          { path: ROUTES.HOME, element: <Home /> },
+          { path: ROUTES.PRODUCTS, element: <Products /> },
+          { path: `${ROUTES.PRODUCT}/:productId`, element: <Product /> },
+          { path: `${ROUTES.PROFILE_SEARCH}`, element: <ProfileSearch /> },
+          ...NON_USER_ROUTES,
+          ...USER_ROUTES,
+          {
+            path: `${ROUTES.PROFILE}/:memberId`,
+            element: <OtherProfile />,
+          },
+        ],
+      },
+      {
+        element: <UserRoutes />,
+        children: [{ path: ROUTES.REGISTER, element: <Register /> }],
       },
       { path: ROUTES.NOT_FOUND, element: <NotFound /> },
     ],


### PR DESCRIPTION
# issue: closed #389 

# 작업 내용
- 로그인 하고 추가정보 입력하지 않은 경우 다른 경로로 이동하지 못하고 다시 추가정보 페이지로 돌아오게 변경
- 프로필 페이지에서도 추가정보 없는 경우 제외하고 표시하도록 오류 수정