### PR TITLE
[Hotfix/FE] 추가 정보 저장 후 이동 경로 이동 불가한 오류 수정 

### DIFF
--- a/frontend/src/hooks/api/usePatch.tsx
+++ b/frontend/src/hooks/api/usePatch.tsx
@@ -1,6 +1,11 @@
 import { AxiosRequestHeaders, AxiosResponse } from 'axios';
 import useAxios from '@/hooks/api/useAxios';
 import useError from '@/hooks/useError';
+import { useContext } from 'react';
+import {
+  SetUserDataContext,
+  UserDataContext,
+} from '@/contexts/LoginContextProvider';
 
 type Props = {
   url: string;
@@ -13,12 +18,20 @@ function usePatch<T>({
 }: Props): (data: Record<string, unknown>) => Promise<AxiosResponse<T>> {
   const { axiosInstance } = useAxios();
   const handleError = useError();
+  const userData = useContext(UserDataContext);
+  const setUserData = useContext(SetUserDataContext);
 
   const patchData = async (data: Record<string, unknown>) => {
     try {
       const response: AxiosResponse<T> = await axiosInstance.patch(url, data, {
         headers,
       });
+
+      const newUserData = { ...userData };
+      newUserData.member = { ...newUserData.member, ...data };
+      newUserData.registerCompleted = true;
+
+      setUserData(newUserData);
       return response;
     } catch (error) {
       const requestBodyString = Object.entries(data).reduce<string>(

--- a/frontend/src/pages/Register/Register.tsx
+++ b/frontend/src/pages/Register/Register.tsx
@@ -1,6 +1,6 @@
 import Stepper from '@/components/common/Stepper/Stepper';
 import * as S from '@/pages/Register/Register.style';
-import { useContext, useState } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import usePatch from '@/hooks/api/usePatch';
 import { UserDataContext } from '@/contexts/LoginContextProvider';
 import { ENDPOINTS } from '@/constants/api';
@@ -86,13 +86,9 @@ function Register() {
       } 개발자이신가요?`
     );
     if (confirmation) {
-      patchAdditionalInfo(input)
-        .then(() => {
-          navigate(ROUTES.HOME);
-        })
-        .catch((error) => {
-          console.log(error);
-        });
+      patchAdditionalInfo(input).catch((error) => {
+        console.log(error);
+      });
     }
   };
 
@@ -116,6 +112,12 @@ function Register() {
   const handleEditButtonClick = () => {
     setStep(1);
   };
+
+  useEffect(() => {
+    if (!userData?.registerCompleted) return;
+
+    navigate(ROUTES.HOME);
+  }, [userData]);
 
   return (
     <S.Container>


### PR DESCRIPTION
# 변경사항
- 추가 정보 저장 시 서버의 요청은 보내지만 그 새로운 상태를 프론트에서 저장하지 않아서 경로를 이동할 수 없었던 현상 수정
