### PR TITLE
[BE] @Builder 사용 시 객체의 기본 값이 Builder에도 설정되도록 수정

### DIFF
--- a/backend/src/main/java/com/woowacourse/f12/domain/inventoryproduct/InventoryProduct.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/inventoryproduct/InventoryProduct.java
@@ -17,6 +17,7 @@ import lombok.Getter;
 
 @Entity
 @Table(name = "inventory_product")
+@Builder
 @Getter
 public class InventoryProduct {
 
@@ -27,18 +28,17 @@ public class InventoryProduct {
     @Column(name = "selected")
     private boolean selected;
 
-    @ManyToOne(fetch = FetchType.EAGER)
-    @JoinColumn(name = "product_id")
-    private Product product;
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "product_id")
+    private Product product;
+
     protected InventoryProduct() {
     }
 
-    @Builder
     private InventoryProduct(final Long id, final boolean selected, final Member member, final Product product) {
         this.id = id;
         this.selected = selected;

--- a/backend/src/main/java/com/woowacourse/f12/domain/member/Member.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/member/Member.java
@@ -24,6 +24,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Entity
 @Table(name = "member")
 @EntityListeners(AuditingEntityListener.class)
+@Builder
 @Getter
 public class Member {
 
@@ -55,7 +56,6 @@ public class Member {
     protected Member() {
     }
 
-    @Builder
     private Member(final Long id, final String gitHubId, final String name, final String imageUrl,
                    final CareerLevel careerLevel, final JobType jobType,
                    final List<InventoryProduct> inventoryProducts) {

--- a/backend/src/main/java/com/woowacourse/f12/domain/member/Member.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/member/Member.java
@@ -49,6 +49,7 @@ public class Member {
     @Enumerated(EnumType.STRING)
     private JobType jobType;
 
+    @Builder.Default
     @BatchSize(size = 150)
     @OneToMany(mappedBy = "member")
     private List<InventoryProduct> inventoryProducts = new ArrayList<>();

--- a/backend/src/main/java/com/woowacourse/f12/domain/review/Review.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/review/Review.java
@@ -25,6 +25,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Entity
 @Table(name = "review")
 @EntityListeners(AuditingEntityListener.class)
+@Builder
 @Getter
 public class Review {
 
@@ -57,7 +58,6 @@ public class Review {
     protected Review() {
     }
 
-    @Builder
     private Review(final Long id, final String content, final int rating, final Product product, final Member member,
                    final LocalDateTime createdAt) {
         validateContent(content);

--- a/backend/src/test/java/com/woowacourse/f12/domain/member/MemberTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/domain/member/MemberTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.woowacourse.f12.domain.inventoryproduct.InventoryProduct;
 import com.woowacourse.f12.domain.product.Category;
 import com.woowacourse.f12.domain.product.Product;
+import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -46,5 +47,13 @@ class MemberTest {
         // then
         assertThat(profileProducts)
                 .containsOnly(selectedInventoryProduct.getProduct());
+    }
+
+    @Test
+    void Builder_테스트() {
+        Member member = Member.builder()
+                .build();
+
+        assertThat(member.getInventoryProducts()).isInstanceOf(ArrayList.class);
     }
 }


### PR DESCRIPTION
# issue: #415 

# 작업 내용
- `@Builder` 어노테이션을 생성자에서 클래스로 이동
  - `AllArgsContstructor`가 없는 `Product`는 제외
- 기본값이 필요한 필드에 `@Builder.Default` 사용