### PR TITLE
[Bugfix/FE] 팔로우 관련 오류를 수정

### DIFF
--- a/frontend/src/components/Profile/ProfileCard/ProfileCard.tsx
+++ b/frontend/src/components/Profile/ProfileCard/ProfileCard.tsx
@@ -6,6 +6,7 @@ import Chip from '@/components/common/Chip/Chip';
 
 import * as S from '@/components/Profile/ProfileCard/ProfileCard.style';
 
+import useAuth from '@/hooks/useAuth';
 import useFollowing from '@/hooks/useFollowing';
 
 import TITLE from '@/constants/header';
@@ -54,6 +55,7 @@ function ProfileCard({
 }: Props) {
   const [positionX, setPositionX] = useState(0);
   const [followed, setFollowed] = useState(following);
+  const { isLoggedIn } = useAuth();
 
   const { followUser, unfollowUser } = useFollowing(id);
 
@@ -74,14 +76,18 @@ function ProfileCard({
   };
 
   const toggleFollow = async () => {
-    if (followed) {
-      await unfollowUser();
+    try {
+      if (followed) {
+        await unfollowUser();
+        setFollowed((prev) => !prev);
+        return;
+      }
+
+      await followUser();
       setFollowed((prev) => !prev);
+    } catch {
       return;
     }
-
-    await followUser();
-    setFollowed((prev) => !prev);
   };
 
   const keyboard = profileProducts.find((product) => product.category === 'keyboard') || {
@@ -135,11 +141,13 @@ function ProfileCard({
             <Chip size="s">{CAREER_LEVELS[careerLevel]}</Chip>
           </S.UserCareer>
         </S.UserInfoWrapper>
-        <S.FollowingButtonWrapper>
-          <S.FollowingButton followed={followed} onClick={toggleFollow}>
-            {followed ? '팔로잉' : '팔로우'}
-          </S.FollowingButton>
-        </S.FollowingButtonWrapper>
+        {isLoggedIn && (
+          <S.FollowingButtonWrapper>
+            <S.FollowingButton followed={followed} onClick={toggleFollow}>
+              {followed ? '팔로잉' : '팔로우'}
+            </S.FollowingButton>
+          </S.FollowingButtonWrapper>
+        )}
         <S.InventoryWrapper>
           <S.LeftButton onClick={handleLeftButtonClick}>
             <PrevSign />

--- a/frontend/src/components/Profile/UserInfo/UserInfo.style.tsx
+++ b/frontend/src/components/Profile/UserInfo/UserInfo.style.tsx
@@ -46,9 +46,12 @@ export const FollowerCount = styled.div`
   font-size: 0.95rem;
 `;
 
-export const FollowButton = styled.button`
+export const FollowButton = styled.button<{ followed: boolean }>`
   padding: 0.4rem 1.4rem;
   background-color: ${({ theme }) => theme.colors.primary};
   border-radius: 0.4rem;
   box-shadow: 4px 4px 10px ${({ theme }) => theme.colors.secondary};
+
+  background-color: ${({ theme, followed }) =>
+    followed ? theme.colors.secondary : theme.colors.primary};
 `;

--- a/frontend/src/components/Profile/UserInfo/UserInfo.tsx
+++ b/frontend/src/components/Profile/UserInfo/UserInfo.tsx
@@ -1,10 +1,12 @@
-import { useContext } from 'react';
+import { useContext, useState } from 'react';
+import { useParams } from 'react-router-dom';
 
 import * as S from '@/components/Profile/UserInfo/UserInfo.style';
 
 import { UserDataContext } from '@/contexts/LoginContextProvider';
 
 import useAuth from '@/hooks/useAuth';
+import useFollowing from '@/hooks/useFollowing';
 
 import { CAREER_LEVELS, JOB_TYPES } from '@/constants/profile';
 
@@ -14,11 +16,31 @@ type Props = {
 };
 
 function UserInfo({ userData, isOwnProfile }: Props) {
-  const { imageUrl, gitHubId, jobType, careerLevel, followerCount } = userData;
+  const { imageUrl, gitHubId, jobType, careerLevel, followerCount, following } = userData;
   const { isLoggedIn } = useAuth();
+
   const loginUserData = useContext(UserDataContext);
   const loginUserGitHubId = loginUserData && loginUserData.member.gitHubId;
   const otherProfilePage = !isOwnProfile && loginUserGitHubId !== gitHubId;
+
+  const { memberId } = useParams();
+  const [followed, setFollowed] = useState(following);
+  const { followUser, unfollowUser } = useFollowing(Number(memberId));
+
+  const toggleFollow = async () => {
+    try {
+      if (followed) {
+        await unfollowUser();
+        setFollowed((prev) => !prev);
+        return;
+      }
+
+      await followUser();
+      setFollowed((prev) => !prev);
+    } catch {
+      return;
+    }
+  };
 
   return (
     <>
@@ -42,7 +64,11 @@ function UserInfo({ userData, isOwnProfile }: Props) {
           <S.FollowerCount>{followerCount}명이 팔로우함</S.FollowerCount>
         </S.InfoWrapper>
       </S.Container>
-      {isLoggedIn && otherProfilePage && <S.FollowButton>팔로우</S.FollowButton>}
+      {isLoggedIn && otherProfilePage && (
+        <S.FollowButton followed={followed} onClick={toggleFollow}>
+          {followed ? '팔로잉' : '팔로우'}
+        </S.FollowButton>
+      )}
     </>
   );
 }

--- a/frontend/src/components/Profile/UserInfo/UserInfo.tsx
+++ b/frontend/src/components/Profile/UserInfo/UserInfo.tsx
@@ -1,4 +1,8 @@
+import { useContext } from 'react';
+
 import * as S from '@/components/Profile/UserInfo/UserInfo.style';
+
+import { UserDataContext } from '@/contexts/LoginContextProvider';
 
 import { CAREER_LEVELS, JOB_TYPES } from '@/constants/profile';
 
@@ -9,6 +13,8 @@ type Props = {
 
 function UserInfo({ userData, isOwnProfile }: Props) {
   const { imageUrl, gitHubId, jobType, careerLevel, followerCount } = userData;
+  const loginUserData = useContext(UserDataContext);
+  const loginUserGitHubId = loginUserData && loginUserData.member.gitHubId;
 
   return (
     <>
@@ -32,7 +38,9 @@ function UserInfo({ userData, isOwnProfile }: Props) {
           <S.FollowerCount>{followerCount}명이 팔로우함</S.FollowerCount>
         </S.InfoWrapper>
       </S.Container>
-      {!isOwnProfile && <S.FollowButton>팔로우</S.FollowButton>}
+      {!isOwnProfile && loginUserGitHubId !== gitHubId && (
+        <S.FollowButton>팔로우</S.FollowButton>
+      )}
     </>
   );
 }

--- a/frontend/src/components/Profile/UserInfo/UserInfo.tsx
+++ b/frontend/src/components/Profile/UserInfo/UserInfo.tsx
@@ -4,6 +4,8 @@ import * as S from '@/components/Profile/UserInfo/UserInfo.style';
 
 import { UserDataContext } from '@/contexts/LoginContextProvider';
 
+import useAuth from '@/hooks/useAuth';
+
 import { CAREER_LEVELS, JOB_TYPES } from '@/constants/profile';
 
 type Props = {
@@ -13,8 +15,10 @@ type Props = {
 
 function UserInfo({ userData, isOwnProfile }: Props) {
   const { imageUrl, gitHubId, jobType, careerLevel, followerCount } = userData;
+  const { isLoggedIn } = useAuth();
   const loginUserData = useContext(UserDataContext);
   const loginUserGitHubId = loginUserData && loginUserData.member.gitHubId;
+  const otherProfilePage = !isOwnProfile && loginUserGitHubId !== gitHubId;
 
   return (
     <>
@@ -38,9 +42,7 @@ function UserInfo({ userData, isOwnProfile }: Props) {
           <S.FollowerCount>{followerCount}명이 팔로우함</S.FollowerCount>
         </S.InfoWrapper>
       </S.Container>
-      {!isOwnProfile && loginUserGitHubId !== gitHubId && (
-        <S.FollowButton>팔로우</S.FollowButton>
-      )}
+      {isLoggedIn && otherProfilePage && <S.FollowButton>팔로우</S.FollowButton>}
     </>
   );
 }

--- a/frontend/src/constants/api.ts
+++ b/frontend/src/constants/api.ts
@@ -12,8 +12,9 @@ export const ENDPOINTS = {
   REVIEWS_BY_REVIEW_ID: (id: number | ':id') => `/reviews/${id}`,
   LOGIN: '/login',
   INVENTORY_PRODUCTS: '/members/inventoryProducts',
-  OTHER_INVENTORY_PRODUCTS: (id: number) => `/members/${id}/inventoryProducts`,
-  REVIEW_BY_INVENTORY_PRODUCT_ID: (id: number) => `/inventoryProducts/${id}/reviews`,
+  OTHER_INVENTORY_PRODUCTS: (id: number | ':id') => `/members/${id}/inventoryProducts`,
+  REVIEW_BY_INVENTORY_PRODUCT_ID: (id: number | ':id') =>
+    `/inventoryProducts/${id}/reviews`,
   MEMBERS: '/members',
   ME: '/members/me',
   MY_FOLLOWING: '/members/me/followees',

--- a/frontend/src/constants/api.ts
+++ b/frontend/src/constants/api.ts
@@ -17,5 +17,5 @@ export const ENDPOINTS = {
   MEMBERS: '/members',
   ME: '/members/me',
   MY_FOLLOWING: '/members/me/followees',
-  FOLLOWING: (id: number | ':id') => `/members/me/${id}/following`,
+  FOLLOWING: (id: number | ':id') => `/members/${id}/following`,
 } as const;

--- a/frontend/src/hooks/api/usePost.tsx
+++ b/frontend/src/hooks/api/usePost.tsx
@@ -24,7 +24,7 @@ function usePost<T>({ url, headers }: Props): (input: T) => Promise<void> {
   const postData = async (body: T) => {
     if (!userData || !userData.token) {
       await showAlert(VALIDATION_ERROR_MESSAGES.LOGIN_REQUIRED);
-      return;
+      throw new Error(VALIDATION_ERROR_MESSAGES.LOGIN_REQUIRED);
     }
 
     const { token } = userData;
@@ -38,6 +38,7 @@ function usePost<T>({ url, headers }: Props): (input: T) => Promise<void> {
         (string, [key, value]) => `${string}\n${key}: ${value as string}`,
         ''
       );
+
       await handleError(
         error as Error,
         `body: ${requestBodyString},\n    token: ${token}`

--- a/frontend/src/hooks/useError.tsx
+++ b/frontend/src/hooks/useError.tsx
@@ -10,7 +10,6 @@ function useError() {
   const handleError = async (error: Error, additionalMessage?: string) => {
     if (!(error instanceof Error)) {
       await showAlert(API_ERROR_CODE_EXCEPTION_MESSAGES.UNKNOWN);
-      console.log(error);
       throw new Error('API 요청에서 오류 발생');
     }
 

--- a/frontend/src/hooks/useFollowing.tsx
+++ b/frontend/src/hooks/useFollowing.tsx
@@ -23,7 +23,7 @@ function useFollowing(memberId: number): Return {
       await postFollow(memberId);
       await showAlert('팔로우 완료!');
     } catch {
-      return;
+      throw new Error('팔로우 실패');
     }
   };
 
@@ -31,7 +31,8 @@ function useFollowing(memberId: number): Return {
     try {
       await deleteFollow(memberId);
       await showAlert('팔로우를 취소합니다.');
-    } catch {
+    } catch (e) {
+      throw new Error('팔로우 취소 실패');
       return;
     }
   };

--- a/frontend/src/hooks/useInventory.tsx
+++ b/frontend/src/hooks/useInventory.tsx
@@ -30,7 +30,7 @@ function useInventory({ memberId }: Props): Return {
     isError,
   } = useGetOne<InventoryResponse>({
     url: memberId
-      ? ENDPOINTS.OTHER_INVENTORY_PRODUCTS(memberId)
+      ? ENDPOINTS.OTHER_INVENTORY_PRODUCTS(Number(memberId))
       : ENDPOINTS.INVENTORY_PRODUCTS,
     headers: { Authorization: `Bearer ${userData?.token}` },
   });

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -124,9 +124,9 @@ const getToken = (req, res, ctx) => {
   const response = {
     member: {
       id: 1,
-      gitHubId: '사용자2',
+      gitHubId: 'yangdongjue5510',
       imageUrl: 'https://avatars.githubusercontent.com/u/61769743?v=4',
-      name: 'F12개발자',
+      name: '양동주',
     },
     registerCompleted: false,
     token: 'iJ9.eyJzdWIiOiIyIiwiaWF0IjoxNjU4MTQ4Mzg1LCJleHAiOjE2NTgxNTE',

--- a/frontend/src/pages/Profile/Profile.tsx
+++ b/frontend/src/pages/Profile/Profile.tsx
@@ -13,12 +13,14 @@ import UserInfo from '@/components/Profile/UserInfo/UserInfo';
 import { UserDataContext } from '@/contexts/LoginContextProvider';
 
 import useGetOne from '@/hooks/api/useGetOne';
+import useAuth from '@/hooks/useAuth';
 import useInventory from '@/hooks/useInventory';
 
 import { ENDPOINTS } from '@/constants/api';
 
 function Profile() {
   const userData = useContext(UserDataContext);
+  const { isLoggedIn } = useAuth();
   const { memberId } = useParams();
 
   const isOwnProfile = !memberId;
@@ -36,7 +38,7 @@ function Profile() {
     isError: isUserInfoError,
   } = useGetOne<Member>({
     url: isOwnProfile ? ENDPOINTS.ME : `${ENDPOINTS.MEMBERS}/${memberId}`,
-    headers: { Authorization: `Bearer ${userData?.token}` },
+    headers: isLoggedIn && { Authorization: `Bearer ${userData?.token}` },
   });
 
   const inventoryList = items?.reduce((acc: Record<string, InventoryProduct[]>, curr) => {


### PR DESCRIPTION
# issue: closed #534 

# 작업 내용
- 다른 사용자의 프로필을 조회할 때 나 자신도 팔로우 버튼이 생겨있는 오류를 수정.
- 비로그인 사용자에게는 팔로우 버튼을 숨김
- 타회원 단일 프로필 조회 페이지에서, 비로그인 상태에서 타회원 프로필 조회 요청 시 Authorization 헤더를 포함하지 않도록 수정
-  프로필 페이지에도 팔로잉 기능 구현
- api endpoint 오타 수정
