### PR TITLE
[FE] 데스크 셋업 변경 시 불필요한 API 요청을 보내지 않는다.

### DIFF
--- a/frontend/src/components/Profile/InventoryProductList/InventoryProductList.tsx
+++ b/frontend/src/components/Profile/InventoryProductList/InventoryProductList.tsx
@@ -8,7 +8,7 @@ import * as S from '@/components/Profile/InventoryProductList/InventoryProductLi
 import { CATEGORIES } from '@/constants/product';
 
 type Props = {
-  submitHandler?: () => void;
+  refetchInventoryProducts?: () => void;
   updateProfileProduct?: (array: number[]) => Promise<boolean>;
   inventoryList: Record<string, InventoryProduct[]>;
   editable: boolean;
@@ -17,7 +17,7 @@ type Props = {
 function InventoryProductList({
   inventoryList,
   editable,
-  submitHandler,
+  refetchInventoryProducts,
   updateProfileProduct,
 }: Props) {
   const selectedItems = Object.values(inventoryList)
@@ -36,10 +36,20 @@ function InventoryProductList({
 
   const handleEdit = async () => {
     if (!editable) return;
+
     if (isEditMode) {
-      const didPatch = await updateProfileProduct(Object.values(selectedState));
-      if (didPatch) submitHandler();
-      setEditMode(false);
+      const isInventoryChanged =
+        JSON.stringify(selectedItemsIdsByCategory) !== JSON.stringify(selectedState);
+
+      if (isInventoryChanged) {
+        await updateProfileProduct(Object.values(selectedState)).then(() => {
+          refetchInventoryProducts();
+        });
+        setEditMode(false);
+      } else {
+        setEditMode(false);
+        return;
+      }
 
       return;
     }

--- a/frontend/src/pages/Profile/Profile.tsx
+++ b/frontend/src/pages/Profile/Profile.tsx
@@ -80,7 +80,7 @@ function Profile() {
           <InventoryProductList
             inventoryList={inventoryList}
             editable={isOwnProfile}
-            submitHandler={refetchInventoryProducts}
+            refetchInventoryProducts={refetchInventoryProducts}
             updateProfileProduct={updateProfileProduct}
           />
         </AsyncWrapper>


### PR DESCRIPTION
# 작업 내용
- 데스크 셋업의 변경 전, 변경 후 상태가 동일할 경우 데스크 셋업 수정 버튼을 눌러도 API 요청을 보내지 않는다.

![화면 기록 2022-09-13 17 05 48](https://user-images.githubusercontent.com/64275588/189847903-29035de4-96dd-4a3c-991a-0de9e171602a.gif)
