### PR TITLE
[Feature/BE] 제품 리뷰 목록 조회 시 수정 및 삭제 가능 여부 기능 구현

### DIFF
--- a/backend/src/main/java/com/woowacourse/f12/application/review/ReviewService.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/review/ReviewService.java
@@ -20,6 +20,7 @@ import com.woowacourse.f12.exception.notfound.InventoryProductNotFoundException;
 import com.woowacourse.f12.exception.notfound.MemberNotFoundException;
 import com.woowacourse.f12.exception.notfound.ProductNotFoundException;
 import com.woowacourse.f12.exception.notfound.ReviewNotFoundException;
+import java.util.Objects;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -89,6 +90,9 @@ public class ReviewService {
                                                             final Pageable pageable) {
         validateKeyboardExists(productId);
         final Slice<Review> page = reviewRepository.findPageByProductId(productId, pageable);
+        if (Objects.isNull(memberId)) {
+            return ReviewWithAuthorPageResponse.from(page);
+        }
         return ReviewWithAuthorPageResponse.of(page, memberId);
     }
 

--- a/backend/src/main/java/com/woowacourse/f12/application/review/ReviewService.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/review/ReviewService.java
@@ -85,10 +85,11 @@ public class ReviewService {
         inventoryProductRepository.save(inventoryProduct);
     }
 
-    public ReviewWithAuthorPageResponse findPageByProductId(final Long productId, final Pageable pageable) {
+    public ReviewWithAuthorPageResponse findPageByProductId(final Long productId, final Long memberId,
+                                                            final Pageable pageable) {
         validateKeyboardExists(productId);
         final Slice<Review> page = reviewRepository.findPageByProductId(productId, pageable);
-        return ReviewWithAuthorPageResponse.from(page);
+        return ReviewWithAuthorPageResponse.of(page, memberId);
     }
 
     private void validateKeyboardExists(final Long productId) {

--- a/backend/src/main/java/com/woowacourse/f12/domain/member/Member.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/member/Member.java
@@ -2,13 +2,21 @@ package com.woowacourse.f12.domain.member;
 
 import com.woowacourse.f12.domain.inventoryproduct.InventoryProduct;
 import com.woowacourse.f12.domain.inventoryproduct.InventoryProducts;
+import java.util.List;
+import java.util.Objects;
+import javax.persistence.Column;
+import javax.persistence.Embedded;
+import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
-import javax.persistence.*;
-import java.util.List;
-import java.util.Objects;
 
 @Entity
 @Table(name = "member")
@@ -98,6 +106,10 @@ public class Member {
 
     public boolean contains(final InventoryProducts inventoryProducts) {
         return this.inventoryProducts.contains(inventoryProducts);
+    }
+
+    public boolean isSameId(final Long id) {
+        return Objects.equals(id, this.id);
     }
 
     @Override

--- a/backend/src/main/java/com/woowacourse/f12/dto/response/review/ReviewWithAuthorPageResponse.java
+++ b/backend/src/main/java/com/woowacourse/f12/dto/response/review/ReviewWithAuthorPageResponse.java
@@ -24,4 +24,12 @@ public class ReviewWithAuthorPageResponse {
                 .collect(Collectors.toList());
         return new ReviewWithAuthorPageResponse(slice.hasNext(), reviews);
     }
+
+    public static ReviewWithAuthorPageResponse from(final Slice<Review> slice) {
+        final List<ReviewWithAuthorResponse> reviews = slice.getContent()
+                .stream()
+                .map(ReviewWithAuthorResponse::from)
+                .collect(Collectors.toList());
+        return new ReviewWithAuthorPageResponse(slice.hasNext(), reviews);
+    }
 }

--- a/backend/src/main/java/com/woowacourse/f12/dto/response/review/ReviewWithAuthorPageResponse.java
+++ b/backend/src/main/java/com/woowacourse/f12/dto/response/review/ReviewWithAuthorPageResponse.java
@@ -17,10 +17,10 @@ public class ReviewWithAuthorPageResponse {
         this.items = items;
     }
 
-    public static ReviewWithAuthorPageResponse from(final Slice<Review> slice) {
+    public static ReviewWithAuthorPageResponse of(final Slice<Review> slice, final Long memberId) {
         final List<ReviewWithAuthorResponse> reviews = slice.getContent()
                 .stream()
-                .map(ReviewWithAuthorResponse::from)
+                .map(review -> ReviewWithAuthorResponse.of(review, memberId))
                 .collect(Collectors.toList());
         return new ReviewWithAuthorPageResponse(slice.hasNext(), reviews);
     }

--- a/backend/src/main/java/com/woowacourse/f12/dto/response/review/ReviewWithAuthorResponse.java
+++ b/backend/src/main/java/com/woowacourse/f12/dto/response/review/ReviewWithAuthorResponse.java
@@ -1,5 +1,6 @@
 package com.woowacourse.f12.dto.response.review;
 
+import com.woowacourse.f12.domain.member.Member;
 import com.woowacourse.f12.domain.review.Review;
 import lombok.Getter;
 
@@ -12,24 +13,28 @@ public class ReviewWithAuthorResponse {
     private String content;
     private int rating;
     private String createdAt;
+    private boolean authorMatch;
 
     private ReviewWithAuthorResponse() {
     }
 
     private ReviewWithAuthorResponse(final Long id, final ReviewAuthorResponse author, final Long productId,
                                      final String content,
-                                     final int rating, final String createdAt) {
+                                     final int rating, final String createdAt, final boolean authorMatch) {
         this.id = id;
         this.author = author;
         this.productId = productId;
         this.content = content;
         this.rating = rating;
         this.createdAt = createdAt;
+        this.authorMatch = authorMatch;
     }
 
-    public static ReviewWithAuthorResponse from(final Review review) {
-        final ReviewAuthorResponse author = ReviewAuthorResponse.from(review.getMember());
-        return new ReviewWithAuthorResponse(review.getId(), author, review.getProduct().getId(), review.getContent(),
-                review.getRating(), review.getCreatedAt().toString());
+    public static ReviewWithAuthorResponse of(final Review review, final Long memberId) {
+        final Member author = review.getMember();
+        final ReviewAuthorResponse authorResponse = ReviewAuthorResponse.from(author);
+        return new ReviewWithAuthorResponse(review.getId(), authorResponse, review.getProduct().getId(),
+                review.getContent(),
+                review.getRating(), review.getCreatedAt().toString(), author.isSameId(memberId));
     }
 }

--- a/backend/src/main/java/com/woowacourse/f12/dto/response/review/ReviewWithAuthorResponse.java
+++ b/backend/src/main/java/com/woowacourse/f12/dto/response/review/ReviewWithAuthorResponse.java
@@ -37,4 +37,12 @@ public class ReviewWithAuthorResponse {
                 review.getContent(),
                 review.getRating(), review.getCreatedAt().toString(), author.isSameId(memberId));
     }
+
+    public static ReviewWithAuthorResponse from(final Review review) {
+        final Member author = review.getMember();
+        final ReviewAuthorResponse authorResponse = ReviewAuthorResponse.from(author);
+        return new ReviewWithAuthorResponse(review.getId(), authorResponse, review.getProduct().getId(),
+                review.getContent(),
+                review.getRating(), review.getCreatedAt().toString(), false);
+    }
 }

--- a/backend/src/main/java/com/woowacourse/f12/presentation/auth/AuthArgumentResolver.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/auth/AuthArgumentResolver.java
@@ -2,6 +2,7 @@ package com.woowacourse.f12.presentation.auth;
 
 import com.woowacourse.f12.application.auth.JwtProvider;
 import com.woowacourse.f12.exception.unauthorized.TokenInvalidException;
+import java.util.Objects;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
@@ -28,6 +29,9 @@ public class AuthArgumentResolver implements HandlerMethodArgumentResolver {
     public Object resolveArgument(final MethodParameter parameter, final ModelAndViewContainer mavContainer,
                                   final NativeWebRequest webRequest, final WebDataBinderFactory binderFactory) {
         final String authorizationHeader = webRequest.getHeader(HttpHeaders.AUTHORIZATION);
+        if (Objects.isNull(authorizationHeader)) {
+            return null;
+        }
         final String payload = jwtProvider.getPayload(authorizationHeader);
         try {
             return Long.parseLong(payload);

--- a/backend/src/main/java/com/woowacourse/f12/presentation/review/ReviewController.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/review/ReviewController.java
@@ -43,8 +43,10 @@ public class ReviewController {
 
     @GetMapping("/products/{productId}/reviews")
     public ResponseEntity<ReviewWithAuthorPageResponse> showPageByProductId(@PathVariable final Long productId,
+                                                                            @VerifiedMember Long memberId,
                                                                             final Pageable pageable) {
-        final ReviewWithAuthorPageResponse reviewPageResponse = reviewService.findPageByProductId(productId, pageable);
+        final ReviewWithAuthorPageResponse reviewPageResponse = reviewService.findPageByProductId(productId, memberId,
+                pageable);
         return ResponseEntity.ok(reviewPageResponse);
     }
 

--- a/backend/src/test/java/com/woowacourse/f12/application/review/ReviewServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/application/review/ReviewServiceTest.java
@@ -1,34 +1,5 @@
 package com.woowacourse.f12.application.review;
 
-import com.woowacourse.f12.domain.inventoryproduct.InventoryProduct;
-import com.woowacourse.f12.domain.inventoryproduct.InventoryProductRepository;
-import com.woowacourse.f12.domain.member.Member;
-import com.woowacourse.f12.domain.member.MemberRepository;
-import com.woowacourse.f12.domain.product.Product;
-import com.woowacourse.f12.domain.product.ProductRepository;
-import com.woowacourse.f12.domain.review.Review;
-import com.woowacourse.f12.domain.review.ReviewRepository;
-import com.woowacourse.f12.dto.request.review.ReviewRequest;
-import com.woowacourse.f12.dto.response.review.*;
-import com.woowacourse.f12.exception.badrequest.AlreadyWrittenReviewException;
-import com.woowacourse.f12.exception.badrequest.RegisterNotCompletedException;
-import com.woowacourse.f12.exception.forbidden.NotAuthorException;
-import com.woowacourse.f12.exception.notfound.InventoryProductNotFoundException;
-import com.woowacourse.f12.exception.notfound.MemberNotFoundException;
-import com.woowacourse.f12.exception.notfound.ProductNotFoundException;
-import com.woowacourse.f12.exception.notfound.ReviewNotFoundException;
-import com.woowacourse.f12.support.ReviewFixtures;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.*;
-import org.springframework.data.domain.Sort.Order;
-
-import java.util.List;
-import java.util.Optional;
-
 import static com.woowacourse.f12.support.InventoryProductFixtures.SELECTED_INVENTORY_PRODUCT;
 import static com.woowacourse.f12.support.InventoryProductFixtures.UNSELECTED_INVENTORY_PRODUCT;
 import static com.woowacourse.f12.support.MemberFixtures.CORINNE;
@@ -43,9 +14,48 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.refEq;
-import static org.mockito.BDDMockito.*;
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+
+import com.woowacourse.f12.domain.inventoryproduct.InventoryProduct;
+import com.woowacourse.f12.domain.inventoryproduct.InventoryProductRepository;
+import com.woowacourse.f12.domain.member.Member;
+import com.woowacourse.f12.domain.member.MemberRepository;
+import com.woowacourse.f12.domain.product.Product;
+import com.woowacourse.f12.domain.product.ProductRepository;
+import com.woowacourse.f12.domain.review.Review;
+import com.woowacourse.f12.domain.review.ReviewRepository;
+import com.woowacourse.f12.dto.request.review.ReviewRequest;
+import com.woowacourse.f12.dto.response.review.ReviewWithAuthorAndProductPageResponse;
+import com.woowacourse.f12.dto.response.review.ReviewWithAuthorAndProductResponse;
+import com.woowacourse.f12.dto.response.review.ReviewWithAuthorPageResponse;
+import com.woowacourse.f12.dto.response.review.ReviewWithAuthorResponse;
+import com.woowacourse.f12.dto.response.review.ReviewWithProductPageResponse;
+import com.woowacourse.f12.dto.response.review.ReviewWithProductResponse;
+import com.woowacourse.f12.exception.badrequest.AlreadyWrittenReviewException;
+import com.woowacourse.f12.exception.badrequest.RegisterNotCompletedException;
+import com.woowacourse.f12.exception.forbidden.NotAuthorException;
+import com.woowacourse.f12.exception.notfound.InventoryProductNotFoundException;
+import com.woowacourse.f12.exception.notfound.MemberNotFoundException;
+import com.woowacourse.f12.exception.notfound.ProductNotFoundException;
+import com.woowacourse.f12.exception.notfound.ReviewNotFoundException;
+import com.woowacourse.f12.support.ReviewFixtures;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Order;
 
 @ExtendWith(MockitoExtension.class)
 class ReviewServiceTest {
@@ -205,13 +215,74 @@ class ReviewServiceTest {
                 .willReturn(slice);
 
         // when
-        ReviewWithAuthorPageResponse reviewPageResponse = reviewService.findPageByProductId(productId, pageable);
+        ReviewWithAuthorPageResponse reviewPageResponse = reviewService.findPageByProductId(productId, null, pageable);
 
         // then
         assertAll(
                 () -> assertThat(reviewPageResponse.getItems()).hasSize(1)
                         .usingRecursiveFieldByFieldElementComparator()
-                        .containsOnly(ReviewWithAuthorResponse.from(review)),
+                        .containsOnly(ReviewWithAuthorResponse.of(review, null)),
+                () -> assertThat(reviewPageResponse.isHasNext()).isTrue(),
+                () -> verify(productRepository).existsById(productId),
+                () -> verify(reviewRepository).findPageByProductId(productId, pageable)
+        );
+    }
+
+    @Test
+    void 로그인_하지_않은_경우_특정_제품에_대한_리뷰_목록을_조회한다() {
+        // given
+        Long productId = 1L;
+        Product product = KEYBOARD_1.생성();
+        Member member = CORINNE.생성(1L);
+        Pageable pageable = PageRequest.of(0, 1, Sort.by(Order.desc("createdAt")));
+        Review review = REVIEW_RATING_5.작성(1L, product, member);
+        Slice<Review> slice = new SliceImpl<>(List.of(review), pageable, true);
+
+        given(productRepository.existsById(productId))
+                .willReturn(true);
+        given(reviewRepository.findPageByProductId(productId, pageable))
+                .willReturn(slice);
+
+        // when
+        ReviewWithAuthorPageResponse reviewPageResponse = reviewService.findPageByProductId(productId, member.getId(),
+                pageable);
+
+        // then
+        assertAll(
+                () -> assertThat(reviewPageResponse.getItems()).hasSize(1)
+                        .usingRecursiveFieldByFieldElementComparator()
+                        .containsOnly(ReviewWithAuthorResponse.of(review, member.getId()))
+                        .extracting("authorMatch").containsExactly(true),
+                () -> assertThat(reviewPageResponse.isHasNext()).isTrue(),
+                () -> verify(productRepository).existsById(productId),
+                () -> verify(reviewRepository).findPageByProductId(productId, pageable)
+        );
+    }
+
+    @Test
+    void 로그인한_경우_특정_제품에_대한_리뷰_목록을_조회한다() {
+        // given
+        Long productId = 1L;
+        Product product = KEYBOARD_1.생성();
+        Member member = CORINNE.생성(1L);
+        Pageable pageable = PageRequest.of(0, 1, Sort.by(Order.desc("createdAt")));
+        Review review = REVIEW_RATING_5.작성(1L, product, member);
+        Slice<Review> slice = new SliceImpl<>(List.of(review), pageable, true);
+
+        given(productRepository.existsById(productId))
+                .willReturn(true);
+        given(reviewRepository.findPageByProductId(productId, pageable))
+                .willReturn(slice);
+
+        // when
+        ReviewWithAuthorPageResponse reviewPageResponse = reviewService.findPageByProductId(productId, null, pageable);
+
+        // then
+        assertAll(
+                () -> assertThat(reviewPageResponse.getItems()).hasSize(1)
+                        .usingRecursiveFieldByFieldElementComparator()
+                        .containsOnly(ReviewWithAuthorResponse.of(review, null))
+                        .extracting("authorMatch").containsExactly(false),
                 () -> assertThat(reviewPageResponse.isHasNext()).isTrue(),
                 () -> verify(productRepository).existsById(productId),
                 () -> verify(reviewRepository).findPageByProductId(productId, pageable)
@@ -227,7 +298,7 @@ class ReviewServiceTest {
 
         // when, then
         assertAll(
-                () -> assertThatThrownBy(() -> reviewService.findPageByProductId(0L, pageable))
+                () -> assertThatThrownBy(() -> reviewService.findPageByProductId(0L, null, pageable))
                         .isExactlyInstanceOf(ProductNotFoundException.class),
                 () -> verify(productRepository).existsById(0L)
         );

--- a/backend/src/test/java/com/woowacourse/f12/application/review/ReviewServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/application/review/ReviewServiceTest.java
@@ -232,7 +232,7 @@ class ReviewServiceTest {
     void 로그인_하지_않은_경우_특정_제품에_대한_리뷰_목록을_조회한다() {
         // given
         Long productId = 1L;
-        Product product = KEYBOARD_1.생성();
+        Product product = KEYBOARD_1.생성(productId);
         Member member = CORINNE.생성(1L);
         Pageable pageable = PageRequest.of(0, 1, Sort.by(Order.desc("createdAt")));
         Review review = REVIEW_RATING_5.작성(1L, product, member);
@@ -260,7 +260,7 @@ class ReviewServiceTest {
     }
 
     @Test
-    void 로그인한_경우_특정_제품에_대한_리뷰_목록을_조회한다() {
+    void 로그인_안한_경우_특정_제품에_대한_리뷰_목록을_조회한다() {
         // given
         Long productId = 1L;
         Product product = KEYBOARD_1.생성();

--- a/backend/src/test/java/com/woowacourse/f12/presentation/review/ReviewPresentationTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/review/ReviewPresentationTest.java
@@ -11,6 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.BDDMockito.willThrow;
@@ -439,12 +440,12 @@ class ReviewPresentationTest extends PresentationTest {
         Product product = KEYBOARD_1.생성(1L);
         Member corinne = CORINNE.생성(1L);
         Member mincho = MINCHO.생성(2L);
-        ReviewWithAuthorPageResponse reviewWithAuthorPageResponse = ReviewWithAuthorPageResponse.from(
+        ReviewWithAuthorPageResponse reviewWithAuthorPageResponse = ReviewWithAuthorPageResponse.of(
                 new SliceImpl<>(
                         List.of(REVIEW_RATING_5.작성(1L, product, corinne), REVIEW_RATING_4.작성(2L, product, mincho)),
-                        pageable, false));
+                        pageable, false), null);
 
-        given(reviewService.findPageByProductId(anyLong(), any(Pageable.class)))
+        given(reviewService.findPageByProductId(anyLong(), nullable(Long.class), any(Pageable.class)))
                 .willReturn(reviewWithAuthorPageResponse);
 
         // when
@@ -458,7 +459,42 @@ class ReviewPresentationTest extends PresentationTest {
                         document("reviews-by-product-page-get")
                 );
 
-        verify(reviewService).findPageByProductId(PRODUCT_ID,
+        verify(reviewService).findPageByProductId(PRODUCT_ID, null,
+                PageRequest.of(0, 10, Sort.by("createdAt", "id").descending()));
+    }
+
+    @Test
+    void 로그인한_상태로_특정_상품의_리뷰_페이지_조회() throws Exception {
+        // given
+        String authorizationHeader = "Bearer Token";
+        PageRequest pageable = PageRequest.of(0, 10, Sort.by("createdAt").descending());
+        Product product = KEYBOARD_1.생성(1L);
+        Member corinne = CORINNE.생성(1L);
+        Member mincho = MINCHO.생성(2L);
+        ReviewWithAuthorPageResponse reviewWithAuthorPageResponse = ReviewWithAuthorPageResponse.of(
+                new SliceImpl<>(
+                        List.of(REVIEW_RATING_5.작성(1L, product, corinne), REVIEW_RATING_4.작성(2L, product, mincho)),
+                        pageable, false), corinne.getId());
+
+        given(reviewService.findPageByProductId(anyLong(), eq(corinne.getId()), any(Pageable.class)))
+                .willReturn(reviewWithAuthorPageResponse);
+        given(jwtProvider.getPayload(authorizationHeader))
+                .willReturn("1");
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                get("/api/v1/products/1/reviews?page=0&size=10&sort=createdAt,desc")
+                        .header(HttpHeaders.AUTHORIZATION, authorizationHeader)
+        );
+
+        // then
+        resultActions.andExpect(status().isOk())
+                .andDo(print())
+                .andDo(
+                        document("reviews-by-product-page-get")
+                );
+
+        verify(reviewService).findPageByProductId(PRODUCT_ID, corinne.getId(),
                 PageRequest.of(0, 10, Sort.by("createdAt", "id").descending()));
     }
 
@@ -468,7 +504,7 @@ class ReviewPresentationTest extends PresentationTest {
         PageRequest pageable = PageRequest.of(0, 150,
                 Sort.by("rating", "id").descending());
 
-        given(reviewService.findPageByProductId(anyLong(), any(Pageable.class)))
+        given(reviewService.findPageByProductId(anyLong(), nullable(Long.class), any(Pageable.class)))
                 .willThrow(new ProductNotFoundException());
 
         // when
@@ -479,7 +515,7 @@ class ReviewPresentationTest extends PresentationTest {
         resultActions.andExpect(status().isNotFound())
                 .andDo(print());
 
-        verify(reviewService).findPageByProductId(0L, pageable);
+        verify(reviewService).findPageByProductId(0L, null, pageable);
     }
 
     @Test

--- a/backend/src/test/java/com/woowacourse/f12/presentation/review/ReviewPresentationTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/review/ReviewPresentationTest.java
@@ -459,7 +459,7 @@ class ReviewPresentationTest extends PresentationTest {
                         document("reviews-by-product-page-get")
                 );
 
-        verify(reviewService).findPageByProductId(PRODUCT_ID, null,
+        verify(reviewService).findPageByProductId(product.getId(), null,
                 PageRequest.of(0, 10, Sort.by("createdAt", "id").descending()));
     }
 
@@ -494,7 +494,7 @@ class ReviewPresentationTest extends PresentationTest {
                         document("reviews-by-product-page-get")
                 );
 
-        verify(reviewService).findPageByProductId(PRODUCT_ID, corinne.getId(),
+        verify(reviewService).findPageByProductId(product.getId(), corinne.getId(),
                 PageRequest.of(0, 10, Sort.by("createdAt", "id").descending()));
     }
 


### PR DESCRIPTION
# 작업 내용
- 특정 제품 리뷰 조회 시 컨트롤러에서 로그인한 사용자의 id 추가로 받도록 구현
- feat: 특정 제품 리뷰 조회 service 메서드에서 memberId 받도록 구현

