### PR TITLE
[BE] Member의 update 로직을 통합

### DIFF
--- a/backend/src/main/java/com/woowacourse/f12/application/auth/AuthService.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/auth/AuthService.java
@@ -26,9 +26,10 @@ public class AuthService {
     public LoginResponse login(final String code) {
         final String gitHubAccessToken = gitHubOauthClient.getAccessToken(code);
         final GitHubProfileResponse gitHubProfileResponse = gitHubOauthClient.getProfile(gitHubAccessToken);
+        final Member requestedMember = gitHubProfileResponse.toMember();
         final Member member = memberRepository.findByGitHubId(gitHubProfileResponse.getGitHubId())
-                .orElseGet(() -> memberRepository.save(gitHubProfileResponse.toMember()));
-        member.updateName(gitHubProfileResponse.getName());
+                .orElseGet(() -> memberRepository.save(requestedMember));
+        member.update(requestedMember);
         final String applicationAccessToken = jwtProvider.createToken(member.getId());
         return LoginResponse.of(applicationAccessToken, member);
     }

--- a/backend/src/main/java/com/woowacourse/f12/application/member/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/member/MemberService.java
@@ -12,11 +12,12 @@ import com.woowacourse.f12.dto.response.member.MemberResponse;
 import com.woowacourse.f12.exception.notfound.MemberNotFoundException;
 import com.woowacourse.f12.presentation.member.CareerLevelConstant;
 import com.woowacourse.f12.presentation.member.JobTypeConstant;
-import java.util.Objects;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Objects;
 
 @Service
 @Transactional(readOnly = true)
@@ -36,8 +37,7 @@ public class MemberService {
     @Transactional
     public void updateMember(final Long memberId, final MemberRequest memberRequest) {
         final Member member = findMember(memberId);
-        member.updateCareerLevel(memberRequest.getCareerLevel().toCareerLevel());
-        member.updateJobType(memberRequest.getJobType().toJobType());
+        member.update(memberRequest.toMember());
     }
 
     private Member findMember(final Long memberId) {

--- a/backend/src/main/java/com/woowacourse/f12/domain/member/Member.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/member/Member.java
@@ -64,7 +64,7 @@ public class Member {
         updateJobType(updateMember.jobType);
     }
 
-    public void updateName(final String name) {
+    private void updateName(final String name) {
         if (Objects.nonNull(name)) {
             this.name = name;
         }
@@ -76,13 +76,13 @@ public class Member {
         }
     }
 
-    public void updateCareerLevel(final CareerLevel careerLevel) {
+    private void updateCareerLevel(final CareerLevel careerLevel) {
         if (Objects.nonNull(careerLevel)) {
             this.careerLevel = careerLevel;
         }
     }
 
-    public void updateJobType(final JobType jobType) {
+    private void updateJobType(final JobType jobType) {
         if (Objects.nonNull(jobType)) {
             this.jobType = jobType;
         }

--- a/backend/src/main/java/com/woowacourse/f12/domain/member/Member.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/member/Member.java
@@ -57,16 +57,35 @@ public class Member {
         this.inventoryProducts = inventoryProducts;
     }
 
+    public void update(final Member updateMember) {
+        updateName(updateMember.name);
+        updateImageUrl(updateMember.imageUrl);
+        updateCareerLevel(updateMember.careerLevel);
+        updateJobType(updateMember.jobType);
+    }
+
     public void updateName(final String name) {
-        this.name = name;
+        if (Objects.nonNull(name)) {
+            this.name = name;
+        }
+    }
+
+    private void updateImageUrl(String imageUrl) {
+        if (Objects.nonNull(imageUrl)) {
+            this.imageUrl = imageUrl;
+        }
     }
 
     public void updateCareerLevel(final CareerLevel careerLevel) {
-        this.careerLevel = careerLevel;
+        if (Objects.nonNull(careerLevel)) {
+            this.careerLevel = careerLevel;
+        }
     }
 
     public void updateJobType(final JobType jobType) {
-        this.jobType = jobType;
+        if (Objects.nonNull(jobType)) {
+            this.jobType = jobType;
+        }
     }
 
     public boolean isRegisterCompleted() {

--- a/backend/src/main/java/com/woowacourse/f12/dto/request/member/MemberRequest.java
+++ b/backend/src/main/java/com/woowacourse/f12/dto/request/member/MemberRequest.java
@@ -1,9 +1,11 @@
 package com.woowacourse.f12.dto.request.member;
 
+import com.woowacourse.f12.domain.member.Member;
 import com.woowacourse.f12.presentation.member.CareerLevelConstant;
 import com.woowacourse.f12.presentation.member.JobTypeConstant;
-import javax.validation.constraints.NotNull;
 import lombok.Getter;
+
+import javax.validation.constraints.NotNull;
 
 @Getter
 public class MemberRequest {
@@ -20,5 +22,12 @@ public class MemberRequest {
     public MemberRequest(final CareerLevelConstant careerLevel, final JobTypeConstant jobType) {
         this.careerLevel = careerLevel;
         this.jobType = jobType;
+    }
+
+    public Member toMember() {
+        return Member.builder()
+                .careerLevel(careerLevel.toCareerLevel())
+                .jobType(jobType.toJobType())
+                .build();
     }
 }

--- a/backend/src/test/java/com/woowacourse/f12/acceptance/MemberAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/acceptance/MemberAcceptanceTest.java
@@ -73,18 +73,24 @@ public class MemberAcceptanceTest extends AcceptanceTest {
         // given
         LoginResponse loginResponse = 로그인을_한다(CORINNE_GITHUB.getCode());
         String token = loginResponse.getToken();
+        LoginMemberResponse loginMemberResponse = loginResponse.getMember();
 
         MemberRequest memberRequest = new MemberRequest(JUNIOR_CONSTANT, BACKEND_CONSTANT);
         로그인된_상태로_PATCH_요청을_보낸다("/api/v1/members/me", token, memberRequest);
+
+        Member expectedMember = Member.builder()
+                .id(loginMemberResponse.getId())
+                .gitHubId(loginMemberResponse.getGitHubId())
+                .name(loginMemberResponse.getName())
+                .imageUrl(loginMemberResponse.getImageUrl())
+                .careerLevel(JUNIOR)
+                .jobType(BACKEND)
+                .build();
 
         // when
         ExtractableResponse<Response> response = 로그인된_상태로_GET_요청을_보낸다("/api/v1/members/me", token);
 
         // then
-        Member expectedMember = 응답을_회원으로_변환한다(loginResponse.getMember());
-        expectedMember.updateCareerLevel(JUNIOR);
-        expectedMember.updateJobType(BACKEND);
-
         assertAll(
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
                 () -> assertThat(response.as(MemberResponse.class)).usingRecursiveComparison()

--- a/backend/src/test/java/com/woowacourse/f12/domain/member/MemberTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/domain/member/MemberTest.java
@@ -1,0 +1,58 @@
+package com.woowacourse.f12.domain.member;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MemberTest {
+
+    @Test
+    void 회원_추가정보들을_수정한다() {
+        // given
+        Member member = Member.builder()
+                .id(1L)
+                .name("괴물")
+                .imageUrl("imageUrl")
+                .careerLevel(CareerLevel.JUNIOR)
+                .jobType(JobType.ETC)
+                .build();
+        Member updateMember = Member.builder()
+                .id(1L)
+                .name("유현지")
+                .imageUrl("updateImageUrl")
+                .careerLevel(CareerLevel.SENIOR)
+                .jobType(JobType.BACKEND)
+                .build();
+        // when
+        member.update(updateMember);
+
+        // then
+        assertThat(member).usingRecursiveComparison()
+                .isEqualTo(updateMember);
+    }
+
+    @Test
+    void null인_필드는_수정하지_않는다() {
+        Member member = Member.builder()
+                .id(1L)
+                .name("유현지")
+                .imageUrl("imageUrl")
+                .careerLevel(CareerLevel.SENIOR)
+                .jobType(JobType.BACKEND)
+                .build();
+        Member expected = Member.builder()
+                .id(1L)
+                .name("유현지")
+                .imageUrl("imageUrl")
+                .careerLevel(CareerLevel.SENIOR)
+                .jobType(JobType.BACKEND)
+                .build();
+
+        // when
+        member.update(Member.builder().build());
+
+        // then
+        assertThat(member).usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+}

--- a/backend/src/test/java/com/woowacourse/f12/domain/product/ProductRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/domain/product/ProductRepositoryTest.java
@@ -1,22 +1,10 @@
 package com.woowacourse.f12.domain.product;
 
-import static com.woowacourse.f12.domain.product.Category.KEYBOARD;
-import static com.woowacourse.f12.support.MemberFixtures.CORINNE;
-import static com.woowacourse.f12.support.ProductFixture.*;
-import static com.woowacourse.f12.support.ReviewFixtures.REVIEW_RATING_1;
-import static com.woowacourse.f12.support.ReviewFixtures.REVIEW_RATING_2;
-import static com.woowacourse.f12.support.ReviewFixtures.REVIEW_RATING_4;
-import static com.woowacourse.f12.support.ReviewFixtures.REVIEW_RATING_5;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
-
 import com.woowacourse.f12.config.JpaConfig;
 import com.woowacourse.f12.domain.member.Member;
 import com.woowacourse.f12.domain.member.MemberRepository;
 import com.woowacourse.f12.domain.review.Review;
 import com.woowacourse.f12.domain.review.ReviewRepository;
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -26,6 +14,16 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Order;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import static com.woowacourse.f12.domain.product.Category.KEYBOARD;
+import static com.woowacourse.f12.support.MemberFixtures.CORINNE;
+import static com.woowacourse.f12.support.ProductFixture.*;
+import static com.woowacourse.f12.support.ReviewFixtures.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 @DataJpaTest
 @Import(JpaConfig.class)

--- a/backend/src/test/java/com/woowacourse/f12/domain/review/ReviewRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/domain/review/ReviewRepositoryTest.java
@@ -1,31 +1,10 @@
 package com.woowacourse.f12.domain.review;
 
-import static com.woowacourse.f12.domain.member.CareerLevel.JUNIOR;
-import static com.woowacourse.f12.domain.member.CareerLevel.SENIOR;
-import static com.woowacourse.f12.domain.member.JobType.BACKEND;
-import static com.woowacourse.f12.domain.member.JobType.MOBILE;
-import static com.woowacourse.f12.support.MemberFixtures.CORINNE;
-import static com.woowacourse.f12.support.MemberFixtures.MINCHO;
-import static com.woowacourse.f12.support.MemberFixtures.NOT_ADDITIONAL_INFO;
-import static com.woowacourse.f12.support.ProductFixture.KEYBOARD_1;
-import static com.woowacourse.f12.support.ProductFixture.KEYBOARD_2;
-import static com.woowacourse.f12.support.ReviewFixtures.REVIEW_RATING_1;
-import static com.woowacourse.f12.support.ReviewFixtures.REVIEW_RATING_2;
-import static com.woowacourse.f12.support.ReviewFixtures.REVIEW_RATING_4;
-import static com.woowacourse.f12.support.ReviewFixtures.REVIEW_RATING_5;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.springframework.data.domain.Sort.Order.desc;
-
 import com.woowacourse.f12.config.JpaConfig;
 import com.woowacourse.f12.domain.member.Member;
 import com.woowacourse.f12.domain.member.MemberRepository;
 import com.woowacourse.f12.domain.product.Product;
 import com.woowacourse.f12.domain.product.ProductRepository;
-import java.util.List;
-import java.util.Optional;
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -34,6 +13,23 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import java.util.List;
+import java.util.Optional;
+
+import static com.woowacourse.f12.domain.member.CareerLevel.JUNIOR;
+import static com.woowacourse.f12.domain.member.CareerLevel.SENIOR;
+import static com.woowacourse.f12.domain.member.JobType.BACKEND;
+import static com.woowacourse.f12.domain.member.JobType.MOBILE;
+import static com.woowacourse.f12.support.MemberFixtures.*;
+import static com.woowacourse.f12.support.ProductFixture.KEYBOARD_1;
+import static com.woowacourse.f12.support.ProductFixture.KEYBOARD_2;
+import static com.woowacourse.f12.support.ReviewFixtures.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.springframework.data.domain.Sort.Order.desc;
 
 @DataJpaTest
 @Import(JpaConfig.class)
@@ -160,14 +156,10 @@ class ReviewRepositoryTest {
         // given
         Product product = 제품_저장(KEYBOARD_1.생성());
 
-        Member corinne = CORINNE.생성();
-        corinne.updateCareerLevel(SENIOR);
-        corinne.updateJobType(MOBILE);
+        Member corinne = CORINNE.추가정보를_입력하여_생성(SENIOR, MOBILE);
         corinne = memberRepository.save(corinne);
 
-        Member mincho = MINCHO.생성();
-        mincho.updateCareerLevel(JUNIOR);
-        mincho.updateJobType(BACKEND);
+        Member mincho = MINCHO.추가정보를_입력하여_생성(JUNIOR, BACKEND);
         mincho = memberRepository.save(mincho);
 
         리뷰_저장(REVIEW_RATING_2.작성(product, corinne));
@@ -214,14 +206,10 @@ class ReviewRepositoryTest {
         // given
         Product product = 제품_저장(KEYBOARD_1.생성());
 
-        Member corinne = CORINNE.생성();
-        corinne.updateCareerLevel(SENIOR);
-        corinne.updateJobType(MOBILE);
+        Member corinne = CORINNE.추가정보를_입력하여_생성(SENIOR, MOBILE);
         corinne = memberRepository.save(corinne);
 
-        Member mincho = MINCHO.생성();
-        mincho.updateCareerLevel(JUNIOR);
-        mincho.updateJobType(BACKEND);
+        Member mincho = MINCHO.추가정보를_입력하여_생성(JUNIOR, BACKEND);
         mincho = memberRepository.save(mincho);
 
         리뷰_저장(REVIEW_RATING_2.작성(product, corinne));

--- a/backend/src/test/java/com/woowacourse/f12/support/MemberFixtures.java
+++ b/backend/src/test/java/com/woowacourse/f12/support/MemberFixtures.java
@@ -66,4 +66,19 @@ public enum MemberFixtures {
                 .inventoryProducts(new InventoryProducts(List.of(inventoryProducts)))
                 .build();
     }
+
+    public Member 추가정보를_입력하여_생성(final CareerLevel careerLevel, final JobType jobType) {
+        return 추가정보를_입력하여_생성(null, careerLevel, jobType);
+    }
+
+    public Member 추가정보를_입력하여_생성(final Long id, final CareerLevel careerLevel, final JobType jobType) {
+        return Member.builder()
+                .id(id)
+                .gitHubId(this.gitHubId)
+                .name(this.name)
+                .imageUrl(this.imageUrl)
+                .careerLevel(careerLevel)
+                .jobType(jobType)
+                .build();
+    }
 }


### PR DESCRIPTION
# issue: #465 

# 작업 내용
- `Member` 도메인의 필드들을 update하는 로직을 하나로 통합