### PR TITLE
[Hotfix/FE] 추가 정보 저장 후 이동 경로 이동 불가한 오류 수정

### DIFF
--- a/backend/src/main/java/com/woowacourse/f12/application/member/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/member/MemberService.java
@@ -9,7 +9,6 @@ import com.woowacourse.f12.dto.request.member.MemberRequest;
 import com.woowacourse.f12.dto.request.member.MemberSearchRequest;
 import com.woowacourse.f12.dto.response.member.MemberPageResponse;
 import com.woowacourse.f12.dto.response.member.MemberResponse;
-import com.woowacourse.f12.exception.badrequest.InvalidProfileArgumentException;
 import com.woowacourse.f12.exception.notfound.MemberNotFoundException;
 import com.woowacourse.f12.presentation.member.CareerLevelConstant;
 import com.woowacourse.f12.presentation.member.JobTypeConstant;
@@ -31,9 +30,6 @@ public class MemberService {
 
     public MemberResponse findById(final Long memberId) {
         final Member member = findMember(memberId);
-        if (!member.isRegisterCompleted()) {
-            throw new InvalidProfileArgumentException();
-        }
         return MemberResponse.from(member);
     }
 

--- a/backend/src/main/java/com/woowacourse/f12/application/review/ReviewService.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/review/ReviewService.java
@@ -12,6 +12,7 @@ import com.woowacourse.f12.dto.request.review.ReviewRequest;
 import com.woowacourse.f12.dto.response.review.ReviewPageResponse;
 import com.woowacourse.f12.dto.response.review.ReviewWithProductPageResponse;
 import com.woowacourse.f12.exception.badrequest.AlreadyWrittenReviewException;
+import com.woowacourse.f12.exception.badrequest.InvalidProfileArgumentException;
 import com.woowacourse.f12.exception.forbidden.NotAuthorException;
 import com.woowacourse.f12.exception.notfound.MemberNotFoundException;
 import com.woowacourse.f12.exception.notfound.ProductNotFoundException;
@@ -44,11 +45,18 @@ public class ReviewService {
                                               final ReviewRequest reviewRequest) {
         final Member member = memberRepository.findById(memberId)
                 .orElseThrow(MemberNotFoundException::new);
+        validateRegisterCompleted(member);
         final Product product = productRepository.findById(productId)
                 .orElseThrow(ProductNotFoundException::new);
         final Long reviewId = saveReview(reviewRequest, member, product);
         saveInventoryProduct(member, product);
         return reviewId;
+    }
+
+    private void validateRegisterCompleted(final Member member) {
+        if (!member.isRegisterCompleted()) {
+            throw new InvalidProfileArgumentException();
+        }
     }
 
     private Long saveReview(final ReviewRequest reviewRequest, final Member member, final Product product) {

--- a/backend/src/main/java/com/woowacourse/f12/domain/member/MemberRepositoryCustomImpl.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/member/MemberRepositoryCustomImpl.java
@@ -1,22 +1,21 @@
 package com.woowacourse.f12.domain.member;
 
+import static com.woowacourse.f12.domain.member.QMember.member;
+
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.PathBuilder;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
-
-import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
-
-import static com.woowacourse.f12.domain.member.QMember.member;
 
 public class MemberRepositoryCustomImpl extends QuerydslRepositorySupport implements MemberRepositoryCustom {
 
@@ -35,7 +34,8 @@ public class MemberRepositoryCustomImpl extends QuerydslRepositorySupport implem
                 .where(
                         containsKeyword(keyword),
                         eqCareerLevel(careerLevel),
-                        eqJobType(jobType)
+                        eqJobType(jobType),
+                        notNullMemberInfo()
                 )
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize() + 1)
@@ -69,6 +69,10 @@ public class MemberRepositoryCustomImpl extends QuerydslRepositorySupport implem
             return null;
         }
         return member.gitHubId.contains(keyword);
+    }
+
+    private BooleanExpression notNullMemberInfo() {
+        return member.careerLevel.isNotNull().and(member.jobType.isNotNull());
     }
 
     private BooleanExpression eqCareerLevel(final CareerLevel careerLevel) {

--- a/backend/src/main/java/com/woowacourse/f12/domain/review/ReviewRepositoryCustomImpl.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/review/ReviewRepositoryCustomImpl.java
@@ -3,6 +3,7 @@ package com.woowacourse.f12.domain.review;
 import static com.woowacourse.f12.domain.member.QMember.member;
 import static com.woowacourse.f12.domain.review.QReview.review;
 
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.woowacourse.f12.domain.product.Product;
 import java.util.List;
@@ -22,7 +23,10 @@ public class ReviewRepositoryCustomImpl extends QuerydslRepositorySupport implem
         return jpaQueryFactory.select(new QCareerLevelCount(member.careerLevel, member.id.count()))
                 .from(review)
                 .innerJoin(review.member, member)
-                .where(review.product.id.eq(productId))
+                .where(
+                        review.product.id.eq(productId),
+                        notNullMemberInfo()
+                )
                 .groupBy(member.careerLevel)
                 .fetch();
     }
@@ -32,8 +36,15 @@ public class ReviewRepositoryCustomImpl extends QuerydslRepositorySupport implem
         return jpaQueryFactory.select(new QJobTypeCount(member.jobType, member.id.count()))
                 .from(review)
                 .innerJoin(review.member, member)
-                .where(review.product.id.eq(productId))
+                .where(
+                        review.product.id.eq(productId),
+                        notNullMemberInfo()
+                )
                 .groupBy(member.jobType)
                 .fetch();
+    }
+
+    private BooleanExpression notNullMemberInfo() {
+        return member.careerLevel.isNotNull().and(member.jobType.isNotNull());
     }
 }

--- a/backend/src/main/java/com/woowacourse/f12/presentation/member/CareerLevelConstant.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/member/CareerLevelConstant.java
@@ -38,7 +38,7 @@ public enum CareerLevelConstant implements ViewConstant {
         return Arrays.stream(values())
                 .filter(it -> it.careerLevel.equals(careerLevel))
                 .findAny()
-                .orElseThrow(InvalidCareerLevelException::new);
+                .orElse(null);
     }
 
     public CareerLevel toCareerLevel() {

--- a/backend/src/main/java/com/woowacourse/f12/presentation/member/JobTypeConstant.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/member/JobTypeConstant.java
@@ -38,7 +38,7 @@ public enum JobTypeConstant implements ViewConstant {
         return Arrays.stream(values())
                 .filter(it -> it.jobType.equals(jobType))
                 .findAny()
-                .orElseThrow(InvalidJobTypeException::new);
+                .orElse(null);
     }
 
     public JobType toJobType() {

--- a/backend/src/test/java/com/woowacourse/f12/acceptance/InventoryProductAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/acceptance/InventoryProductAcceptanceTest.java
@@ -4,11 +4,12 @@ import static com.woowacourse.f12.acceptance.support.LoginUtil.로그인을_한�
 import static com.woowacourse.f12.acceptance.support.RestAssuredRequestUtil.GET_요청을_보낸다;
 import static com.woowacourse.f12.acceptance.support.RestAssuredRequestUtil.로그인된_상태로_GET_요청을_보낸다;
 import static com.woowacourse.f12.acceptance.support.RestAssuredRequestUtil.로그인된_상태로_PATCH_요청을_보낸다;
+import static com.woowacourse.f12.presentation.member.CareerLevelConstant.SENIOR_CONSTANT;
+import static com.woowacourse.f12.presentation.member.JobTypeConstant.BACKEND_CONSTANT;
 import static com.woowacourse.f12.support.GitHubProfileFixtures.CORINNE_GITHUB;
 import static com.woowacourse.f12.support.InventoryProductFixtures.SELECTED_INVENTORY_PRODUCT;
 import static com.woowacourse.f12.support.InventoryProductFixtures.UNSELECTED_INVENTORY_PRODUCT;
 import static com.woowacourse.f12.support.ProductFixture.KEYBOARD_1;
-import static com.woowacourse.f12.support.ProductFixture.KEYBOARD_2;
 import static com.woowacourse.f12.support.ReviewFixtures.REVIEW_RATING_5;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -19,6 +20,7 @@ import com.woowacourse.f12.domain.member.Member;
 import com.woowacourse.f12.domain.product.Product;
 import com.woowacourse.f12.domain.product.ProductRepository;
 import com.woowacourse.f12.dto.request.inventoryproduct.ProfileProductRequest;
+import com.woowacourse.f12.dto.request.member.MemberRequest;
 import com.woowacourse.f12.dto.response.auth.LoginMemberResponse;
 import com.woowacourse.f12.dto.response.auth.LoginResponse;
 import com.woowacourse.f12.dto.response.inventoryproduct.InventoryProductResponse;
@@ -43,6 +45,8 @@ class InventoryProductAcceptanceTest extends AcceptanceTest {
         // given
         Long productId = 제품을_저장한다(KEYBOARD_1.생성()).getId();
         String token = 로그인을_한다(CORINNE_GITHUB.getCode()).getToken();
+        MemberRequest memberRequest = new MemberRequest(SENIOR_CONSTANT, BACKEND_CONSTANT);
+        로그인된_상태로_PATCH_요청을_보낸다("/api/v1/members/me", token, memberRequest);
         REVIEW_RATING_5.작성_요청을_보낸다(productId, token);
 
         // when

--- a/backend/src/test/java/com/woowacourse/f12/acceptance/MemberAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/acceptance/MemberAcceptanceTest.java
@@ -1,26 +1,9 @@
 package com.woowacourse.f12.acceptance;
 
-import com.woowacourse.f12.domain.inventoryproduct.InventoryProduct;
-import com.woowacourse.f12.domain.member.Member;
-import com.woowacourse.f12.domain.product.Product;
-import com.woowacourse.f12.domain.product.ProductRepository;
-import com.woowacourse.f12.dto.request.member.MemberRequest;
-import com.woowacourse.f12.dto.response.auth.LoginMemberResponse;
-import com.woowacourse.f12.dto.response.auth.LoginResponse;
-import com.woowacourse.f12.dto.response.member.MemberPageResponse;
-import com.woowacourse.f12.dto.response.member.MemberResponse;
-import com.woowacourse.f12.dto.response.member.MemberWithProfileProductResponse;
-import com.woowacourse.f12.dto.response.product.ProductResponse;
-import io.restassured.response.ExtractableResponse;
-import io.restassured.response.Response;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
-
-import java.util.List;
-
 import static com.woowacourse.f12.acceptance.support.LoginUtil.로그인을_한다;
-import static com.woowacourse.f12.acceptance.support.RestAssuredRequestUtil.*;
+import static com.woowacourse.f12.acceptance.support.RestAssuredRequestUtil.GET_요청을_보낸다;
+import static com.woowacourse.f12.acceptance.support.RestAssuredRequestUtil.로그인된_상태로_GET_요청을_보낸다;
+import static com.woowacourse.f12.acceptance.support.RestAssuredRequestUtil.로그인된_상태로_PATCH_요청을_보낸다;
 import static com.woowacourse.f12.domain.member.CareerLevel.JUNIOR;
 import static com.woowacourse.f12.domain.member.JobType.BACKEND;
 import static com.woowacourse.f12.presentation.member.CareerLevelConstant.JUNIOR_CONSTANT;
@@ -37,6 +20,24 @@ import static com.woowacourse.f12.support.ReviewFixtures.REVIEW_RATING_4;
 import static com.woowacourse.f12.support.ReviewFixtures.REVIEW_RATING_5;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.woowacourse.f12.domain.inventoryproduct.InventoryProduct;
+import com.woowacourse.f12.domain.member.Member;
+import com.woowacourse.f12.domain.product.Product;
+import com.woowacourse.f12.domain.product.ProductRepository;
+import com.woowacourse.f12.dto.request.member.MemberRequest;
+import com.woowacourse.f12.dto.response.auth.LoginMemberResponse;
+import com.woowacourse.f12.dto.response.auth.LoginResponse;
+import com.woowacourse.f12.dto.response.member.MemberPageResponse;
+import com.woowacourse.f12.dto.response.member.MemberResponse;
+import com.woowacourse.f12.dto.response.member.MemberWithProfileProductResponse;
+import com.woowacourse.f12.dto.response.product.ProductResponse;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 
 public class MemberAcceptanceTest extends AcceptanceTest {
 
@@ -84,6 +85,25 @@ public class MemberAcceptanceTest extends AcceptanceTest {
         Member expectedMember = 응답을_회원으로_변환한다(loginResponse.getMember());
         expectedMember.updateCareerLevel(JUNIOR);
         expectedMember.updateJobType(BACKEND);
+
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(response.as(MemberResponse.class)).usingRecursiveComparison()
+                        .isEqualTo(MemberResponse.from(expectedMember))
+        );
+    }
+
+    @Test
+    void 로그인_된_상태에서_추가정보가_입력되지_않았을떄_내_회원정보를_조회한다() {
+        // given
+        LoginResponse loginResponse = 로그인을_한다(CORINNE_GITHUB.getCode());
+        String token = loginResponse.getToken();
+
+        // when
+        ExtractableResponse<Response> response = 로그인된_상태로_GET_요청을_보낸다("/api/v1/members/me", token);
+
+        // then
+        Member expectedMember = 응답을_회원으로_변환한다(loginResponse.getMember());
 
         assertAll(
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
@@ -154,6 +174,42 @@ public class MemberAcceptanceTest extends AcceptanceTest {
                         memberPageResponse.getItems()).usingRecursiveFieldByFieldElementComparatorIgnoringFields(
                                 "profileProducts")
                         .hasSize(2)
+                        .contains(memberWithProfileProductResponse)
+        );
+    }
+
+    @Test
+    void 회원정보를_키워드와_옵션을_입력하지않고_조회할때_추가정보가_입력되지않은_회원은_포함되지_않는다() {
+        // given
+        Product product = 제품을_저장한다(KEYBOARD_1.생성());
+
+        MemberRequest memberRequest = new MemberRequest(SENIOR_CONSTANT, BACKEND_CONSTANT);
+        로그인을_한다(MINCHO_GITHUB.getCode());
+
+        LoginResponse secondLoginResponse = 로그인을_한다(CORINNE_GITHUB.getCode());
+        String token = secondLoginResponse.getToken();
+        Long memberId = secondLoginResponse.getMember().getId();
+        로그인된_상태로_PATCH_요청을_보낸다("/api/v1/members/me", token, memberRequest);
+
+        REVIEW_RATING_5.작성_요청을_보낸다(product.getId(), token);
+
+        // when
+        ExtractableResponse<Response> response = GET_요청을_보낸다("/api/v1/members?page=0&size=2");
+
+        // then
+        MemberPageResponse memberPageResponse = response.as(MemberPageResponse.class);
+        InventoryProduct inventoryProduct = SELECTED_INVENTORY_PRODUCT.생성(1L, CORINNE.생성(memberId), product);
+        Member member = CORINNE.대표장비를_추가해서_생성(memberId, inventoryProduct);
+        MemberWithProfileProductResponse memberWithProfileProductResponse = MemberWithProfileProductResponse.from(
+                member);
+
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(memberPageResponse.isHasNext()).isFalse(),
+                () -> assertThat(
+                        memberPageResponse.getItems()).usingRecursiveFieldByFieldElementComparatorIgnoringFields(
+                                "profileProducts")
+                        .hasSize(1)
                         .contains(memberWithProfileProductResponse)
         );
     }

--- a/backend/src/test/java/com/woowacourse/f12/acceptance/ProductAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/acceptance/ProductAcceptanceTest.java
@@ -106,8 +106,13 @@ class ProductAcceptanceTest extends AcceptanceTest {
         // given
         Product product1 = 제품을_저장한다(KEYBOARD_1.생성());
         Product product2 = 제품을_저장한다(KEYBOARD_2.생성());
+        MemberRequest memberRequest = new MemberRequest(SENIOR_CONSTANT, BACKEND_CONSTANT);
+
         String corinneToken = 로그인을_한다(CORINNE_GITHUB.getCode()).getToken();
+        로그인된_상태로_PATCH_요청을_보낸다("/api/v1/members/me", corinneToken, memberRequest);
         String minchoToken = 로그인을_한다(MINCHO_GITHUB.getCode()).getToken();
+        로그인된_상태로_PATCH_요청을_보낸다("/api/v1/members/me", minchoToken, memberRequest);
+
         REVIEW_RATING_5.작성_요청을_보낸다(product1.getId(), corinneToken);
         REVIEW_RATING_4.작성_요청을_보낸다(product1.getId(), minchoToken);
         REVIEW_RATING_3.작성_요청을_보낸다(product2.getId(), minchoToken);

--- a/backend/src/test/java/com/woowacourse/f12/acceptance/ReviewAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/acceptance/ReviewAcceptanceTest.java
@@ -3,7 +3,10 @@ package com.woowacourse.f12.acceptance;
 import static com.woowacourse.f12.acceptance.support.LoginUtil.로그인을_한다;
 import static com.woowacourse.f12.acceptance.support.RestAssuredRequestUtil.GET_요청을_보낸다;
 import static com.woowacourse.f12.acceptance.support.RestAssuredRequestUtil.로그인된_상태로_DELETE_요청을_보낸다;
+import static com.woowacourse.f12.acceptance.support.RestAssuredRequestUtil.로그인된_상태로_PATCH_요청을_보낸다;
 import static com.woowacourse.f12.acceptance.support.RestAssuredRequestUtil.로그인된_상태로_PUT_요청을_보낸다;
+import static com.woowacourse.f12.presentation.member.CareerLevelConstant.SENIOR_CONSTANT;
+import static com.woowacourse.f12.presentation.member.JobTypeConstant.BACKEND_CONSTANT;
 import static com.woowacourse.f12.support.GitHubProfileFixtures.CORINNE_GITHUB;
 import static com.woowacourse.f12.support.GitHubProfileFixtures.MINCHO_GITHUB;
 import static com.woowacourse.f12.support.ProductFixture.KEYBOARD_1;
@@ -15,6 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.woowacourse.f12.domain.product.Product;
 import com.woowacourse.f12.domain.product.ProductRepository;
+import com.woowacourse.f12.dto.request.member.MemberRequest;
 import com.woowacourse.f12.dto.request.review.ReviewRequest;
 import com.woowacourse.f12.dto.response.ExceptionResponse;
 import com.woowacourse.f12.dto.response.review.ReviewPageResponse;
@@ -37,6 +41,8 @@ public class ReviewAcceptanceTest extends AcceptanceTest {
         // given
         Product product = 키보드를_저장한다(KEYBOARD_1.생성());
         String token = 로그인을_한다(CORINNE_GITHUB.getCode()).getToken();
+        MemberRequest memberRequest = new MemberRequest(SENIOR_CONSTANT, BACKEND_CONSTANT);
+        로그인된_상태로_PATCH_요청을_보낸다("/api/v1/members/me", token, memberRequest);
 
         // when
         ExtractableResponse<Response> response = REVIEW_RATING_5.작성_요청을_보낸다(product.getId(), token);
@@ -53,6 +59,8 @@ public class ReviewAcceptanceTest extends AcceptanceTest {
         // given
         Product product = 키보드를_저장한다(KEYBOARD_1.생성());
         String token = 로그인을_한다(CORINNE_GITHUB.getCode()).getToken();
+        MemberRequest memberRequest = new MemberRequest(SENIOR_CONSTANT, BACKEND_CONSTANT);
+        로그인된_상태로_PATCH_요청을_보낸다("/api/v1/members/me", token, memberRequest);
         REVIEW_RATING_5.작성_요청을_보낸다(product.getId(), token);
 
         // when
@@ -70,9 +78,14 @@ public class ReviewAcceptanceTest extends AcceptanceTest {
     void 특정_제품_리뷰_목록을_최신순으로_조회한다() {
         // given
         Product product = 키보드를_저장한다(KEYBOARD_1.생성());
+        MemberRequest memberRequest = new MemberRequest(SENIOR_CONSTANT, BACKEND_CONSTANT);
+
         String token = 로그인을_한다(CORINNE_GITHUB.getCode()).getToken();
+        로그인된_상태로_PATCH_요청을_보낸다("/api/v1/members/me", token, memberRequest);
         REVIEW_RATING_5.작성_요청을_보낸다(product.getId(), token);
+
         String token2 = 로그인을_한다(MINCHO_GITHUB.getCode()).getToken();
+        로그인된_상태로_PATCH_요청을_보낸다("/api/v1/members/me", token2, memberRequest);
         Long reviewId = Location_헤더에서_id값을_꺼낸다(REVIEW_RATING_5.작성_요청을_보낸다(product.getId(), token2));
 
         // when
@@ -95,8 +108,11 @@ public class ReviewAcceptanceTest extends AcceptanceTest {
         // given
         Product product = 키보드를_저장한다(KEYBOARD_1.생성());
         String token = 로그인을_한다(CORINNE_GITHUB.getCode()).getToken();
+        MemberRequest memberRequest = new MemberRequest(SENIOR_CONSTANT, BACKEND_CONSTANT);
+        로그인된_상태로_PATCH_요청을_보낸다("/api/v1/members/me", token, memberRequest);
         REVIEW_RATING_4.작성_요청을_보낸다(product.getId(), token);
         String token2 = 로그인을_한다(MINCHO_GITHUB.getCode()).getToken();
+        로그인된_상태로_PATCH_요청을_보낸다("/api/v1/members/me", token2, memberRequest);
         Long reviewId = Location_헤더에서_id값을_꺼낸다(REVIEW_RATING_5.작성_요청을_보낸다(product.getId(), token2));
 
         // when
@@ -120,6 +136,8 @@ public class ReviewAcceptanceTest extends AcceptanceTest {
         Product product1 = 키보드를_저장한다(KEYBOARD_1.생성());
         Product product2 = 키보드를_저장한다(KEYBOARD_2.생성());
         String token = 로그인을_한다(CORINNE_GITHUB.getCode()).getToken();
+        MemberRequest memberRequest = new MemberRequest(SENIOR_CONSTANT, BACKEND_CONSTANT);
+        로그인된_상태로_PATCH_요청을_보낸다("/api/v1/members/me", token, memberRequest);
         Long reviewId1 = Location_헤더에서_id값을_꺼낸다(REVIEW_RATING_4.작성_요청을_보낸다(product1.getId(), token));
         Long reviewId2 = Location_헤더에서_id값을_꺼낸다(REVIEW_RATING_4.작성_요청을_보낸다(product2.getId(), token));
 
@@ -142,6 +160,8 @@ public class ReviewAcceptanceTest extends AcceptanceTest {
         // given
         Product product = 키보드를_저장한다(KEYBOARD_1.생성());
         String token = 로그인을_한다(CORINNE_GITHUB.getCode()).getToken();
+        MemberRequest memberRequest = new MemberRequest(SENIOR_CONSTANT, BACKEND_CONSTANT);
+        로그인된_상태로_PATCH_요청을_보낸다("/api/v1/members/me", token, memberRequest);
         long reviewId = Location_헤더에서_id값을_꺼낸다(REVIEW_RATING_5.작성_요청을_보낸다(product.getId(), token));
         ReviewRequest requestBody = new ReviewRequest("수정된 내용", 4);
 
@@ -166,6 +186,8 @@ public class ReviewAcceptanceTest extends AcceptanceTest {
         // given
         Product product = 키보드를_저장한다(KEYBOARD_1.생성());
         String token = 로그인을_한다(CORINNE_GITHUB.getCode()).getToken();
+        MemberRequest memberRequest = new MemberRequest(SENIOR_CONSTANT, BACKEND_CONSTANT);
+        로그인된_상태로_PATCH_요청을_보낸다("/api/v1/members/me", token, memberRequest);
         long reviewId = Location_헤더에서_id값을_꺼낸다(REVIEW_RATING_5.작성_요청을_보낸다(product.getId(), token));
 
         // when

--- a/backend/src/test/java/com/woowacourse/f12/application/member/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/application/member/MemberServiceTest.java
@@ -23,8 +23,8 @@ import com.woowacourse.f12.dto.request.member.MemberSearchRequest;
 import com.woowacourse.f12.dto.response.member.MemberPageResponse;
 import com.woowacourse.f12.dto.response.member.MemberResponse;
 import com.woowacourse.f12.dto.response.member.MemberWithProfileProductResponse;
-import com.woowacourse.f12.exception.badrequest.InvalidProfileArgumentException;
 import com.woowacourse.f12.exception.notfound.MemberNotFoundException;
+import com.woowacourse.f12.support.MemberFixtures;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -77,21 +77,18 @@ class MemberServiceTest {
     }
 
     @Test
-    void 추가_정보가_입력되지_않은_멤버_아이디로_회원정보를_조회하면_예외가_발생한다() {
+    void 추가_정보가_입력되지_않은_멤버_아이디로_회원정보를_조회한다() {
         // given
-        Member member = Member.builder()
-                .id(1L)
-                .gitHubId("gitHubId")
-                .name("name")
-                .imageUrl("url")
-                .build();
+        Member member = MemberFixtures.NOT_ADDITIONAL_INFO.생성();
         given(memberRepository.findById(1L))
                 .willReturn(Optional.of(member));
 
-        // when, then
+        // when
+        MemberResponse memberResponse = memberService.findById(1L);
+        // then
         assertAll(
-                () -> assertThatThrownBy(() -> memberService.findById(1L))
-                        .isExactlyInstanceOf(InvalidProfileArgumentException.class),
+                () -> assertThat(memberResponse).usingRecursiveComparison()
+                        .isEqualTo(MemberResponse.from(member)),
                 () -> verify(memberRepository).findById(1L)
         );
     }

--- a/backend/src/test/java/com/woowacourse/f12/application/review/ReviewServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/application/review/ReviewServiceTest.java
@@ -2,6 +2,7 @@ package com.woowacourse.f12.application.review;
 
 import static com.woowacourse.f12.support.InventoryProductFixtures.UNSELECTED_INVENTORY_PRODUCT;
 import static com.woowacourse.f12.support.MemberFixtures.CORINNE;
+import static com.woowacourse.f12.support.MemberFixtures.NOT_ADDITIONAL_INFO;
 import static com.woowacourse.f12.support.ProductFixture.KEYBOARD_1;
 import static com.woowacourse.f12.support.ProductFixture.KEYBOARD_2;
 import static com.woowacourse.f12.support.ReviewFixtures.REVIEW_RATING_5;
@@ -29,6 +30,7 @@ import com.woowacourse.f12.dto.response.review.ReviewResponse;
 import com.woowacourse.f12.dto.response.review.ReviewWithProductPageResponse;
 import com.woowacourse.f12.dto.response.review.ReviewWithProductResponse;
 import com.woowacourse.f12.exception.badrequest.AlreadyWrittenReviewException;
+import com.woowacourse.f12.exception.badrequest.InvalidProfileArgumentException;
 import com.woowacourse.f12.exception.forbidden.NotAuthorException;
 import com.woowacourse.f12.exception.notfound.MemberNotFoundException;
 import com.woowacourse.f12.exception.notfound.ProductNotFoundException;
@@ -114,6 +116,26 @@ class ReviewServiceTest {
                 () -> assertThatThrownBy(
                         () -> reviewService.saveReviewAndInventoryProduct(productId, memberId, reviewRequest))
                         .isExactlyInstanceOf(MemberNotFoundException.class),
+                () -> verify(memberRepository).findById(memberId),
+                () -> verify(reviewRepository, times(0)).save(any(Review.class))
+        );
+    }
+
+    @Test
+    void 추가정보가_없는_회원으로_로그인하여_리뷰를_작성하면_예외를_반환한다() {
+        // given
+        Long memberId = 1L;
+        Long productId = 1L;
+        ReviewRequest reviewRequest = new ReviewRequest("내용", 5);
+
+        given(memberRepository.findById(memberId))
+                .willReturn(Optional.of(NOT_ADDITIONAL_INFO.생성(1L)));
+
+        // when, then
+        assertAll(
+                () -> assertThatThrownBy(
+                        () -> reviewService.saveReviewAndInventoryProduct(productId, memberId, reviewRequest))
+                        .isExactlyInstanceOf(InvalidProfileArgumentException.class),
                 () -> verify(memberRepository).findById(memberId),
                 () -> verify(reviewRepository, times(0)).save(any(Review.class))
         );

--- a/backend/src/test/java/com/woowacourse/f12/domain/member/MemberRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/domain/member/MemberRepositoryTest.java
@@ -4,6 +4,7 @@ import static com.woowacourse.f12.domain.member.CareerLevel.SENIOR;
 import static com.woowacourse.f12.domain.member.JobType.BACKEND;
 import static com.woowacourse.f12.support.MemberFixtures.CORINNE;
 import static com.woowacourse.f12.support.MemberFixtures.MINCHO;
+import static com.woowacourse.f12.support.MemberFixtures.NOT_ADDITIONAL_INFO;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
@@ -109,6 +110,21 @@ class MemberRepositoryTest {
                 () -> assertThat(slice.hasNext()).isFalse(),
                 () -> assertThat(slice.getContent()).usingRecursiveFieldByFieldElementComparatorIgnoringFields("id")
                         .containsOnly(CORINNE.생성())
+        );
+    }
+
+    @Test
+    void 추가정보가_입력되지않은_회원은_회원을_조회할때_포함되지_않는다() {
+        // given
+        memberRepository.save(NOT_ADDITIONAL_INFO.생성());
+
+        // when
+        Slice<Member> slice = memberRepository.findBySearchConditions(null, null, null, PageRequest.of(0, 2));
+
+        // then
+        assertAll(
+                () -> assertThat(slice.hasNext()).isFalse(),
+                () -> assertThat(slice.getContent()).isEmpty()
         );
     }
 }

--- a/backend/src/test/java/com/woowacourse/f12/domain/review/ReviewRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/domain/review/ReviewRepositoryTest.java
@@ -6,6 +6,7 @@ import static com.woowacourse.f12.domain.member.JobType.BACKEND;
 import static com.woowacourse.f12.domain.member.JobType.MOBILE;
 import static com.woowacourse.f12.support.MemberFixtures.CORINNE;
 import static com.woowacourse.f12.support.MemberFixtures.MINCHO;
+import static com.woowacourse.f12.support.MemberFixtures.NOT_ADDITIONAL_INFO;
 import static com.woowacourse.f12.support.ProductFixture.KEYBOARD_1;
 import static com.woowacourse.f12.support.ProductFixture.KEYBOARD_2;
 import static com.woowacourse.f12.support.ReviewFixtures.REVIEW_RATING_1;
@@ -185,6 +186,29 @@ class ReviewRepositoryTest {
     }
 
     @Test
+    void 제품에_대한_사용자_연차의_총_개수를_반환할때_추가정보가_없는_회원은_포함되지_않는다() {
+        // given
+        Product product = 제품_저장(KEYBOARD_1.생성());
+
+        Member corinne = CORINNE.생성();
+        corinne = memberRepository.save(corinne);
+        Member notAdditionalInfo = NOT_ADDITIONAL_INFO.생성();
+        notAdditionalInfo = memberRepository.save(notAdditionalInfo);
+
+        리뷰_저장(REVIEW_RATING_2.작성(product, corinne));
+        리뷰_저장(REVIEW_RATING_1.작성(product, notAdditionalInfo));
+
+        // when
+        List<CareerLevelCount> careerLevelCounts = reviewRepository.findCareerLevelCountByProductId(
+                product.getId());
+
+        // then
+        assertThat(careerLevelCounts).usingRecursiveFieldByFieldElementComparator()
+                .hasSize(1)
+                .containsOnly(new CareerLevelCount(SENIOR, 1));
+    }
+
+    @Test
     void 제품에_대한_사용자_직군의_총_개수를_반환한다() {
         // given
         Product product = 제품_저장(KEYBOARD_1.생성());
@@ -212,6 +236,28 @@ class ReviewRepositoryTest {
                         new JobTypeCount(MOBILE, 1),
                         new JobTypeCount(BACKEND, 1)
                 );
+    }
+
+    @Test
+    void 제품에_대한_사용자_직군의_총_개수를_반환할때_추가정보가_없는_회원은_포함되지_않는다() {
+        // given
+        Product product = 제품_저장(KEYBOARD_1.생성());
+
+        Member corinne = CORINNE.생성();
+        corinne = memberRepository.save(corinne);
+        Member notAdditionalInfo = NOT_ADDITIONAL_INFO.생성();
+        notAdditionalInfo = memberRepository.save(notAdditionalInfo);
+
+        리뷰_저장(REVIEW_RATING_2.작성(product, corinne));
+        리뷰_저장(REVIEW_RATING_1.작성(product, notAdditionalInfo));
+
+        // when
+        List<JobTypeCount> jobTypeCounts = reviewRepository.findJobTypeCountByProductId(product.getId());
+
+        // then
+        assertThat(jobTypeCounts).usingRecursiveFieldByFieldElementComparator()
+                .hasSize(1)
+                .containsOnly(new JobTypeCount(BACKEND, 1));
     }
 
     private Product 제품_저장(Product product) {

--- a/backend/src/test/java/com/woowacourse/f12/support/MemberFixtures.java
+++ b/backend/src/test/java/com/woowacourse/f12/support/MemberFixtures.java
@@ -16,7 +16,8 @@ public enum MemberFixtures {
 
     CORINNE("hamcheeseburger", "유현지", "corinne_url", SENIOR, BACKEND),
     MINCHO("jswith", "홍영민", "mincho_url", JUNIOR, FRONTEND),
-    CORINNE_UPDATED("hamcheeseburger", "괴물개발자", "corinne_url", SENIOR, BACKEND);
+    CORINNE_UPDATED("hamcheeseburger", "괴물개발자", "corinne_url", SENIOR, BACKEND),
+    NOT_ADDITIONAL_INFO("invalid", "invalid", "invalid", null, null);
 
     private final String gitHubId;
     private final String name;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "f12",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "개발자의 모든 도구 - F12",
   "main": "index.js",
   "scripts": {

--- a/frontend/src/components/common/UserInfo/UserInfo.tsx
+++ b/frontend/src/components/common/UserInfo/UserInfo.tsx
@@ -33,14 +33,16 @@ function UserInfo({ userData }: Props) {
         <S.ProfileImage src={imageUrl} alt="" />
       </S.ImageWrapper>
       <S.Username>{`@${gitHubId}`}</S.Username>
-      <S.ChipWrapper>
-        <Chip paddingTopBottom={0.5} paddingLeftRight={0.5}>
-          {chipMapper[jobType]}
-        </Chip>
-        <Chip paddingTopBottom={0.5} paddingLeftRight={0.8}>
-          {chipMapper[careerLevel]}
-        </Chip>
-      </S.ChipWrapper>
+      {jobType && careerLevel && (
+        <S.ChipWrapper>
+          <Chip paddingTopBottom={0.5} paddingLeftRight={0.5}>
+            {chipMapper[jobType]}
+          </Chip>
+          <Chip paddingTopBottom={0.5} paddingLeftRight={0.8}>
+            {chipMapper[careerLevel]}
+          </Chip>
+        </S.ChipWrapper>
+      )}
     </S.Container>
   );
 }

--- a/frontend/src/hooks/api/usePatch.tsx
+++ b/frontend/src/hooks/api/usePatch.tsx
@@ -1,6 +1,11 @@
 import { AxiosRequestHeaders, AxiosResponse } from 'axios';
 import useAxios from '@/hooks/api/useAxios';
 import useError from '@/hooks/useError';
+import { useContext } from 'react';
+import {
+  SetUserDataContext,
+  UserDataContext,
+} from '@/contexts/LoginContextProvider';
 
 type Props = {
   url: string;
@@ -13,12 +18,20 @@ function usePatch<T>({
 }: Props): (data: Record<string, unknown>) => Promise<AxiosResponse<T>> {
   const { axiosInstance } = useAxios();
   const handleError = useError();
+  const userData = useContext(UserDataContext);
+  const setUserData = useContext(SetUserDataContext);
 
   const patchData = async (data: Record<string, unknown>) => {
     try {
       const response: AxiosResponse<T> = await axiosInstance.patch(url, data, {
         headers,
       });
+
+      const newUserData = { ...userData };
+      newUserData.member = { ...newUserData.member, ...data };
+      newUserData.registerCompleted = true;
+
+      setUserData(newUserData);
       return response;
     } catch (error) {
       const requestBodyString = Object.entries(data).reduce<string>(

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -173,6 +173,10 @@ const submitAdditionalInfo = (req, res, ctx) => {
   return res(ctx.status(200));
 };
 
+const getOtherMemberInfo = (req, res, ctx) => {
+  return res(ctx.json({ ...myData, jobType: null, careerLevel: null }));
+};
+
 export const handlers = [
   rest.get(`${BASE_URL}${ENDPOINTS.PRODUCTS}`, getKeyboards),
   rest.get(`${BASE_URL}${ENDPOINTS.PRODUCT(':id')}`, getKeyboard),
@@ -202,4 +206,5 @@ export const handlers = [
   ),
   rest.get(`${BASE_URL}${ENDPOINTS.ME}`, getMyInfo),
   rest.patch(`${BASE_URL}${ENDPOINTS.ME}`, submitAdditionalInfo),
+  rest.get(`${BASE_URL}${ENDPOINTS.MEMBERS}/:memberId`, getOtherMemberInfo),
 ];

--- a/frontend/src/pages/OtherProfile/OtherProfile.tsx
+++ b/frontend/src/pages/OtherProfile/OtherProfile.tsx
@@ -22,7 +22,11 @@ type Member = {
 function OtherProfile() {
   const { memberId } = useParams();
 
-  const { items, isReady: isInventoryProductsReady } = useOtherInventory({
+  const {
+    items,
+    isReady: isInventoryProductsReady,
+    isError: isInventoryProductsError,
+  } = useOtherInventory({
     memberId,
   });
 
@@ -66,7 +70,7 @@ function OtherProfile() {
         <AsyncWrapper
           fallback={<Loading />}
           isReady={isInventoryProductsReady}
-          isError={isMyDataError}
+          isError={isInventoryProductsError}
         >
           <ProductSelect inventoryList={inventoryList} editable={false} />
         </AsyncWrapper>
@@ -79,7 +83,7 @@ function OtherProfile() {
         <AsyncWrapper
           fallback={<Loading />}
           isReady={isInventoryProductsReady}
-          isError={isMyDataError}
+          isError={isInventoryProductsError}
         >
           <div>키보드</div>
           <InventoryProductList products={keyboardItems} />

--- a/frontend/src/pages/Register/Register.tsx
+++ b/frontend/src/pages/Register/Register.tsx
@@ -1,6 +1,6 @@
 import Stepper from '@/components/common/Stepper/Stepper';
 import * as S from '@/pages/Register/Register.style';
-import { useContext, useState } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import usePatch from '@/hooks/api/usePatch';
 import { UserDataContext } from '@/contexts/LoginContextProvider';
 import { ENDPOINTS } from '@/constants/api';
@@ -86,13 +86,9 @@ function Register() {
       } 개발자이신가요?`
     );
     if (confirmation) {
-      patchAdditionalInfo(input)
-        .then(() => {
-          navigate(ROUTES.HOME);
-        })
-        .catch((error) => {
-          console.log(error);
-        });
+      patchAdditionalInfo(input).catch((error) => {
+        console.log(error);
+      });
     }
   };
 
@@ -116,6 +112,12 @@ function Register() {
   const handleEditButtonClick = () => {
     setStep(1);
   };
+
+  useEffect(() => {
+    if (!userData?.registerCompleted) return;
+
+    navigate(ROUTES.HOME);
+  }, [userData]);
 
   return (
     <S.Container>

--- a/frontend/src/pages/common/ClosedRoutes/ClosedRoutes.tsx
+++ b/frontend/src/pages/common/ClosedRoutes/ClosedRoutes.tsx
@@ -1,0 +1,18 @@
+import ROUTES from '@/constants/routes';
+import { Navigate, Outlet } from 'react-router-dom';
+
+type Routes = keyof typeof ROUTES;
+type Props = {
+  when: boolean;
+  redirectPath?: typeof ROUTES[Routes];
+};
+
+function ClosedRoute({ when, redirectPath = ROUTES.HOME }: Props) {
+  if (when) {
+    return <Navigate to={redirectPath} replace />;
+  }
+
+  return <Outlet />;
+}
+
+export default ClosedRoute;

--- a/frontend/src/pages/common/RegisterIncompleteRoute/RegisterCompleteRoute.tsx
+++ b/frontend/src/pages/common/RegisterIncompleteRoute/RegisterCompleteRoute.tsx
@@ -1,0 +1,21 @@
+import ROUTES from '@/constants/routes';
+import { UserDataContext } from '@/contexts/LoginContextProvider';
+import useAuth from '@/hooks/useAuth';
+import useModal from '@/hooks/useModal';
+import ClosedRoute from '@/pages/common/ClosedRoutes/ClosedRoutes';
+import { useContext } from 'react';
+
+function RegisterCompleteRoute() {
+  const { isLoggedIn } = useAuth();
+  const userData = useContext(UserDataContext);
+  const { showAlert } = useModal();
+
+  const isRegistered =
+    !isLoggedIn || (isLoggedIn && userData?.registerCompleted);
+
+  if (!isRegistered) showAlert('추가 정보 입력 후 이용해주세요.');
+
+  return <ClosedRoute when={!isRegistered} redirectPath={ROUTES.REGISTER} />;
+}
+
+export default RegisterCompleteRoute;

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -11,12 +11,12 @@ import ProfileSearch from '@/pages/ProfileSearch/ProfileSearch';
 import UserRoutes from '@/pages/common/UserRoutes/UserRoutes';
 import NonUserRoutes from '@/pages/common/NonUserRoutes/NonUserRoutes';
 import NotFound from '@/pages/NotFound/NotFound';
+import RegisterCompleteRoute from '@/pages/common/RegisterIncompleteRoute/RegisterCompleteRoute';
 
 const USER_ROUTES = [
   {
     element: <UserRoutes />,
     children: [
-      { path: ROUTES.REGISTER, element: <Register /> },
       {
         path: ROUTES.PROFILE,
         element: <Profile />,
@@ -36,15 +36,24 @@ export const PAGES = [
   {
     element: <PageLayout />,
     children: [
-      { path: ROUTES.HOME, element: <Home /> },
-      { path: ROUTES.PRODUCTS, element: <Products /> },
-      { path: `${ROUTES.PRODUCT}/:productId`, element: <Product /> },
-      { path: `${ROUTES.PROFILE_SEARCH}`, element: <ProfileSearch /> },
-      ...NON_USER_ROUTES,
-      ...USER_ROUTES,
       {
-        path: `${ROUTES.PROFILE}/:memberId`,
-        element: <OtherProfile />,
+        element: <RegisterCompleteRoute />,
+        children: [
+          { path: ROUTES.HOME, element: <Home /> },
+          { path: ROUTES.PRODUCTS, element: <Products /> },
+          { path: `${ROUTES.PRODUCT}/:productId`, element: <Product /> },
+          { path: `${ROUTES.PROFILE_SEARCH}`, element: <ProfileSearch /> },
+          ...NON_USER_ROUTES,
+          ...USER_ROUTES,
+          {
+            path: `${ROUTES.PROFILE}/:memberId`,
+            element: <OtherProfile />,
+          },
+        ],
+      },
+      {
+        element: <UserRoutes />,
+        children: [{ path: ROUTES.REGISTER, element: <Register /> }],
       },
       { path: ROUTES.NOT_FOUND, element: <NotFound /> },
     ],


### PR DESCRIPTION
# 변경사항
- 추가 정보 저장 시 서버의 요청은 보내지만 그 새로운 상태를 프론트에서 저장하지 않아서 경로를 이동할 수 없었던 현상 수정
