### PR TITLE
[BE] API 요청 소요시간 로깅 기능 피드백 반영

### DIFF
--- a/backend/src/main/java/com/woowacourse/f12/config/LoggingConfig.java
+++ b/backend/src/main/java/com/woowacourse/f12/config/LoggingConfig.java
@@ -1,0 +1,20 @@
+package com.woowacourse.f12.config;
+
+import com.woowacourse.f12.support.RequestLogTimer;
+import java.time.Clock;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class LoggingConfig {
+
+    @Bean
+    public Clock clock() {
+        return Clock.systemDefaultZone();
+    }
+
+    @Bean
+    public RequestLogTimer requestLogTimer() {
+        return new RequestLogTimer(clock());
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/exception/internalserver/IllegalRequestLogTimerStateException.java
+++ b/backend/src/main/java/com/woowacourse/f12/exception/internalserver/IllegalRequestLogTimerStateException.java
@@ -2,9 +2,9 @@ package com.woowacourse.f12.exception.internalserver;
 
 import static com.woowacourse.f12.exception.ErrorCode.INTERNAL_SERVER_ERROR;
 
-public class IllegalRequestLogTimerState extends InternalServerException {
+public class IllegalRequestLogTimerStateException extends InternalServerException {
 
-    public IllegalRequestLogTimerState() {
+    public IllegalRequestLogTimerStateException() {
         super(INTERNAL_SERVER_ERROR, "시간을 측정할 수 없습니다.");
     }
 }

--- a/backend/src/main/java/com/woowacourse/f12/presentation/LoggingInterceptor.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/LoggingInterceptor.java
@@ -11,14 +11,14 @@ import org.springframework.web.util.ContentCachingResponseWrapper;
 
 @Slf4j
 @Component
-public class LogInterceptor implements HandlerInterceptor {
+public class LoggingInterceptor implements HandlerInterceptor {
 
     private static final String REQUEST_LOG_FORMAT = "METHOD: {}, URL : {}, AUTHORIZATION : {}, BODY : {}";
     private static final String RESPONSE_LOG_FORMAT = "STATUS_CODE: {}, URL : {}, BODY : {}, TIME_TAKEN : {}";
 
     private final RequestLogTimer requestLogTimer;
 
-    public LogInterceptor(final RequestLogTimer requestLogTimer) {
+    public LoggingInterceptor(final RequestLogTimer requestLogTimer) {
         this.requestLogTimer = requestLogTimer;
     }
 
@@ -42,6 +42,6 @@ public class LogInterceptor implements HandlerInterceptor {
         final ContentCachingResponseWrapper contentCachingResponseWrapper = new ContentCachingResponseWrapper(response);
         final String responseBody = new String(contentCachingResponseWrapper.getContentAsByteArray());
         log.info(RESPONSE_LOG_FORMAT, response.getStatus(), request.getRequestURI(), responseBody,
-                requestLogTimer.getSpentTime());
+                requestLogTimer.getTakenTime());
     }
 }

--- a/backend/src/main/java/com/woowacourse/f12/support/RequestLogTimer.java
+++ b/backend/src/main/java/com/woowacourse/f12/support/RequestLogTimer.java
@@ -1,24 +1,29 @@
 package com.woowacourse.f12.support;
 
 import com.woowacourse.f12.exception.internalserver.IllegalRequestLogTimerState;
+import java.time.Clock;
 import java.util.Objects;
-import org.springframework.stereotype.Component;
 import org.springframework.web.context.annotation.RequestScope;
 
-@Component
 @RequestScope
 public class RequestLogTimer {
+
+    private final Clock clock;
 
     private Long startTime;
     private Long endTime;
 
+    public RequestLogTimer(final Clock clock) {
+        this.clock = clock;
+    }
+
     public void start() {
-        this.startTime = System.currentTimeMillis();
+        this.startTime = clock.millis();
     }
 
     public void stop() {
         validateTime(startTime);
-        this.endTime = System.currentTimeMillis();
+        this.endTime = clock.millis();
     }
 
     public Long getSpentTime() {

--- a/backend/src/main/java/com/woowacourse/f12/support/RequestLogTimer.java
+++ b/backend/src/main/java/com/woowacourse/f12/support/RequestLogTimer.java
@@ -1,6 +1,6 @@
 package com.woowacourse.f12.support;
 
-import com.woowacourse.f12.exception.internalserver.IllegalRequestLogTimerState;
+import com.woowacourse.f12.exception.internalserver.IllegalRequestLogTimerStateException;
 import java.time.Clock;
 import java.util.Objects;
 import org.springframework.web.context.annotation.RequestScope;
@@ -26,14 +26,14 @@ public class RequestLogTimer {
         this.endTime = clock.millis();
     }
 
-    public Long getSpentTime() {
+    public Long getTakenTime() {
         validateTime(endTime);
         return endTime - startTime;
     }
 
     private void validateTime(final Long time) {
         if (Objects.isNull(time)) {
-            throw new IllegalRequestLogTimerState();
+            throw new IllegalRequestLogTimerStateException();
         }
     }
 }

--- a/backend/src/test/java/com/woowacourse/f12/presentation/ControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/ControllerTest.java
@@ -1,8 +1,8 @@
 package com.woowacourse.f12.presentation;
 
 import com.woowacourse.f12.application.auth.JwtProvider;
+import com.woowacourse.f12.config.LoggingConfig;
 import com.woowacourse.f12.support.AuthTokenExtractor;
-import com.woowacourse.f12.support.RequestLogTimer;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.context.annotation.Import;
@@ -10,6 +10,6 @@ import org.springframework.restdocs.RestDocumentationExtension;
 
 @AutoConfigureRestDocs
 @ExtendWith(RestDocumentationExtension.class)
-@Import({AuthTokenExtractor.class, JwtProvider.class, RestDocsConfig.class, RequestLogTimer.class})
+@Import({AuthTokenExtractor.class, JwtProvider.class, RestDocsConfig.class, LoggingConfig.class})
 public class ControllerTest {
 }

--- a/backend/src/test/java/com/woowacourse/f12/presentation/CustomPageableArgumentResolverTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/CustomPageableArgumentResolverTest.java
@@ -12,11 +12,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.woowacourse.f12.application.auth.JwtProvider;
 import com.woowacourse.f12.application.product.ProductService;
+import com.woowacourse.f12.config.LoggingConfig;
 import com.woowacourse.f12.dto.request.product.ProductSearchRequest;
 import com.woowacourse.f12.dto.response.product.ProductPageResponse;
 import com.woowacourse.f12.presentation.product.ProductController;
 import com.woowacourse.f12.support.AuthTokenExtractor;
-import com.woowacourse.f12.support.RequestLogTimer;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,7 +30,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(ProductController.class)
-@Import({AuthTokenExtractor.class, JwtProvider.class, RequestLogTimer.class})
+@Import({AuthTokenExtractor.class, JwtProvider.class, LoggingConfig.class})
 public class CustomPageableArgumentResolverTest {
 
     @Autowired

--- a/backend/src/test/java/com/woowacourse/f12/presentation/auth/AuthInterceptorTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/auth/AuthInterceptorTest.java
@@ -14,9 +14,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.woowacourse.f12.application.auth.JwtProvider;
 import com.woowacourse.f12.application.review.ReviewService;
+import com.woowacourse.f12.config.LoggingConfig;
 import com.woowacourse.f12.dto.request.review.ReviewRequest;
 import com.woowacourse.f12.presentation.review.ReviewController;
-import com.woowacourse.f12.support.RequestLogTimer;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -27,7 +27,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(ReviewController.class)
-@Import(RequestLogTimer.class)
+@Import(LoggingConfig.class)
 class AuthInterceptorTest {
 
     @Autowired

--- a/backend/src/test/java/com/woowacourse/f12/support/RequestLogTimerTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/support/RequestLogTimerTest.java
@@ -7,7 +7,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import com.woowacourse.f12.exception.internalserver.IllegalRequestLogTimerState;
+import com.woowacourse.f12.exception.internalserver.IllegalRequestLogTimerStateException;
 import java.time.Clock;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -33,7 +33,7 @@ class RequestLogTimerTest {
         // when
         requestLogTimer.start();
         requestLogTimer.stop();
-        Long timeTaken = requestLogTimer.getSpentTime();
+        Long timeTaken = requestLogTimer.getTakenTime();
 
         // then
         assertAll(
@@ -46,7 +46,7 @@ class RequestLogTimerTest {
     void 시작하지_않았는데_측정_종료하는_경우_예외_발생한다() {
         // given, when, then
         assertThatThrownBy(() -> requestLogTimer.stop())
-                .isExactlyInstanceOf(IllegalRequestLogTimerState.class);
+                .isExactlyInstanceOf(IllegalRequestLogTimerStateException.class);
     }
 
     @Test
@@ -57,7 +57,7 @@ class RequestLogTimerTest {
         requestLogTimer.start();
 
         // when, then
-        assertThatThrownBy(() -> requestLogTimer.getSpentTime())
-                .isExactlyInstanceOf(IllegalRequestLogTimerState.class);
+        assertThatThrownBy(() -> requestLogTimer.getTakenTime())
+                .isExactlyInstanceOf(IllegalRequestLogTimerStateException.class);
     }
 }

--- a/backend/src/test/java/com/woowacourse/f12/support/RequestLogTimerTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/support/RequestLogTimerTest.java
@@ -2,32 +2,44 @@ package com.woowacourse.f12.support;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import com.woowacourse.f12.exception.internalserver.IllegalRequestLogTimerState;
-import org.junit.jupiter.api.BeforeEach;
+import java.time.Clock;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+@ExtendWith(MockitoExtension.class)
 class RequestLogTimerTest {
 
-    private RequestLogTimer requestLogTimer;
+    @Mock
+    private Clock clock;
 
-    @BeforeEach
-    void setUp() {
-        requestLogTimer = new RequestLogTimer();
-    }
+    @InjectMocks
+    private RequestLogTimer requestLogTimer;
 
     @Test
     void 측정_시작과_끝_사이_걸리는_시간을_측정한다() throws InterruptedException {
         // given
-        requestLogTimer.start();
-        Thread.sleep(5000);
-        requestLogTimer.stop();
+        given(clock.millis())
+                .willReturn(1L, 2L);
 
         // when
+        requestLogTimer.start();
+        requestLogTimer.stop();
         Long timeTaken = requestLogTimer.getSpentTime();
 
         // then
-        assertThat(timeTaken).isGreaterThan(4999);
+        assertAll(
+                () -> assertThat(timeTaken).isGreaterThanOrEqualTo(1),
+                () -> verify(clock, times(2)).millis()
+        );
     }
 
     @Test
@@ -40,6 +52,8 @@ class RequestLogTimerTest {
     @Test
     void 측정_종료하지_않고_측정_시간을_구하면_예외_발생한다() {
         // given
+        given(clock.millis())
+                .willReturn(1L);
         requestLogTimer.start();
 
         // when, then


### PR DESCRIPTION
# issue: #472 

# 작업 내용
- Clock 객체를 빈등록 하고 주입받는 방식으로 수정
- 테스트에서 Clock 객체를 모킹해서 테스트가 시간에 의존하지 않도록 수정
- 메서드 및 클래스 이름 수정