### PR TITLE
[BE] 한 번의 API 요청에 쿼리가 10개 이상 실행되면 경고를 출력하는 기능 구현

### DIFF
--- a/backend/src/main/java/com/woowacourse/f12/logging/LoggingInterceptor.java
+++ b/backend/src/main/java/com/woowacourse/f12/logging/LoggingInterceptor.java
@@ -16,6 +16,9 @@ public class LoggingInterceptor implements HandlerInterceptor {
     private static final String REQUEST_LOG_FORMAT = "METHOD: {}, URL: {}, AUTHORIZATION: {}, BODY: {}";
     private static final String QUERY_COUNT_LOG_FORMAT = "QUERY_COUNT: {}";
     private static final String RESPONSE_LOG_FORMAT = "STATUS_CODE: {}, URL: {}, TIME_TAKEN: {}ms, BODY: {}";
+    private static final String QUERY_COUNT_WARNING_LOG_FORMAT = "쿼리가 {}번 이상 실행되었습니다.";
+
+    private static final int QUERY_COUNT_WARNING_STANDARD = 10;
 
     private final StopWatch apiTimer;
     private final ApiQueryCounter apiQueryCounter;
@@ -44,8 +47,12 @@ public class LoggingInterceptor implements HandlerInterceptor {
 
         final ContentCachingResponseWrapper contentCachingResponseWrapper = new ContentCachingResponseWrapper(response);
         final String responseBody = new String(contentCachingResponseWrapper.getContentAsByteArray());
+        final int queryCount = apiQueryCounter.getCount();
 
-        log.info(QUERY_COUNT_LOG_FORMAT, apiQueryCounter.getCount());
+        log.info(QUERY_COUNT_LOG_FORMAT, queryCount);
+        if (queryCount >= QUERY_COUNT_WARNING_STANDARD) {
+            log.warn(QUERY_COUNT_WARNING_LOG_FORMAT, QUERY_COUNT_WARNING_STANDARD);
+        }
         log.info(RESPONSE_LOG_FORMAT, response.getStatus(), request.getRequestURI(), apiTimer.getLastTaskTimeMillis(),
                 responseBody);
     }

--- a/backend/src/main/java/com/woowacourse/f12/logging/LoggingInterceptor.java
+++ b/backend/src/main/java/com/woowacourse/f12/logging/LoggingInterceptor.java
@@ -14,8 +14,8 @@ import org.springframework.web.util.ContentCachingResponseWrapper;
 public class LoggingInterceptor implements HandlerInterceptor {
 
     private static final String REQUEST_LOG_FORMAT = "METHOD: {}, URL: {}, AUTHORIZATION: {}, BODY: {}";
-    private static final String QUERY_COUNT_LOG_FORMAT = "QUERY_COUNT: {}";
-    private static final String RESPONSE_LOG_FORMAT = "STATUS_CODE: {}, URL: {}, TIME_TAKEN: {}ms, BODY: {}";
+    private static final String RESPONSE_LOG_FORMAT =
+            "STATUS_CODE: {}, METHOD: {}, URL: {}, QUERY_COUNT: {}, TIME_TAKEN: {}ms, BODY: {}";
     private static final String QUERY_COUNT_WARNING_LOG_FORMAT = "쿼리가 {}번 이상 실행되었습니다.";
 
     private static final int QUERY_COUNT_WARNING_STANDARD = 10;
@@ -49,11 +49,10 @@ public class LoggingInterceptor implements HandlerInterceptor {
         final String responseBody = new String(contentCachingResponseWrapper.getContentAsByteArray());
         final int queryCount = apiQueryCounter.getCount();
 
-        log.info(QUERY_COUNT_LOG_FORMAT, queryCount);
+        log.info(RESPONSE_LOG_FORMAT, response.getStatus(), request.getMethod(), request.getRequestURI(),
+                queryCount, apiTimer.getLastTaskTimeMillis(), responseBody);
         if (queryCount >= QUERY_COUNT_WARNING_STANDARD) {
             log.warn(QUERY_COUNT_WARNING_LOG_FORMAT, QUERY_COUNT_WARNING_STANDARD);
         }
-        log.info(RESPONSE_LOG_FORMAT, response.getStatus(), request.getRequestURI(), apiTimer.getLastTaskTimeMillis(),
-                responseBody);
     }
 }

--- a/backend/src/main/resources/log4j2/log4j2-local.xml
+++ b/backend/src/main/resources/log4j2/log4j2-local.xml
@@ -2,7 +2,7 @@
 <Configuration xmlns="http://logging.apache.org/log4j/2.0/config">
     <Appenders>
         <Console name="ConsoleAppender" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level %t %class{36}.%M L:%L %m%n"/>
+            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level %m%n"/>
         </Console>
     </Appenders>
     <Loggers>

--- a/backend/src/main/resources/log4j2/log4j2-main.xml
+++ b/backend/src/main/resources/log4j2/log4j2-main.xml
@@ -3,7 +3,7 @@
     <Properties>
         <Property name="log">logs/log/log</Property>
         <Property name="db-log">logs/db/db</Property>
-        <Property name="log-pattern">%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level %t %class{36}.%M L:%L %m%n</Property>
+        <Property name="log-pattern">%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level %m%n</Property>
         <Property name="file-pattern">%d{yyyy-MM-dd}-%i.log.gz</Property>
     </Properties>
     <Appenders>

--- a/backend/src/main/resources/log4j2/log4j2-release.xml
+++ b/backend/src/main/resources/log4j2/log4j2-release.xml
@@ -3,7 +3,7 @@
     <Properties>
         <Property name="log">logs/log/log</Property>
         <Property name="db-log">logs/db/db</Property>
-        <Property name="log-pattern">%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level %t %class{36}.%M L:%L %m%n</Property>
+        <Property name="log-pattern">%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level %t L:%L %m%n</Property>
         <Property name="file-pattern">%d{yyyy-MM-dd}-%i.log.gz</Property>
     </Properties>
     <Appenders>


### PR DESCRIPTION
# issue: #482 

# 작업 내용
- 한 번의 API 요청에 쿼리가 10개 이상 실행되면 경고를 출력하는 기능 구현
- response 로그와 query count 로그를 통합