### PR TITLE
[BE] equals 메서드가 제대로 작성되지 않은 경우 수정

### DIFF
--- a/backend/src/main/java/com/woowacourse/f12/domain/inventoryproduct/InventoryProduct.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/inventoryproduct/InventoryProduct.java
@@ -59,7 +59,7 @@ public class InventoryProduct {
             return false;
         }
         final InventoryProduct that = (InventoryProduct) o;
-        return Objects.equals(id, that.id);
+        return Objects.equals(id, that.getId());
     }
 
     @Override

--- a/backend/src/main/java/com/woowacourse/f12/domain/review/Review.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/review/Review.java
@@ -99,11 +99,11 @@ public class Review {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (!(o instanceof Review)) {
             return false;
         }
         final Review review = (Review) o;
-        return Objects.equals(id, review.id);
+        return Objects.equals(id, review.getId());
     }
 
     @Override


### PR DESCRIPTION
# issue: #400 

# 작업 내용
- `InventoryProduct`의 equals가 id 비교를 getter가 아닌 직접 참조로 비교하는 부분 수정
- `Review`의 equals가 JPA 프록시를 고려하지 않은 부분 수정