### PR TITLE
[BE] CORS가 허용된 origin 제한

### DIFF
--- a/backend/src/main/java/com/woowacourse/f12/config/WebConfig.java
+++ b/backend/src/main/java/com/woowacourse/f12/config/WebConfig.java
@@ -16,6 +16,10 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 public class WebConfig implements WebMvcConfigurer {
 
     private static final String CORS_ALLOWED_METHODS = "GET,POST,HEAD,PUT,PATCH,DELETE,TRACE,OPTIONS";
+    private static final String MAIN_SERVER_DOMAIN = "https://f12.app";
+    private static final String MAIN_SERVER_WWW_DOMAIN = "https://www.f12.app";
+    private static final String TEST_SERVER_DOMAIN = "https://test.f12.app";
+    private static final String FRONTEND_LOCALHOST = "http://localhost:3000";
 
     private final List<HandlerInterceptor> interceptors;
     private final List<HandlerMethodArgumentResolver> resolvers;
@@ -37,6 +41,7 @@ public class WebConfig implements WebMvcConfigurer {
     public void addCorsMappings(final CorsRegistry registry) {
         registry.addMapping("/api/**")
                 .allowedMethods(CORS_ALLOWED_METHODS.split(","))
+                .allowedOrigins(MAIN_SERVER_DOMAIN, MAIN_SERVER_WWW_DOMAIN, TEST_SERVER_DOMAIN, FRONTEND_LOCALHOST)
                 .exposedHeaders(HttpHeaders.LOCATION);
     }
 

--- a/backend/src/test/java/com/woowacourse/f12/config/WebConfigTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/config/WebConfigTest.java
@@ -6,6 +6,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -21,17 +23,29 @@ class WebConfigTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @Test
-    void CORS가_허용되어있다() throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = {"https://f12.app", "https://www.f12.app", "https://test.f12.app", "http://localhost:3000"})
+    void 특정_Origin에_CORS가_허용되어있다(String origin) throws Exception {
         mockMvc.perform(
                         options("/api/v1/products")
-                                .header(HttpHeaders.ORIGIN, "http://localhost:8080")
+                                .header(HttpHeaders.ORIGIN, origin)
                                 .header(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, "GET")
                 )
                 .andExpect(status().isOk())
-                .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "*"))
+                .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, origin))
                 .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS, CORS_ALLOWED_METHODS))
                 .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS, HttpHeaders.LOCATION))
+                .andDo(print());
+    }
+
+    @Test
+    void CORS가_허용되지_않은_Origin에서_Preflight_요청을_보내면_허용하지_않는다() throws Exception {
+        mockMvc.perform(
+                        options("/api/v1/products")
+                                .header(HttpHeaders.ORIGIN, "http://not-allowed-origin")
+                                .header(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, "GET")
+                )
+                .andExpect(status().isForbidden())
                 .andDo(print());
     }
 }


### PR DESCRIPTION
# issue: #406 

# 작업 내용
- 기존에는 CORS가 모든 origin에 대해 열려 있었으나, 실제 도메인 + 로컬 프론트엔드 환경에만 허용하도록 수정 완료