### PR TITLE
[BugFix/BE] 로그에 QueryParam이 출력되지 않는 문제 해결

### DIFF
--- a/backend/src/main/java/com/woowacourse/f12/logging/LoggingFilter.java
+++ b/backend/src/main/java/com/woowacourse/f12/logging/LoggingFilter.java
@@ -1,11 +1,18 @@
 package com.woowacourse.f12.logging;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StopWatch;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -16,12 +23,18 @@ import org.springframework.web.util.ContentCachingResponseWrapper;
 @Component
 public class LoggingFilter extends OncePerRequestFilter {
 
-    private static final String REQUEST_LOG_FORMAT = "METHOD: {}, URL: {}, AUTHORIZATION: {}, BODY: {}";
-    private static final String RESPONSE_LOG_FORMAT =
-            "STATUS_CODE: {}, METHOD: {}, URL: {}, QUERY_COUNT: {}, TIME_TAKEN: {}ms, BODY: {}";
+    private static final String REQUEST_LOG_NO_BODY_FORMAT = "REQUEST :: METHOD: {}, URL: {}, AUTHORIZATION: {}";
+    private static final String REQUEST_LOG_FORMAT = REQUEST_LOG_NO_BODY_FORMAT.concat(", BODY: {}");
+    private static final String RESPONSE_LOG_NO_BODY_FORMAT = "RESPONSE :: STATUS_CODE: {}, METHOD: {}, URL: {}, QUERY_COUNT: {}, TIME_TAKEN: {}ms";
+    private static final String RESPONSE_LOG_FORMAT = RESPONSE_LOG_NO_BODY_FORMAT.concat(", BODY: {}");
     private static final String QUERY_COUNT_WARNING_LOG_FORMAT = "쿼리가 {}번 이상 실행되었습니다.";
 
     private static final int QUERY_COUNT_WARNING_STANDARD = 10;
+    private static final String NOT_JSON_VALUE = "NOT_JSON_VALUE";
+    private static final String START_OF_PARAMS = "?";
+    private static final String PARAM_DELIMITER = "&";
+    private static final String KEY_VALUE_DELIMITER = "=";
+    private static final String AUTHORIZATION = "Authorization";
 
     private final StopWatch apiTimer;
     private final ApiQueryCounter apiQueryCounter;
@@ -48,15 +61,65 @@ public class LoggingFilter extends OncePerRequestFilter {
 
     private void logRequestAndResponse(final ContentCachingRequestWrapper request,
                                        final ContentCachingResponseWrapper response) {
-        final int queryCount = apiQueryCounter.getCount();
-        final String requestBody = new String(request.getContentAsByteArray());
-        final String responseBody = new String(response.getContentAsByteArray());
-
-        log.info(REQUEST_LOG_FORMAT, request.getMethod(), request.getRequestURI(),
-                request.getHeader("Authorization"), requestBody);
-        log.info(RESPONSE_LOG_FORMAT, response.getStatus(), request.getMethod(), request.getRequestURI(),
-                queryCount, apiTimer.getLastTaskTimeMillis(), responseBody);
+        logRequest(request);
+        logResponse(request, response);
         warnByQueryCount();
+    }
+
+    private void logRequest(final ContentCachingRequestWrapper request) {
+        final String requestBody = new String(request.getContentAsByteArray());
+
+        if (requestBody.isBlank()) {
+            log.info(REQUEST_LOG_NO_BODY_FORMAT, request.getMethod(), getRequestURIWithParams(request),
+                    request.getHeader(AUTHORIZATION));
+            return;
+        }
+        log.info(REQUEST_LOG_FORMAT, request.getMethod(), getRequestURIWithParams(request),
+                request.getHeader(AUTHORIZATION), requestBody);
+    }
+
+    private void logResponse(final ContentCachingRequestWrapper request, final ContentCachingResponseWrapper response) {
+        final Optional<String> jsonResponseBody = getJsonResponseBody(response);
+        final int queryCount = apiQueryCounter.getCount();
+
+        if (jsonResponseBody.isEmpty()) {
+            log.info(RESPONSE_LOG_NO_BODY_FORMAT, response.getStatus(), request.getMethod(),
+                    getRequestURIWithParams(request), queryCount, apiTimer.getLastTaskTimeMillis());
+            return;
+        }
+        log.info(RESPONSE_LOG_FORMAT, response.getStatus(), request.getMethod(), getRequestURIWithParams(request),
+                queryCount, apiTimer.getLastTaskTimeMillis(), jsonResponseBody.get());
+    }
+
+    private String getRequestURIWithParams(final ContentCachingRequestWrapper request) {
+        final String requestURI = request.getRequestURI();
+        final Map<String, String[]> params = request.getParameterMap();
+        if (params.isEmpty()) {
+            return requestURI;
+        }
+        final String parsedParams = parseParams(params);
+        return requestURI.concat(parsedParams);
+    }
+
+    private String parseParams(final Map<String, String[]> params) {
+        final String everyParamStrings = params.entrySet().stream()
+                .map(this::toParamString)
+                .collect(Collectors.joining(PARAM_DELIMITER));
+        return START_OF_PARAMS.concat(everyParamStrings);
+    }
+
+    private String toParamString(final Entry<String, String[]> entry) {
+        final String key = entry.getKey();
+        return Arrays.stream(entry.getValue())
+                .map(value -> key.concat(KEY_VALUE_DELIMITER).concat(value))
+                .collect(Collectors.joining(PARAM_DELIMITER));
+    }
+
+    private Optional<String> getJsonResponseBody(final ContentCachingResponseWrapper response) {
+        if (Objects.equals(response.getContentType(), MediaType.APPLICATION_JSON_VALUE)) {
+            return Optional.of(new String(response.getContentAsByteArray()));
+        }
+        return Optional.empty();
     }
 
     private void warnByQueryCount() {


### PR DESCRIPTION
# issue: closes #496 

# 작업 내용
- 로그에 QueryParam이 출력되지 않는 문제 해결완료
- 응답 content type 이 json 형식일 경우 body를 출력하지 않도록 구현완료
- 응답과 요청에 body가 없으면 출력하지 않도록 구현완료