### PR TITLE
[BE] 리뷰가 삭제되면 등록 장비도 삭제되는 로직 추가

### DIFF
--- a/backend/src/main/java/com/woowacourse/f12/application/review/ReviewService.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/review/ReviewService.java
@@ -46,8 +46,7 @@ public class ReviewService {
     @Transactional
     public Long saveReviewAndInventoryProduct(final Long productId, final Long memberId,
                                               final ReviewRequest reviewRequest) {
-        final Member member = memberRepository.findById(memberId)
-                .orElseThrow(MemberNotFoundException::new);
+        final Member member = findMemberById(memberId);
         validateRegisterCompleted(member);
         final Product product = productRepository.findById(productId)
                 .orElseThrow(ProductNotFoundException::new);
@@ -112,17 +111,28 @@ public class ReviewService {
 
     @Transactional
     public void delete(final Long reviewId, final Long memberId) {
-        final Review target = findTarget(reviewId, memberId);
-        reviewRepository.delete(target);
+        final Review review = findTarget(reviewId, memberId);
+        reviewRepository.delete(review);
+        final InventoryProduct inventoryProduct = inventoryProductRepository.findByMemberIdAndProductId(memberId, review.getProduct().getId())
+                .orElseThrow(InventoryProductNotFoundException::new);
+        inventoryProductRepository.delete(inventoryProduct);
     }
 
     private Review findTarget(final Long reviewId, final Long memberId) {
-        final Member member = memberRepository.findById(memberId)
-                .orElseThrow(MemberNotFoundException::new);
-        final Review target = reviewRepository.findById(reviewId)
-                .orElseThrow(ReviewNotFoundException::new);
+        final Member member = findMemberById(memberId);
+        final Review target = findReviewById(reviewId);
         validateAuthor(member, target);
         return target;
+    }
+
+    private Review findReviewById(Long reviewId) {
+        return reviewRepository.findById(reviewId)
+                .orElseThrow(ReviewNotFoundException::new);
+    }
+
+    private Member findMemberById(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(MemberNotFoundException::new);
     }
 
     private void validateAuthor(final Member member, final Review target) {

--- a/backend/src/main/java/com/woowacourse/f12/domain/inventoryproduct/InventoryProductRepository.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/inventoryproduct/InventoryProductRepository.java
@@ -2,14 +2,18 @@ package com.woowacourse.f12.domain.inventoryproduct;
 
 import com.woowacourse.f12.domain.member.Member;
 import com.woowacourse.f12.domain.product.Product;
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface InventoryProductRepository extends JpaRepository<InventoryProduct, Long> {
 
     List<InventoryProduct> findByMemberId(Long memberId);
+
+    Optional<InventoryProduct> findByMemberAndProduct(Member member, Product product);
 
     boolean existsByMemberAndProduct(Member member, Product product);
 

--- a/backend/src/main/java/com/woowacourse/f12/domain/inventoryproduct/InventoryProductRepository.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/inventoryproduct/InventoryProductRepository.java
@@ -13,7 +13,7 @@ public interface InventoryProductRepository extends JpaRepository<InventoryProdu
 
     List<InventoryProduct> findByMemberId(Long memberId);
 
-    Optional<InventoryProduct> findByMemberAndProduct(Member member, Product product);
+    Optional<InventoryProduct> findByMemberIdAndProductId(Long memberId, Long productId);
 
     boolean existsByMemberAndProduct(Member member, Product product);
 

--- a/backend/src/test/java/com/woowacourse/f12/acceptance/AcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/acceptance/AcceptanceTest.java
@@ -1,7 +1,5 @@
 package com.woowacourse.f12.acceptance;
 
-import static io.restassured.RestAssured.UNDEFINED_PORT;
-
 import com.woowacourse.f12.acceptance.support.DatabaseCleanup;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.BeforeEach;
@@ -10,8 +8,10 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
 
+import static io.restassured.RestAssured.UNDEFINED_PORT;
+
 @SpringBootTest(webEnvironment = WebEnvironment.DEFINED_PORT)
-public class AcceptanceTest {
+class AcceptanceTest {
 
     @LocalServerPort
     private int port;

--- a/backend/src/test/java/com/woowacourse/f12/acceptance/MemberAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/acceptance/MemberAcceptanceTest.java
@@ -1,9 +1,26 @@
 package com.woowacourse.f12.acceptance;
 
+import com.woowacourse.f12.domain.inventoryproduct.InventoryProduct;
+import com.woowacourse.f12.domain.member.Member;
+import com.woowacourse.f12.domain.product.Product;
+import com.woowacourse.f12.domain.product.ProductRepository;
+import com.woowacourse.f12.dto.request.member.MemberRequest;
+import com.woowacourse.f12.dto.response.auth.LoginMemberResponse;
+import com.woowacourse.f12.dto.response.auth.LoginResponse;
+import com.woowacourse.f12.dto.response.member.MemberPageResponse;
+import com.woowacourse.f12.dto.response.member.MemberResponse;
+import com.woowacourse.f12.dto.response.member.MemberWithProfileProductResponse;
+import com.woowacourse.f12.dto.response.product.ProductResponse;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+
+import java.util.List;
+
 import static com.woowacourse.f12.acceptance.support.LoginUtil.로그인을_한다;
-import static com.woowacourse.f12.acceptance.support.RestAssuredRequestUtil.GET_요청을_보낸다;
-import static com.woowacourse.f12.acceptance.support.RestAssuredRequestUtil.로그인된_상태로_GET_요청을_보낸다;
-import static com.woowacourse.f12.acceptance.support.RestAssuredRequestUtil.로그인된_상태로_PATCH_요청을_보낸다;
+import static com.woowacourse.f12.acceptance.support.RestAssuredRequestUtil.*;
 import static com.woowacourse.f12.domain.member.CareerLevel.JUNIOR;
 import static com.woowacourse.f12.domain.member.JobType.BACKEND;
 import static com.woowacourse.f12.presentation.member.CareerLevelConstant.JUNIOR_CONSTANT;
@@ -21,25 +38,7 @@ import static com.woowacourse.f12.support.ReviewFixtures.REVIEW_RATING_5;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-import com.woowacourse.f12.domain.inventoryproduct.InventoryProduct;
-import com.woowacourse.f12.domain.member.Member;
-import com.woowacourse.f12.domain.product.Product;
-import com.woowacourse.f12.domain.product.ProductRepository;
-import com.woowacourse.f12.dto.request.member.MemberRequest;
-import com.woowacourse.f12.dto.response.auth.LoginMemberResponse;
-import com.woowacourse.f12.dto.response.auth.LoginResponse;
-import com.woowacourse.f12.dto.response.member.MemberPageResponse;
-import com.woowacourse.f12.dto.response.member.MemberResponse;
-import com.woowacourse.f12.dto.response.member.MemberWithProfileProductResponse;
-import com.woowacourse.f12.dto.response.product.ProductResponse;
-import io.restassured.response.ExtractableResponse;
-import io.restassured.response.Response;
-import java.util.List;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
-
-public class MemberAcceptanceTest extends AcceptanceTest {
+class MemberAcceptanceTest extends AcceptanceTest {
 
     @Autowired
     private ProductRepository productRepository;

--- a/backend/src/test/java/com/woowacourse/f12/acceptance/ReviewAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/acceptance/ReviewAcceptanceTest.java
@@ -33,7 +33,7 @@ import static com.woowacourse.f12.support.ReviewFixtures.REVIEW_RATING_5;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-public class ReviewAcceptanceTest extends AcceptanceTest {
+class ReviewAcceptanceTest extends AcceptanceTest {
 
     @Autowired
     private ProductRepository productRepository;

--- a/backend/src/test/java/com/woowacourse/f12/acceptance/ReviewAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/acceptance/ReviewAcceptanceTest.java
@@ -1,11 +1,26 @@
 package com.woowacourse.f12.acceptance;
 
+import com.woowacourse.f12.domain.product.Product;
+import com.woowacourse.f12.domain.product.ProductRepository;
+import com.woowacourse.f12.dto.request.member.MemberRequest;
+import com.woowacourse.f12.dto.request.review.ReviewRequest;
+import com.woowacourse.f12.dto.response.ExceptionResponse;
+import com.woowacourse.f12.dto.response.auth.LoginResponse;
+import com.woowacourse.f12.dto.response.inventoryproduct.InventoryProductResponse;
+import com.woowacourse.f12.dto.response.inventoryproduct.InventoryProductsResponse;
+import com.woowacourse.f12.dto.response.product.ProductResponse;
+import com.woowacourse.f12.dto.response.review.*;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
 import static com.woowacourse.f12.acceptance.support.LoginUtil.로그인을_한다;
-import static com.woowacourse.f12.acceptance.support.RestAssuredRequestUtil.GET_요청을_보낸다;
-import static com.woowacourse.f12.acceptance.support.RestAssuredRequestUtil.로그인된_상태로_DELETE_요청을_보낸다;
-import static com.woowacourse.f12.acceptance.support.RestAssuredRequestUtil.로그인된_상태로_GET_요청을_보낸다;
-import static com.woowacourse.f12.acceptance.support.RestAssuredRequestUtil.로그인된_상태로_PATCH_요청을_보낸다;
-import static com.woowacourse.f12.acceptance.support.RestAssuredRequestUtil.로그인된_상태로_PUT_요청을_보낸다;
+import static com.woowacourse.f12.acceptance.support.RestAssuredRequestUtil.*;
 import static com.woowacourse.f12.presentation.member.CareerLevelConstant.SENIOR_CONSTANT;
 import static com.woowacourse.f12.presentation.member.JobTypeConstant.BACKEND_CONSTANT;
 import static com.woowacourse.f12.support.GitHubProfileFixtures.CORINNE_GITHUB;
@@ -17,27 +32,6 @@ import static com.woowacourse.f12.support.ReviewFixtures.REVIEW_RATING_4;
 import static com.woowacourse.f12.support.ReviewFixtures.REVIEW_RATING_5;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
-
-import com.woowacourse.f12.domain.product.Product;
-import com.woowacourse.f12.domain.product.ProductRepository;
-import com.woowacourse.f12.dto.request.member.MemberRequest;
-import com.woowacourse.f12.dto.request.review.ReviewRequest;
-import com.woowacourse.f12.dto.response.ExceptionResponse;
-import com.woowacourse.f12.dto.response.auth.LoginResponse;
-import com.woowacourse.f12.dto.response.inventoryproduct.InventoryProductsResponse;
-import com.woowacourse.f12.dto.response.product.ProductResponse;
-import com.woowacourse.f12.dto.response.review.ReviewWithAuthorAndProductPageResponse;
-import com.woowacourse.f12.dto.response.review.ReviewWithAuthorAndProductResponse;
-import com.woowacourse.f12.dto.response.review.ReviewWithAuthorPageResponse;
-import com.woowacourse.f12.dto.response.review.ReviewWithProductPageResponse;
-import com.woowacourse.f12.dto.response.review.ReviewWithProductResponse;
-import io.restassured.response.ExtractableResponse;
-import io.restassured.response.Response;
-import java.util.List;
-import java.util.stream.Collectors;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
 
 public class ReviewAcceptanceTest extends AcceptanceTest {
 
@@ -192,7 +186,7 @@ public class ReviewAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
-    void 로그인한_회원이_리뷰_작성자와_일치하면_리뷰를_삭제한다() {
+    void 로그인한_회원이_리뷰_작성자와_일치하면_리뷰를_삭제하고_인벤토리_장비도_삭제한다() {
         // given
         Product product = 제품을_저장한다(KEYBOARD_1.생성());
         String token = 로그인을_한다(CORINNE_GITHUB.getCode()).getToken();
@@ -207,11 +201,15 @@ public class ReviewAcceptanceTest extends AcceptanceTest {
                 "/api/v1/reviews?page=0&size=2&sort=createdAt,desc")
                 .as(ReviewWithAuthorAndProductPageResponse.class)
                 .getItems();
+        List<InventoryProductResponse> inventoryProducts = 로그인된_상태로_GET_요청을_보낸다("/api/v1/members/inventoryProducts", token)
+                .as(InventoryProductsResponse.class)
+                .getItems();
 
         // then
         assertAll(
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value()),
-                () -> assertThat(reviews).isEmpty()
+                () -> assertThat(reviews).isEmpty(),
+                () -> assertThat(inventoryProducts).isEmpty()
         );
     }
 

--- a/backend/src/test/java/com/woowacourse/f12/documentation/member/MemberDocumentation.java
+++ b/backend/src/test/java/com/woowacourse/f12/documentation/member/MemberDocumentation.java
@@ -1,5 +1,30 @@
 package com.woowacourse.f12.documentation.member;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.woowacourse.f12.application.auth.JwtProvider;
+import com.woowacourse.f12.application.member.MemberService;
+import com.woowacourse.f12.documentation.Documentation;
+import com.woowacourse.f12.domain.inventoryproduct.InventoryProduct;
+import com.woowacourse.f12.domain.member.Member;
+import com.woowacourse.f12.dto.request.member.MemberRequest;
+import com.woowacourse.f12.dto.request.member.MemberSearchRequest;
+import com.woowacourse.f12.dto.response.member.MemberPageResponse;
+import com.woowacourse.f12.dto.response.member.MemberResponse;
+import com.woowacourse.f12.presentation.member.MemberController;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.util.List;
+
 import static com.woowacourse.f12.presentation.member.CareerLevelConstant.JUNIOR_CONSTANT;
 import static com.woowacourse.f12.presentation.member.JobTypeConstant.BACKEND_CONSTANT;
 import static com.woowacourse.f12.support.InventoryProductFixtures.SELECTED_INVENTORY_PRODUCT;
@@ -14,32 +39,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.woowacourse.f12.application.auth.JwtProvider;
-import com.woowacourse.f12.application.member.MemberService;
-import com.woowacourse.f12.documentation.Documentation;
-import com.woowacourse.f12.domain.inventoryproduct.InventoryProduct;
-import com.woowacourse.f12.domain.member.Member;
-import com.woowacourse.f12.dto.request.member.MemberRequest;
-import com.woowacourse.f12.dto.request.member.MemberSearchRequest;
-import com.woowacourse.f12.dto.response.member.MemberPageResponse;
-import com.woowacourse.f12.dto.response.member.MemberResponse;
-import com.woowacourse.f12.presentation.member.MemberController;
-import java.util.List;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.SliceImpl;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.ResultActions;
-
 @WebMvcTest(MemberController.class)
-public class MemberDocumentation extends Documentation {
+class MemberDocumentation extends Documentation {
 
     @Autowired
     private MockMvc mockMvc;

--- a/backend/src/test/java/com/woowacourse/f12/documentation/review/ReviewDocumentation.java
+++ b/backend/src/test/java/com/woowacourse/f12/documentation/review/ReviewDocumentation.java
@@ -1,24 +1,5 @@
 package com.woowacourse.f12.documentation.review;
 
-import static com.woowacourse.f12.support.MemberFixtures.CORINNE;
-import static com.woowacourse.f12.support.MemberFixtures.MINCHO;
-import static com.woowacourse.f12.support.ProductFixture.KEYBOARD_1;
-import static com.woowacourse.f12.support.ProductFixture.KEYBOARD_2;
-import static com.woowacourse.f12.support.ReviewFixtures.REVIEW_RATING_1;
-import static com.woowacourse.f12.support.ReviewFixtures.REVIEW_RATING_4;
-import static com.woowacourse.f12.support.ReviewFixtures.REVIEW_RATING_5;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.willDoNothing;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.woowacourse.f12.application.auth.JwtProvider;
 import com.woowacourse.f12.application.review.ReviewService;
@@ -32,7 +13,6 @@ import com.woowacourse.f12.dto.response.review.ReviewWithProductPageResponse;
 import com.woowacourse.f12.dto.response.review.ReviewWithProductResponse;
 import com.woowacourse.f12.exception.badrequest.AlreadyWrittenReviewException;
 import com.woowacourse.f12.presentation.review.ReviewController;
-import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -46,8 +26,23 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
+import java.util.List;
+
+import static com.woowacourse.f12.support.MemberFixtures.CORINNE;
+import static com.woowacourse.f12.support.MemberFixtures.MINCHO;
+import static com.woowacourse.f12.support.ProductFixture.KEYBOARD_1;
+import static com.woowacourse.f12.support.ProductFixture.KEYBOARD_2;
+import static com.woowacourse.f12.support.ReviewFixtures.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 @WebMvcTest(ReviewController.class)
-public class ReviewDocumentation extends Documentation {
+class ReviewDocumentation extends Documentation {
 
     @Autowired
     private MockMvc mockMvc;

--- a/backend/src/test/java/com/woowacourse/f12/domain/inventoryproduct/InventoryProductRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/domain/inventoryproduct/InventoryProductRepositoryTest.java
@@ -1,5 +1,18 @@
 package com.woowacourse.f12.domain.inventoryproduct;
 
+import com.woowacourse.f12.config.JpaConfig;
+import com.woowacourse.f12.domain.member.Member;
+import com.woowacourse.f12.domain.member.MemberRepository;
+import com.woowacourse.f12.domain.product.Product;
+import com.woowacourse.f12.domain.product.ProductRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import java.util.List;
+import java.util.Optional;
+
 import static com.woowacourse.f12.support.InventoryProductFixtures.SELECTED_INVENTORY_PRODUCT;
 import static com.woowacourse.f12.support.InventoryProductFixtures.UNSELECTED_INVENTORY_PRODUCT;
 import static com.woowacourse.f12.support.MemberFixtures.CORINNE;
@@ -7,17 +20,6 @@ import static com.woowacourse.f12.support.MemberFixtures.MINCHO;
 import static com.woowacourse.f12.support.ProductFixture.KEYBOARD_1;
 import static com.woowacourse.f12.support.ProductFixture.KEYBOARD_2;
 import static org.assertj.core.api.Assertions.assertThat;
-
-import com.woowacourse.f12.config.JpaConfig;
-import com.woowacourse.f12.domain.member.Member;
-import com.woowacourse.f12.domain.member.MemberRepository;
-import com.woowacourse.f12.domain.product.Product;
-import com.woowacourse.f12.domain.product.ProductRepository;
-import java.util.List;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.Import;
 
 @DataJpaTest
 @Import(JpaConfig.class)
@@ -94,6 +96,21 @@ class InventoryProductRepositoryTest {
 
         // then
         assertThat(actual).isOne();
+    }
+
+    @Test
+    void 멤버와_제품으로_인벤토리_제품을_조회한다() {
+        // given
+        Member member = 회원을_저장한다(CORINNE.생성());
+        Product product = 제품을_저장한다(KEYBOARD_1.생성());
+        InventoryProduct inventoryProduct = UNSELECTED_INVENTORY_PRODUCT.생성(member, product);
+        inventoryProductRepository.save(inventoryProduct);
+
+        // when
+        Optional<InventoryProduct> actual = inventoryProductRepository.findByMemberAndProduct(member, product);
+
+        // then
+        assertThat(actual).isPresent();
     }
 
     private Product 제품을_저장한다(Product product) {

--- a/backend/src/test/java/com/woowacourse/f12/domain/inventoryproduct/InventoryProductRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/domain/inventoryproduct/InventoryProductRepositoryTest.java
@@ -107,7 +107,7 @@ class InventoryProductRepositoryTest {
         inventoryProductRepository.save(inventoryProduct);
 
         // when
-        Optional<InventoryProduct> actual = inventoryProductRepository.findByMemberAndProduct(member, product);
+        Optional<InventoryProduct> actual = inventoryProductRepository.findByMemberIdAndProductId(member.getId(), product.getId());
 
         // then
         assertThat(actual).isPresent();

--- a/backend/src/test/java/com/woowacourse/f12/domain/product/ProductRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/domain/product/ProductRepositoryTest.java
@@ -1,22 +1,10 @@
 package com.woowacourse.f12.domain.product;
 
-import static com.woowacourse.f12.domain.product.Category.KEYBOARD;
-import static com.woowacourse.f12.support.MemberFixtures.CORINNE;
-import static com.woowacourse.f12.support.ProductFixture.*;
-import static com.woowacourse.f12.support.ReviewFixtures.REVIEW_RATING_1;
-import static com.woowacourse.f12.support.ReviewFixtures.REVIEW_RATING_2;
-import static com.woowacourse.f12.support.ReviewFixtures.REVIEW_RATING_4;
-import static com.woowacourse.f12.support.ReviewFixtures.REVIEW_RATING_5;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
-
 import com.woowacourse.f12.config.JpaConfig;
 import com.woowacourse.f12.domain.member.Member;
 import com.woowacourse.f12.domain.member.MemberRepository;
 import com.woowacourse.f12.domain.review.Review;
 import com.woowacourse.f12.domain.review.ReviewRepository;
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -26,6 +14,16 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Order;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import static com.woowacourse.f12.domain.product.Category.KEYBOARD;
+import static com.woowacourse.f12.support.MemberFixtures.CORINNE;
+import static com.woowacourse.f12.support.ProductFixture.*;
+import static com.woowacourse.f12.support.ReviewFixtures.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 @DataJpaTest
 @Import(JpaConfig.class)
@@ -50,8 +48,7 @@ class ProductRepositoryTest {
         Member member = memberRepository.save(CORINNE.생성());
         리뷰_저장(REVIEW_RATING_4.작성(product, member));
         리뷰_저장(REVIEW_RATING_5.작성(product, member));
-        entityManager.flush();
-        entityManager.refresh(product);
+        entityManager.clear();
 
         // when
         Product savedProduct = productRepository.findById(product.getId())


### PR DESCRIPTION
# issue: #442 

# 작업 내용
- 리뷰가 삭제되면 등록 장비도 삭제되도록 함
- 테스트 클래스에 접근수정자 default로 변경
- entityManager refresh 제거 및 clear 적용