### PR TITLE
[FE] confirm 모달 창 promise가 무조건 resolve 되도록 수정

### DIFF
--- a/frontend/src/contexts/ModalContextProvider.tsx
+++ b/frontend/src/contexts/ModalContextProvider.tsx
@@ -6,6 +6,7 @@ export const GetConfirmContext =
   createContext<(message: string) => Promise<boolean>>(null);
 
 let resolveConfirm: (value: boolean | PromiseLike<boolean>) => void;
+
 function ModalContextProvider({ children }: PropsWithChildren) {
   const [message, setMessage] = useState('');
   const [alertOpen, setAlertOpen] = useState(false);
@@ -15,13 +16,18 @@ function ModalContextProvider({ children }: PropsWithChildren) {
     setMessage(message);
     setAlertOpen(true);
   };
+
+  const handleAlertClose = () => {
+    setAlertOpen(false);
+  };
+
   const showConfirm = (message: string) => {
     setMessage(message);
     setConfirmOpen(true);
   };
 
-  const handleClose = () => {
-    setAlertOpen(false);
+  const handleConfirmClose = () => {
+    resolveConfirm(false);
     setConfirmOpen(false);
   };
 
@@ -43,12 +49,12 @@ function ModalContextProvider({ children }: PropsWithChildren) {
       <GetConfirmContext.Provider value={getConfirm}>
         {children}
         {alertOpen && (
-          <Modal handleClose={handleClose}>
+          <Modal handleClose={handleAlertClose}>
             <Modal.Body>{message}</Modal.Body>
           </Modal>
         )}
         {confirmOpen && (
-          <Modal handleClose={handleClose} handleConfirm={handleConfirm}>
+          <Modal handleClose={handleConfirmClose} handleConfirm={handleConfirm}>
             <Modal.Body>{message}</Modal.Body>
           </Modal>
         )}


### PR DESCRIPTION
# issue: closed #422

# 작업 내용
- confirm 모달 취소 시 promise가 resolve 되도록 처리
- reject로 처리하려 했으나 confirm이 작동하는 방식은 false를 반환하는 것이므로 reject가 아니라 false가 resovle 되도록 구현