### PR TITLE
[FE] API 요청에 대한 캐싱 구현

### DIFF
--- a/frontend/src/constants/cache.ts
+++ b/frontend/src/constants/cache.ts
@@ -1,0 +1,6 @@
+const MINS = 60 * 100;
+
+export const CACHE_TIME = {
+  FIVE_MINS: 5 * MINS,
+  THREE_MINS: 3 * MINS,
+} as const;

--- a/frontend/src/contexts/CacheContextProvider.tsx
+++ b/frontend/src/contexts/CacheContextProvider.tsx
@@ -1,0 +1,55 @@
+import { AxiosResponse } from 'axios';
+import { createContext, PropsWithChildren, useState } from 'react';
+
+type CacheBody = { response: AxiosResponse<unknown>; expires: number };
+type CacheMap = Map<string, CacheBody>;
+
+export const GetCacheContext =
+  createContext<(url: string) => AxiosResponse<unknown, unknown>>(null);
+export const AddCacheContext =
+  createContext<(url: string, response: AxiosResponse<unknown>) => void>(null);
+export const RemoveCacheContext = createContext<(url: string) => void>(null);
+
+function CacheContextProvider({ children }: PropsWithChildren) {
+  const [cache, setCache] = useState<CacheMap>(new Map());
+
+  const addCache = (url: string, response: AxiosResponse<unknown>) => {
+    setCache((prev) => prev.set(url, { response, expires: Date.now() + 100 * 60 * 5 }));
+  };
+
+  const getCache = (url: string) => {
+    const cacheBody = cache.get(url);
+
+    if (!cacheBody) {
+      return;
+    }
+
+    if (cacheBody.expires < Date.now()) {
+      removeCache(url);
+
+      return;
+    }
+
+    return cacheBody.response;
+  };
+
+  const removeCache = (url: string) => {
+    setCache((prev) => {
+      const current = new Map(prev);
+      current.delete(url);
+      return current;
+    });
+  };
+
+  return (
+    <GetCacheContext.Provider value={getCache}>
+      <AddCacheContext.Provider value={addCache}>
+        <RemoveCacheContext.Provider value={removeCache}>
+          {children}
+        </RemoveCacheContext.Provider>
+      </AddCacheContext.Provider>
+    </GetCacheContext.Provider>
+  );
+}
+
+export default CacheContextProvider;

--- a/frontend/src/contexts/CacheContextProvider.tsx
+++ b/frontend/src/contexts/CacheContextProvider.tsx
@@ -1,20 +1,28 @@
 import { AxiosResponse } from 'axios';
 import { createContext, PropsWithChildren, useState } from 'react';
 
+import { CACHE_TIME } from '@/constants/cache';
+
 type CacheBody = { response: AxiosResponse<unknown>; expires: number };
 type CacheMap = Map<string, CacheBody>;
 
 export const GetCacheContext =
   createContext<(url: string) => AxiosResponse<unknown, unknown>>(null);
 export const AddCacheContext =
-  createContext<(url: string, response: AxiosResponse<unknown>) => void>(null);
+  createContext<(url: string, response: AxiosResponse<unknown>, maxAge?: number) => void>(
+    null
+  );
 export const RemoveCacheContext = createContext<(url: string) => void>(null);
 
 function CacheContextProvider({ children }: PropsWithChildren) {
   const [cache, setCache] = useState<CacheMap>(new Map());
 
-  const addCache = (url: string, response: AxiosResponse<unknown>) => {
-    setCache((prev) => prev.set(url, { response, expires: Date.now() + 100 * 60 * 5 }));
+  const addCache = (
+    url: string,
+    response: AxiosResponse<unknown>,
+    maxAge = CACHE_TIME.FIVE_MINS
+  ) => {
+    setCache((prev) => prev.set(url, { response, expires: Date.now() + maxAge }));
   };
 
   const getCache = (url: string) => {

--- a/frontend/src/hooks/api/useCache.tsx
+++ b/frontend/src/hooks/api/useCache.tsx
@@ -11,6 +11,7 @@ type getWithCacheParams = {
   axiosInstance: AxiosInstance;
   url: string;
   config?: AxiosRequestConfig;
+  maxAge: number;
 };
 
 function useCache() {
@@ -18,7 +19,12 @@ function useCache() {
   const addCache = useContext(AddCacheContext);
   const removeCache = useContext(RemoveCacheContext);
 
-  const getWithCache = async ({ axiosInstance, url, config }: getWithCacheParams) => {
+  const getWithCache = async ({
+    axiosInstance,
+    url,
+    config,
+    maxAge,
+  }: getWithCacheParams) => {
     const searchParams = new URLSearchParams(config.params as Record<string, string>);
     const completeUrl = `${url}${searchParams.toString()}`;
 
@@ -29,7 +35,7 @@ function useCache() {
     }
 
     const response = await axiosInstance.get(url, config);
-    addCache(completeUrl, response);
+    addCache(completeUrl, response, maxAge);
 
     return response;
   };

--- a/frontend/src/hooks/api/useCache.tsx
+++ b/frontend/src/hooks/api/useCache.tsx
@@ -1,0 +1,40 @@
+import { AxiosInstance, AxiosRequestConfig } from 'axios';
+import { useContext } from 'react';
+
+import {
+  AddCacheContext,
+  GetCacheContext,
+  RemoveCacheContext,
+} from '@/contexts/CacheContextProvider';
+
+type getWithCacheParams = {
+  axiosInstance: AxiosInstance;
+  url: string;
+  config?: AxiosRequestConfig;
+};
+
+function useCache() {
+  const getCache = useContext(GetCacheContext);
+  const addCache = useContext(AddCacheContext);
+  const removeCache = useContext(RemoveCacheContext);
+
+  const getWithCache = async ({ axiosInstance, url, config }: getWithCacheParams) => {
+    const searchParams = new URLSearchParams(config.params as Record<string, string>);
+    const completeUrl = `${url}${searchParams.toString()}`;
+
+    const cachedResponse = getCache(completeUrl);
+
+    if (cachedResponse) {
+      return cachedResponse;
+    }
+
+    const response = await axiosInstance.get(url, config);
+    addCache(completeUrl, response);
+
+    return response;
+  };
+
+  return { getWithCache, removeCache };
+}
+
+export default useCache;

--- a/frontend/src/hooks/api/useGetMany.tsx
+++ b/frontend/src/hooks/api/useGetMany.tsx
@@ -6,6 +6,8 @@ import useAxios from '@/hooks/api/useAxios';
 import useCache from '@/hooks/api/useCache';
 import useModal from '@/hooks/useModal';
 
+import { CACHE_TIME } from '@/constants/cache';
+
 type SearchParams = Record<string, string>;
 
 type GetManyParams = SearchParams & { size: string };
@@ -69,6 +71,7 @@ function useGetMany<T>({ url, params, body, headers }: Props): Return<T> {
           ...params,
         },
       },
+      maxAge: CACHE_TIME.THREE_MINS,
     })) as AxiosResponse<Data<T>>;
 
     setDataFromResponse(items);

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -4,6 +4,7 @@ import { ThemeProvider } from 'styled-components';
 
 import App from '@/App';
 
+import CacheContextProvider from '@/contexts/CacheContextProvider';
 import LoginContextProvider from '@/contexts/LoginContextProvider';
 import ModalContextProvider from '@/contexts/ModalContextProvider';
 
@@ -34,11 +35,13 @@ root.render(
       <ResetCss />
       <GlobalStyles />
       <BrowserRouter>
-        <LoginContextProvider>
-          <ModalContextProvider>
-            <App />
-          </ModalContextProvider>
-        </LoginContextProvider>
+        <CacheContextProvider>
+          <LoginContextProvider>
+            <ModalContextProvider>
+              <App />
+            </ModalContextProvider>
+          </LoginContextProvider>
+        </CacheContextProvider>
       </BrowserRouter>
     </ThemeProvider>
   </>


### PR DESCRIPTION
# issue: #552

# 작업 내용
- API 캐싱 구현
- 캐싱 시간은 기본 5분, useGetOne, useGetMany에서 사용할 때는 3분으로 설정
- 외부 저장소에 저장하지 않고 앱 안에서만 저장 (API 요청에 대한 너무 긴 캐시 타임을 적용하지 않도록)
- 컨텍스트 기반으로 구현
