### PR TITLE
[Feature/FE] GitHub 프로필 이미지 크기를 최적화

### DIFF
--- a/frontend/src/components/Profile/ProfileCard/ProfileCard.tsx
+++ b/frontend/src/components/Profile/ProfileCard/ProfileCard.tsx
@@ -9,7 +9,7 @@ import useAuth from '@/hooks/useAuth';
 import useFollowing from '@/hooks/useFollowing';
 
 import TITLE from '@/constants/header';
-import { GITHUB_URL } from '@/constants/link';
+import { GITHUB_IMAGE_SIZE_SEARCH_PARAM, GITHUB_URL } from '@/constants/link';
 import { CAREER_LEVELS, JOB_TYPES } from '@/constants/profile';
 import ROUTES from '@/constants/routes';
 
@@ -122,7 +122,7 @@ function ProfileCard({
     <S.Container index={index}>
       <S.LeftSection>
         <S.ProfileImageWrapper>
-          <S.ProfileImage src={imageUrl} />
+          <S.ProfileImage src={`${imageUrl}${GITHUB_IMAGE_SIZE_SEARCH_PARAM.large}`} />
         </S.ProfileImageWrapper>
       </S.LeftSection>
       <S.RightSection>

--- a/frontend/src/components/Profile/UserInfo/UserInfo.tsx
+++ b/frontend/src/components/Profile/UserInfo/UserInfo.tsx
@@ -8,6 +8,7 @@ import { UserDataContext } from '@/contexts/LoginContextProvider';
 import useAuth from '@/hooks/useAuth';
 import useFollowing from '@/hooks/useFollowing';
 
+import { GITHUB_IMAGE_SIZE_SEARCH_PARAM } from '@/constants/link';
 import { CAREER_LEVELS, JOB_TYPES } from '@/constants/profile';
 
 type Props = {
@@ -56,7 +57,10 @@ function UserInfo({ userData, isOwnProfile }: Props) {
     <>
       <S.Container>
         <S.ImageWrapper>
-          <S.ProfileImage src={imageUrl} alt="" />
+          <S.ProfileImage
+            src={`${imageUrl}${GITHUB_IMAGE_SIZE_SEARCH_PARAM.medium}`}
+            alt=""
+          />
         </S.ImageWrapper>
         <S.InfoWrapper>
           {`${CAREER_LEVELS[careerLevel]}, `}

--- a/frontend/src/components/Review/ReviewCard/ReviewCard.stories.tsx
+++ b/frontend/src/components/Review/ReviewCard/ReviewCard.stories.tsx
@@ -13,6 +13,4 @@ const Template: ComponentStory<typeof ReviewCard> = (args) => <ReviewCard {...ar
 
 const reviewData = reviewsWithProduct[0];
 
-export const Default = () => (
-  <Template reviewId={1} loginUserGithubId={'hamcheeseburger'} reviewData={reviewData} />
-);
+export const Default = () => <Template reviewId={1} reviewData={reviewData} />;

--- a/frontend/src/components/Review/ReviewCard/ReviewCard.tsx
+++ b/frontend/src/components/Review/ReviewCard/ReviewCard.tsx
@@ -9,6 +9,7 @@ import * as S from '@/components/Review/ReviewCard/ReviewCard.style';
 import useAnimation from '@/hooks/useAnimation';
 import useAuth from '@/hooks/useAuth';
 
+import { GITHUB_IMAGE_SIZE_SEARCH_PARAM } from '@/constants/link';
 import ROUTES from '@/constants/routes';
 
 type Props = {
@@ -68,7 +69,10 @@ function ReviewCard({
           <S.UserWrapper>
             {userNameVisible && (
               <S.ProfileLink to={`${ROUTES.PROFILE}/${author.id}`}>
-                <UserNameTag imageUrl={author.imageUrl} username={author.gitHubId} />
+                <UserNameTag
+                  imageUrl={`${author.imageUrl}${GITHUB_IMAGE_SIZE_SEARCH_PARAM.small}`}
+                  username={author.gitHubId}
+                />
               </S.ProfileLink>
             )}
             {!product && authorMatch && (

--- a/frontend/src/constants/link.ts
+++ b/frontend/src/constants/link.ts
@@ -1,1 +1,7 @@
 export const GITHUB_URL = 'https://github.com/';
+
+export const GITHUB_IMAGE_SIZE_SEARCH_PARAM = {
+  small: '&s=32',
+  medium: '&s=60',
+  large: '&s=152',
+} as const;


### PR DESCRIPTION
# 작업 내용
- GitHub 프로필 이미지 사이즈가 크게 3가지로 분류되어 있음.
- 이미지 사이즈를 관리하는 객체를 만들고 3가지를 small, medium, large로 관리.

<img width="425" alt="스크린샷 2022-09-19 15 27 58" src="https://user-images.githubusercontent.com/64275588/190967038-fd57365f-314b-4499-b137-95fac6f525cb.png">


<img width="368" alt="스크린샷 2022-09-19 15 28 24" src="https://user-images.githubusercontent.com/64275588/190967043-0bcf5dbc-29a4-4cfb-a64a-163f40b5c8d0.png">


<img width="416" alt="스크린샷 2022-09-19 15 28 37" src="https://user-images.githubusercontent.com/64275588/190967048-cf896a84-049d-4d07-ae39-affab869a08b.png">
