### PR TITLE
[Feature/FE] 불필요한 리렌더링이 발생하지 않도록 최적화 진행

### DIFF
--- a/frontend/src/components/Product/ProductCard/ProductCard.tsx
+++ b/frontend/src/components/Product/ProductCard/ProductCard.tsx
@@ -1,3 +1,5 @@
+import { memo } from 'react';
+
 import LazyImage from '@/components/common/LazyImage/LazyImage';
 import Rating from '@/components/common/Rating/Rating';
 import ReviewCount from '@/components/common/ReviewCount/ReviewCount';
@@ -23,4 +25,4 @@ function ProductCard({ imageUrl, name, rating, reviewCount, index = 0 }: Props) 
   );
 }
 
-export default ProductCard;
+export default memo(ProductCard);

--- a/frontend/src/components/Profile/ProfileCard/ProfileCard.tsx
+++ b/frontend/src/components/Profile/ProfileCard/ProfileCard.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, memo } from 'react';
 import { Link } from 'react-router-dom';
 
 import Chip from '@/components/common/Chip/Chip';
@@ -194,4 +194,4 @@ function ProfileCard({
   );
 }
 
-export default ProfileCard;
+export default memo(ProfileCard);

--- a/frontend/src/hooks/useLazyImage.tsx
+++ b/frontend/src/hooks/useLazyImage.tsx
@@ -6,10 +6,10 @@ type Props = {
 
 function useLazyImage({ src }: Props) {
   const [imageSrc, setImageSrc] = useState<string | null>(null);
-  const imageRef = useRef(null);
+  const imageRef = useRef<HTMLImageElement>(null);
 
   useEffect(() => {
-    let imageContentObserver;
+    let imageContentObserver: IntersectionObserver;
 
     if (imageRef && !imageSrc) {
       imageContentObserver = new IntersectionObserver(
@@ -26,7 +26,7 @@ function useLazyImage({ src }: Props) {
     }
 
     return () => {
-      imageContentObserver && imageContentObserver.disconnect(imageRef);
+      imageContentObserver && imageContentObserver.disconnect();
     };
   }, [imageRef, imageSrc, src]);
 


### PR DESCRIPTION
# 작업 내용

- React Devtool로 리렌더링이 감소하는지 여부를 파악한 후 memo 적용

## ProfileCard memo 적용 전
<img width="1053" alt="스크린샷 2022-09-14 13 24 27" src="https://user-images.githubusercontent.com/64275588/190059433-3755c62d-96aa-471e-9278-bf8db27fb22b.png">



## ProfileCard memo 적용 후
<img width="942" alt="스크린샷 2022-09-14 13 24 50" src="https://user-images.githubusercontent.com/64275588/190059359-99972e4e-9fed-4c2f-9b48-f1c3b4a1eb50.png">


## ProductCard memo 적용 전
<img width="1083" alt="스크린샷 2022-09-14 13 22 54" src="https://user-images.githubusercontent.com/64275588/190059102-0c1f929e-f020-4ff8-a98f-dd8d8e82844f.png">


## ProductCard memo 적용 후
<img width="1104" alt="스크린샷 2022-09-14 13 23 44" src="https://user-images.githubusercontent.com/64275588/190059069-80d0c5bb-4c05-4147-bf1c-746b077966bd.png">

