### PR TITLE
[Feature/BE] HTTP 요청마다 쿼리 개수를 세는 기능 구현

### DIFF
--- a/backend/src/main/java/com/woowacourse/f12/config/HibernateConfig.java
+++ b/backend/src/main/java/com/woowacourse/f12/config/HibernateConfig.java
@@ -1,0 +1,23 @@
+package com.woowacourse.f12.config;
+
+import com.woowacourse.f12.logging.ApiQueryInspector;
+import org.hibernate.cfg.AvailableSettings;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernatePropertiesCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class HibernateConfig {
+
+    private final ApiQueryInspector apiQueryInspector;
+
+    public HibernateConfig(final ApiQueryInspector apiQueryInspector) {
+        this.apiQueryInspector = apiQueryInspector;
+    }
+
+    @Bean
+    public HibernatePropertiesCustomizer hibernatePropertyConfig() {
+        return hibernateProperties ->
+                hibernateProperties.put(AvailableSettings.STATEMENT_INSPECTOR, apiQueryInspector);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/logging/ApiQueryCounter.java
+++ b/backend/src/main/java/com/woowacourse/f12/logging/ApiQueryCounter.java
@@ -1,0 +1,17 @@
+package com.woowacourse.f12.logging;
+
+import lombok.Getter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.annotation.RequestScope;
+
+@Getter
+@Component
+@RequestScope
+public class ApiQueryCounter {
+
+    private int count;
+
+    public void increaseCount() {
+        count++;
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/logging/ApiQueryCounter.java
+++ b/backend/src/main/java/com/woowacourse/f12/logging/ApiQueryCounter.java
@@ -4,9 +4,9 @@ import lombok.Getter;
 import org.springframework.stereotype.Component;
 import org.springframework.web.context.annotation.RequestScope;
 
-@Getter
 @Component
 @RequestScope
+@Getter
 public class ApiQueryCounter {
 
     private int count;

--- a/backend/src/main/java/com/woowacourse/f12/logging/ApiQueryInspector.java
+++ b/backend/src/main/java/com/woowacourse/f12/logging/ApiQueryInspector.java
@@ -1,0 +1,28 @@
+package com.woowacourse.f12.logging;
+
+import java.util.Objects;
+import org.hibernate.resource.jdbc.spi.StatementInspector;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+
+@Component
+public class ApiQueryInspector implements StatementInspector {
+
+    private final ApiQueryCounter apiQueryCounter;
+
+    public ApiQueryInspector(final ApiQueryCounter apiQueryCounter) {
+        this.apiQueryCounter = apiQueryCounter;
+    }
+
+    @Override
+    public String inspect(final String sql) {
+        if (isInRequestScope()) {
+            apiQueryCounter.increaseCount();
+        }
+        return sql;
+    }
+
+    private boolean isInRequestScope() {
+        return Objects.nonNull(RequestContextHolder.getRequestAttributes());
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/logging/LoggingInterceptor.java
+++ b/backend/src/main/java/com/woowacourse/f12/logging/LoggingInterceptor.java
@@ -14,8 +14,11 @@ import org.springframework.web.util.ContentCachingResponseWrapper;
 public class LoggingInterceptor implements HandlerInterceptor {
 
     private static final String REQUEST_LOG_FORMAT = "METHOD: {}, URL: {}, AUTHORIZATION: {}, BODY: {}";
-    private static final String QUERY_COUNT_LOG_FORMAT = "QUERY_COUNT: {}";
-    private static final String RESPONSE_LOG_FORMAT = "STATUS_CODE: {}, URL: {}, TIME_TAKEN: {}ms, BODY: {}";
+    private static final String RESPONSE_LOG_FORMAT =
+            "STATUS_CODE: {}, METHOD: {}, URL: {}, QUERY_COUNT: {}, TIME_TAKEN: {}ms, BODY: {}";
+    private static final String QUERY_COUNT_WARNING_LOG_FORMAT = "쿼리가 {}번 이상 실행되었습니다.";
+
+    private static final int QUERY_COUNT_WARNING_STANDARD = 10;
 
     private final StopWatch apiTimer;
     private final ApiQueryCounter apiQueryCounter;
@@ -44,9 +47,12 @@ public class LoggingInterceptor implements HandlerInterceptor {
 
         final ContentCachingResponseWrapper contentCachingResponseWrapper = new ContentCachingResponseWrapper(response);
         final String responseBody = new String(contentCachingResponseWrapper.getContentAsByteArray());
+        final int queryCount = apiQueryCounter.getCount();
 
-        log.info(QUERY_COUNT_LOG_FORMAT, apiQueryCounter.getCount());
-        log.info(RESPONSE_LOG_FORMAT, response.getStatus(), request.getRequestURI(), apiTimer.getLastTaskTimeMillis(),
-                responseBody);
+        log.info(RESPONSE_LOG_FORMAT, response.getStatus(), request.getMethod(), request.getRequestURI(),
+                queryCount, apiTimer.getLastTaskTimeMillis(), responseBody);
+        if (queryCount >= QUERY_COUNT_WARNING_STANDARD) {
+            log.warn(QUERY_COUNT_WARNING_LOG_FORMAT, QUERY_COUNT_WARNING_STANDARD);
+        }
     }
 }

--- a/backend/src/main/java/com/woowacourse/f12/logging/LoggingInterceptor.java
+++ b/backend/src/main/java/com/woowacourse/f12/logging/LoggingInterceptor.java
@@ -1,4 +1,4 @@
-package com.woowacourse.f12.presentation;
+package com.woowacourse.f12.logging;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -13,21 +13,25 @@ import org.springframework.web.util.ContentCachingResponseWrapper;
 @Component
 public class LoggingInterceptor implements HandlerInterceptor {
 
-    private static final String REQUEST_LOG_FORMAT = "METHOD: {}, URL : {}, AUTHORIZATION : {}, BODY : {}";
-    private static final String RESPONSE_LOG_FORMAT = "STATUS_CODE: {}, URL : {}, BODY : {}, TIME_TAKEN : {}";
+    private static final String REQUEST_LOG_FORMAT = "METHOD: {}, URL: {}, AUTHORIZATION: {}, BODY: {}";
+    private static final String QUERY_COUNT_LOG_FORMAT = "QUERY_COUNT: {}";
+    private static final String RESPONSE_LOG_FORMAT = "STATUS_CODE: {}, URL: {}, TIME_TAKEN: {}ms, BODY: {}";
 
-    private final StopWatch requestLogTimer;
+    private final StopWatch apiTimer;
+    private final ApiQueryCounter apiQueryCounter;
 
-    public LoggingInterceptor(final StopWatch requestLogTimer) {
-        this.requestLogTimer = requestLogTimer;
+    public LoggingInterceptor(final StopWatch apiTimer, final ApiQueryCounter apiQueryCounter) {
+        this.apiTimer = apiTimer;
+        this.apiQueryCounter = apiQueryCounter;
     }
 
     @Override
     public boolean preHandle(final HttpServletRequest request, final HttpServletResponse response,
                              final Object handler) {
-        requestLogTimer.start();
+        apiTimer.start();
 
         final String body = new String(new ContentCachingRequestWrapper(request).getContentAsByteArray());
+
         log.info(REQUEST_LOG_FORMAT, request.getMethod(), request.getRequestURI(), request.getHeader("Authorization"),
                 body);
         return true;
@@ -36,11 +40,13 @@ public class LoggingInterceptor implements HandlerInterceptor {
     @Override
     public void afterCompletion(final HttpServletRequest request, final HttpServletResponse response,
                                 final Object handler, final Exception ex) {
-        requestLogTimer.stop();
+        apiTimer.stop();
 
         final ContentCachingResponseWrapper contentCachingResponseWrapper = new ContentCachingResponseWrapper(response);
         final String responseBody = new String(contentCachingResponseWrapper.getContentAsByteArray());
-        log.info(RESPONSE_LOG_FORMAT, response.getStatus(), request.getRequestURI(), responseBody,
-                requestLogTimer.getLastTaskTimeMillis());
+
+        log.info(QUERY_COUNT_LOG_FORMAT, apiQueryCounter.getCount());
+        log.info(RESPONSE_LOG_FORMAT, response.getStatus(), request.getRequestURI(), apiTimer.getLastTaskTimeMillis(),
+                responseBody);
     }
 }

--- a/backend/src/main/resources/log4j2/log4j2-local.xml
+++ b/backend/src/main/resources/log4j2/log4j2-local.xml
@@ -2,7 +2,7 @@
 <Configuration xmlns="http://logging.apache.org/log4j/2.0/config">
     <Appenders>
         <Console name="ConsoleAppender" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level %t %class{36}.%M L:%L %m%n"/>
+            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level %m%n"/>
         </Console>
     </Appenders>
     <Loggers>

--- a/backend/src/main/resources/log4j2/log4j2-main.xml
+++ b/backend/src/main/resources/log4j2/log4j2-main.xml
@@ -3,7 +3,7 @@
     <Properties>
         <Property name="log">logs/log/log</Property>
         <Property name="db-log">logs/db/db</Property>
-        <Property name="log-pattern">%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level %t %class{36}.%M L:%L %m%n</Property>
+        <Property name="log-pattern">%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level %m%n</Property>
         <Property name="file-pattern">%d{yyyy-MM-dd}-%i.log.gz</Property>
     </Properties>
     <Appenders>

--- a/backend/src/main/resources/log4j2/log4j2-release.xml
+++ b/backend/src/main/resources/log4j2/log4j2-release.xml
@@ -3,7 +3,7 @@
     <Properties>
         <Property name="log">logs/log/log</Property>
         <Property name="db-log">logs/db/db</Property>
-        <Property name="log-pattern">%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level %t %class{36}.%M L:%L %m%n</Property>
+        <Property name="log-pattern">%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level %t L:%L %m%n</Property>
         <Property name="file-pattern">%d{yyyy-MM-dd}-%i.log.gz</Property>
     </Properties>
     <Appenders>

--- a/backend/src/test/java/com/woowacourse/f12/logging/ApiQueryCounterTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/logging/ApiQueryCounterTest.java
@@ -15,6 +15,6 @@ class ApiQueryCounterTest {
         apiQueryCounter.increaseCount();
 
         // then
-        assertThat(apiQueryCounter.getCount()).isEqualTo(1);
+        assertThat(apiQueryCounter.getCount()).isOne();
     }
 }

--- a/backend/src/test/java/com/woowacourse/f12/logging/ApiQueryCounterTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/logging/ApiQueryCounterTest.java
@@ -1,0 +1,20 @@
+package com.woowacourse.f12.logging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class ApiQueryCounterTest {
+
+    @Test
+    void 쿼리_개수를_증가시킨다() {
+        // given
+        ApiQueryCounter apiQueryCounter = new ApiQueryCounter();
+
+        // when
+        apiQueryCounter.increaseCount();
+
+        // then
+        assertThat(apiQueryCounter.getCount()).isEqualTo(1);
+    }
+}

--- a/backend/src/test/java/com/woowacourse/f12/logging/ApiQueryInspectorTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/logging/ApiQueryInspectorTest.java
@@ -1,0 +1,41 @@
+package com.woowacourse.f12.logging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@SpringBootTest
+class ApiQueryInspectorTest {
+
+    @Autowired
+    private ApiQueryInspector apiQueryInspector;
+
+    @Autowired
+    private ApiQueryCounter apiQueryCounter;
+
+    @Test
+    void inspect는_원래_쿼리를_그대로_반환한다() {
+        // given, when
+        String inspectResult = apiQueryInspector.inspect("sql");
+
+        // then
+        assertThat(inspectResult).isEqualTo("sql");
+    }
+
+    @Test
+    void request_안에서_inspect를_호출하면_QueryCounter를_증가시킨다() {
+        // given
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(new MockHttpServletRequest()));
+
+        // when
+        apiQueryInspector.inspect("sql");
+
+        // then
+        assertThat(apiQueryCounter.getCount()).isEqualTo(1);
+    }
+}

--- a/backend/src/test/java/com/woowacourse/f12/logging/ApiQueryInspectorTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/logging/ApiQueryInspectorTest.java
@@ -36,6 +36,6 @@ class ApiQueryInspectorTest {
         apiQueryInspector.inspect("sql");
 
         // then
-        assertThat(apiQueryCounter.getCount()).isEqualTo(1);
+        assertThat(apiQueryCounter.getCount()).isOne();
     }
 }

--- a/backend/src/test/java/com/woowacourse/f12/presentation/CustomPageableArgumentResolverTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/CustomPageableArgumentResolverTest.java
@@ -10,19 +10,15 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.woowacourse.f12.application.auth.JwtProvider;
 import com.woowacourse.f12.application.product.ProductService;
-import com.woowacourse.f12.config.LoggingConfig;
 import com.woowacourse.f12.dto.request.product.ProductSearchRequest;
 import com.woowacourse.f12.dto.response.product.ProductPageResponse;
 import com.woowacourse.f12.presentation.product.ProductController;
-import com.woowacourse.f12.support.AuthTokenExtractor;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.SliceImpl;
@@ -30,8 +26,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(ProductController.class)
-@Import({AuthTokenExtractor.class, JwtProvider.class, LoggingConfig.class})
-public class CustomPageableArgumentResolverTest {
+public class CustomPageableArgumentResolverTest extends PresentationTest {
 
     @Autowired
     private MockMvc mockMvc;

--- a/backend/src/test/java/com/woowacourse/f12/presentation/PresentationTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/PresentationTest.java
@@ -2,6 +2,7 @@ package com.woowacourse.f12.presentation;
 
 import com.woowacourse.f12.application.auth.JwtProvider;
 import com.woowacourse.f12.config.LoggingConfig;
+import com.woowacourse.f12.logging.ApiQueryCounter;
 import com.woowacourse.f12.support.AuthTokenExtractor;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
@@ -10,6 +11,7 @@ import org.springframework.restdocs.RestDocumentationExtension;
 
 @AutoConfigureRestDocs
 @ExtendWith(RestDocumentationExtension.class)
-@Import({AuthTokenExtractor.class, JwtProvider.class, RestDocsConfig.class, LoggingConfig.class})
-public class ControllerTest {
+@Import({AuthTokenExtractor.class, JwtProvider.class, RestDocsConfig.class, LoggingConfig.class, ApiQueryCounter.class})
+public class PresentationTest {
+
 }

--- a/backend/src/test/java/com/woowacourse/f12/presentation/auth/AuthInterceptorTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/auth/AuthInterceptorTest.java
@@ -14,21 +14,19 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.woowacourse.f12.application.auth.JwtProvider;
 import com.woowacourse.f12.application.review.ReviewService;
-import com.woowacourse.f12.config.LoggingConfig;
 import com.woowacourse.f12.dto.request.review.ReviewRequest;
+import com.woowacourse.f12.presentation.PresentationTest;
 import com.woowacourse.f12.presentation.review.ReviewController;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(ReviewController.class)
-@Import(LoggingConfig.class)
-class AuthInterceptorTest {
+class AuthInterceptorTest extends PresentationTest {
 
     @Autowired
     private MockMvc mockMvc;

--- a/backend/src/test/java/com/woowacourse/f12/presentation/auth/AuthPresentationTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/auth/AuthPresentationTest.java
@@ -12,7 +12,7 @@ import com.woowacourse.f12.application.auth.AuthService;
 import com.woowacourse.f12.dto.response.auth.LoginResponse;
 import com.woowacourse.f12.exception.badrequest.InvalidGitHubLoginException;
 import com.woowacourse.f12.exception.internalserver.GitHubServerException;
-import com.woowacourse.f12.presentation.ControllerTest;
+import com.woowacourse.f12.presentation.PresentationTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -21,7 +21,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
 @WebMvcTest(AuthController.class)
-class AuthControllerTest extends ControllerTest {
+class AuthPresentationTest extends PresentationTest {
 
     @Autowired
     private MockMvc mockMvc;

--- a/backend/src/test/java/com/woowacourse/f12/presentation/inventoryproduct/InventoryProductPresentationTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/inventoryproduct/InventoryProductPresentationTest.java
@@ -27,7 +27,7 @@ import com.woowacourse.f12.dto.response.inventoryproduct.InventoryProductsRespon
 import com.woowacourse.f12.exception.badrequest.DuplicatedProfileProductCategoryException;
 import com.woowacourse.f12.exception.badrequest.InvalidProfileProductCategoryException;
 import com.woowacourse.f12.exception.notfound.InventoryProductNotFoundException;
-import com.woowacourse.f12.presentation.ControllerTest;
+import com.woowacourse.f12.presentation.PresentationTest;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -39,7 +39,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
 @WebMvcTest(InventoryProductController.class)
-class InventoryProductControllerTest extends ControllerTest {
+class InventoryProductPresentationTest extends PresentationTest {
 
     @Autowired
     private MockMvc mockMvc;

--- a/backend/src/test/java/com/woowacourse/f12/presentation/member/MemberPresentationTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/member/MemberPresentationTest.java
@@ -31,7 +31,7 @@ import com.woowacourse.f12.dto.request.member.MemberSearchRequest;
 import com.woowacourse.f12.dto.response.member.MemberPageResponse;
 import com.woowacourse.f12.dto.response.member.MemberResponse;
 import com.woowacourse.f12.exception.notfound.MemberNotFoundException;
-import com.woowacourse.f12.presentation.ControllerTest;
+import com.woowacourse.f12.presentation.PresentationTest;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -49,7 +49,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
 @WebMvcTest(MemberController.class)
-class MemberControllerTest extends ControllerTest {
+class MemberPresentationTest extends PresentationTest {
 
     @Autowired
     private MockMvc mockMvc;

--- a/backend/src/test/java/com/woowacourse/f12/presentation/product/ProductPresentationTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/product/ProductPresentationTest.java
@@ -30,7 +30,7 @@ import com.woowacourse.f12.dto.response.product.ProductPageResponse;
 import com.woowacourse.f12.dto.response.product.ProductResponse;
 import com.woowacourse.f12.dto.response.product.ProductStatisticsResponse;
 import com.woowacourse.f12.exception.notfound.ProductNotFoundException;
-import com.woowacourse.f12.presentation.ControllerTest;
+import com.woowacourse.f12.presentation.PresentationTest;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -45,7 +45,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
 @WebMvcTest(ProductController.class)
-class ProductControllerTest extends ControllerTest {
+class ProductPresentationTest extends PresentationTest {
 
     @Autowired
     private MockMvc mockMvc;

--- a/backend/src/test/java/com/woowacourse/f12/presentation/review/ReviewPresentationTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/review/ReviewPresentationTest.java
@@ -43,7 +43,7 @@ import com.woowacourse.f12.exception.forbidden.NotAuthorException;
 import com.woowacourse.f12.exception.notfound.MemberNotFoundException;
 import com.woowacourse.f12.exception.notfound.ProductNotFoundException;
 import com.woowacourse.f12.exception.notfound.ReviewNotFoundException;
-import com.woowacourse.f12.presentation.ControllerTest;
+import com.woowacourse.f12.presentation.PresentationTest;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -61,7 +61,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
 @WebMvcTest(ReviewController.class)
-class ReviewControllerTest extends ControllerTest {
+class ReviewPresentationTest extends PresentationTest {
 
     private static final long PRODUCT_ID = 1L;
 
@@ -76,7 +76,7 @@ class ReviewControllerTest extends ControllerTest {
     @MockBean
     private JwtProvider jwtProvider;
 
-    public ReviewControllerTest() {
+    public ReviewPresentationTest() {
         this.objectMapper = new ObjectMapper();
     }
 


### PR DESCRIPTION
# issue: closes #471 

# 작업 내용
- 쿼리 개수를 저장할 QueryCounter 구현
- HTTP 요청의 쿼리 개수를 셀 ApiQueryInspector 구현
- 로그 관련된 패키지 분리