### PR TITLE
[Bugfix/FE] github oauth에서 인증을 취소할 시 발생하는 오류 해결

### DIFF
--- a/frontend/src/components/Login/Login.tsx
+++ b/frontend/src/components/Login/Login.tsx
@@ -15,6 +15,13 @@ function Login() {
   const navigate = useNavigate();
 
   useEffect(() => {
+    const githubCode = searchParam.get('code');
+    if (!githubCode) {
+      showAlert('로그인을 취소했거나 오류가 발생했습니다.');
+      navigate(ROUTES.HOME);
+      return;
+    }
+
     login(searchParam.get('code')).catch(() => {
       showAlert('로그인에 실패했습니다. 잠시 후 다시 시도해주세요.');
       navigate(ROUTES.HOME);


### PR DESCRIPTION
# issue: closed #401 

# 작업 내용
깃헙에서 인증 취소 시에
1. 로그인 과정을 멈추고
2. 사용자에게 로그인을 취소했거나 오류가 발생했다는 메시지를 표시하고
3. 홈으로 이동
