### PR TITLE
[BE/Feature] @BatchSize와 Fetch EAGER를 제거한다

### DIFF
--- a/backend/src/main/java/com/woowacourse/f12/application/inventoryproduct/InventoryProductService.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/inventoryproduct/InventoryProductService.java
@@ -54,7 +54,7 @@ public class InventoryProductService {
 
     public InventoryProductsResponse findByMemberId(final Long memberId) {
         validateMember(memberId);
-        final List<InventoryProduct> inventoryProducts = inventoryProductRepository.findByMemberId(memberId);
+        final List<InventoryProduct> inventoryProducts = inventoryProductRepository.findWithProductByMemberId(memberId);
         return InventoryProductsResponse.from(inventoryProducts);
     }
 

--- a/backend/src/main/java/com/woowacourse/f12/application/member/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/member/MemberService.java
@@ -157,12 +157,21 @@ public class MemberService {
                 .orElseThrow(NotFollowingException::new);
     }
 
-    public MemberPageResponse findFollowingsByConditions(final Long loggedInId, final MemberSearchRequest memberSearchRequest,
+    public MemberPageResponse findFollowingsByConditions(final Long loggedInId,
+                                                         final MemberSearchRequest memberSearchRequest,
                                                          final Pageable pageable) {
+        final Slice<Member> slice = findFollowingsBySearchConditions(loggedInId,
+                memberSearchRequest, pageable);
+        setInventoryProductsToMembers(slice);
+        return MemberPageResponse.ofByFollowingCondition(slice, true);
+    }
+
+    private Slice<Member> findFollowingsBySearchConditions(final Long loggedInId,
+                                                           final MemberSearchRequest memberSearchRequest,
+                                                           final Pageable pageable) {
         final CareerLevel careerLevel = parseCareerLevel(memberSearchRequest);
         final JobType jobType = parseJobType(memberSearchRequest);
-        final Slice<Member> slice = memberRepository.findFollowingsBySearchConditions(loggedInId, memberSearchRequest.getQuery(),
+        return memberRepository.findFollowingsBySearchConditions(loggedInId, memberSearchRequest.getQuery(),
                 careerLevel, jobType, pageable);
-        return MemberPageResponse.ofByFollowingCondition(slice, true);
     }
 }

--- a/backend/src/main/java/com/woowacourse/f12/application/member/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/member/MemberService.java
@@ -1,6 +1,8 @@
 package com.woowacourse.f12.application.member;
 
 
+import com.woowacourse.f12.domain.inventoryproduct.InventoryProduct;
+import com.woowacourse.f12.domain.inventoryproduct.InventoryProductRepository;
 import com.woowacourse.f12.domain.member.*;
 import com.woowacourse.f12.dto.request.member.MemberRequest;
 import com.woowacourse.f12.dto.request.member.MemberSearchRequest;
@@ -30,10 +32,12 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
     private final FollowingRepository followingRepository;
+    private final InventoryProductRepository inventoryProductRepository;
 
-    public MemberService(final MemberRepository memberRepository, final FollowingRepository followingRepository) {
+    public MemberService(final MemberRepository memberRepository, final FollowingRepository followingRepository, final InventoryProductRepository inventoryProductRepository) {
         this.memberRepository = memberRepository;
         this.followingRepository = followingRepository;
+        this.inventoryProductRepository = inventoryProductRepository;
     }
 
     public LoggedInMemberResponse findLoggedInMember(final Long loggedInId) {
@@ -70,15 +74,30 @@ public class MemberService {
     }
 
     public MemberPageResponse findByContains(@Nullable final Long loggedInId, final MemberSearchRequest memberSearchRequest, final Pageable pageable) {
-        final CareerLevel careerLevel = parseCareerLevel(memberSearchRequest);
-        final JobType jobType = parseJobType(memberSearchRequest);
-        final Slice<Member> slice = memberRepository.findBySearchConditions(memberSearchRequest.getQuery(), careerLevel,
-                jobType, pageable);
+        final Slice<Member> slice = findMembersBySearchConditions(memberSearchRequest, pageable);
+        setInventoryProductsToMembers(slice);
         if (isNotLoggedIn(loggedInId)) {
             return MemberPageResponse.ofByFollowingCondition(slice, false);
         }
         final List<Following> followings = followingRepository.findByFollowerIdAndFollowingIdIn(loggedInId, extractMemberIds(slice.getContent()));
         return MemberPageResponse.of(slice, followings);
+    }
+
+    private Slice<Member> findMembersBySearchConditions(final MemberSearchRequest memberSearchRequest, final Pageable pageable) {
+        final CareerLevel careerLevel = parseCareerLevel(memberSearchRequest);
+        final JobType jobType = parseJobType(memberSearchRequest);
+        return memberRepository.findBySearchConditions(memberSearchRequest.getQuery(), careerLevel,
+                jobType, pageable);
+    }
+
+    private void setInventoryProductsToMembers(final Slice<Member> slice) {
+        final List<InventoryProduct> mixedInventoryProducts = inventoryProductRepository.findWithProductByMembers(slice.getContent());
+        for (Member member : slice.getContent()) {
+            final List<InventoryProduct> memberInventoryProducts = mixedInventoryProducts.stream()
+                    .filter(it -> it.getMember().isSameId(member.getId()))
+                    .collect(Collectors.toList());
+            member.updateInventoryProducts(memberInventoryProducts);
+        }
     }
 
     private JobType parseJobType(final MemberSearchRequest memberSearchRequest) {

--- a/backend/src/main/java/com/woowacourse/f12/application/review/ReviewService.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/review/ReviewService.java
@@ -118,7 +118,7 @@ public class ReviewService {
     public void delete(final Long reviewId, final Long memberId) {
         final Review review = findTarget(reviewId, memberId);
         reviewRepository.delete(review);
-        final InventoryProduct inventoryProduct = inventoryProductRepository.findByMemberAndProduct(review.getMember(), review.getProduct())
+        final InventoryProduct inventoryProduct = inventoryProductRepository.findWithProductByMemberAndProduct(review.getMember(), review.getProduct())
                 .orElseThrow(InventoryProductNotFoundException::new);
         inventoryProductRepository.delete(inventoryProduct);
     }

--- a/backend/src/main/java/com/woowacourse/f12/domain/inventoryproduct/InventoryProduct.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/inventoryproduct/InventoryProduct.java
@@ -26,7 +26,7 @@ public class InventoryProduct {
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @ManyToOne(fetch = FetchType.EAGER)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "product_id")
     private Product product;
 

--- a/backend/src/main/java/com/woowacourse/f12/domain/inventoryproduct/InventoryProductRepository.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/inventoryproduct/InventoryProductRepository.java
@@ -11,9 +11,11 @@ import java.util.Optional;
 
 public interface InventoryProductRepository extends JpaRepository<InventoryProduct, Long> {
 
-    List<InventoryProduct> findByMemberId(Long memberId);
+    @Query("select i from InventoryProduct i join fetch i.product where i.member.id = :memberId")
+    List<InventoryProduct> findWithProductByMemberId(Long memberId);
 
-    Optional<InventoryProduct> findByMemberAndProduct(Member member, Product product);
+    @Query("select i from InventoryProduct i join fetch i.product where i.member = :member and i.product = :product")
+    Optional<InventoryProduct> findWithProductByMemberAndProduct(Member member, Product product);
 
     boolean existsByMemberAndProduct(Member member, Product product);
 
@@ -25,4 +27,7 @@ public interface InventoryProductRepository extends JpaRepository<InventoryProdu
     @Query("update InventoryProduct i set i.selected = :selected "
             + "where i.member = :member and i.id in :selectedInventoryProductIds")
     int updateBulkProfileProductByMemberAndIds(Member member, List<Long> selectedInventoryProductIds, boolean selected);
+
+    @Query("select i from InventoryProduct i join fetch i.product where i.member IN :members")
+    List<InventoryProduct> findWithProductByMembers(List<Member> members);
 }

--- a/backend/src/main/java/com/woowacourse/f12/domain/inventoryproduct/InventoryProducts.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/inventoryproduct/InventoryProducts.java
@@ -5,7 +5,6 @@ import com.woowacourse.f12.domain.product.Product;
 import com.woowacourse.f12.exception.badrequest.DuplicatedProfileProductCategoryException;
 import com.woowacourse.f12.exception.badrequest.InvalidProfileProductCategoryException;
 import lombok.Getter;
-import org.hibernate.annotations.BatchSize;
 
 import javax.persistence.Embeddable;
 import javax.persistence.OneToMany;
@@ -19,7 +18,6 @@ import java.util.stream.Collectors;
 @Embeddable
 public class InventoryProducts {
 
-    @BatchSize(size = 150)
     @OneToMany(mappedBy = "member")
     private List<InventoryProduct> items = new ArrayList<>();
 

--- a/backend/src/main/java/com/woowacourse/f12/domain/member/Member.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/member/Member.java
@@ -108,6 +108,10 @@ public class Member {
         return Objects.equals(id, this.id);
     }
 
+    public void updateInventoryProducts(final List<InventoryProduct> values) {
+        this.inventoryProducts = new InventoryProducts(values);
+    }
+
     @Override
     public boolean equals(final Object o) {
         if (this == o) {

--- a/backend/src/test/java/com/woowacourse/f12/acceptance/InventoryProductAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/acceptance/InventoryProductAcceptanceTest.java
@@ -1,17 +1,5 @@
 package com.woowacourse.f12.acceptance;
 
-import static com.woowacourse.f12.acceptance.support.RestAssuredRequestUtil.GET_요청을_보낸다;
-import static com.woowacourse.f12.acceptance.support.RestAssuredRequestUtil.로그인된_상태로_GET_요청을_보낸다;
-import static com.woowacourse.f12.acceptance.support.RestAssuredRequestUtil.로그인된_상태로_PATCH_요청을_보낸다;
-import static com.woowacourse.f12.presentation.member.CareerLevelConstant.SENIOR_CONSTANT;
-import static com.woowacourse.f12.presentation.member.JobTypeConstant.BACKEND_CONSTANT;
-import static com.woowacourse.f12.support.fixture.AcceptanceFixture.코린;
-import static com.woowacourse.f12.support.fixture.ProductFixture.KEYBOARD_1;
-import static com.woowacourse.f12.support.fixture.ProductFixture.KEYBOARD_2;
-import static com.woowacourse.f12.support.fixture.ReviewFixture.REVIEW_RATING_5;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
-
 import com.woowacourse.f12.domain.inventoryproduct.InventoryProduct;
 import com.woowacourse.f12.domain.inventoryproduct.InventoryProductRepository;
 import com.woowacourse.f12.domain.member.Member;
@@ -25,10 +13,21 @@ import com.woowacourse.f12.dto.response.inventoryproduct.InventoryProductRespons
 import com.woowacourse.f12.dto.response.inventoryproduct.InventoryProductsResponse;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
-import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
+
+import java.util.List;
+
+import static com.woowacourse.f12.acceptance.support.RestAssuredRequestUtil.*;
+import static com.woowacourse.f12.presentation.member.CareerLevelConstant.SENIOR_CONSTANT;
+import static com.woowacourse.f12.presentation.member.JobTypeConstant.BACKEND_CONSTANT;
+import static com.woowacourse.f12.support.fixture.AcceptanceFixture.코린;
+import static com.woowacourse.f12.support.fixture.ProductFixture.KEYBOARD_1;
+import static com.woowacourse.f12.support.fixture.ProductFixture.KEYBOARD_2;
+import static com.woowacourse.f12.support.fixture.ReviewFixture.REVIEW_RATING_5;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 class InventoryProductAcceptanceTest extends AcceptanceTest {
 
@@ -197,6 +196,6 @@ class InventoryProductAcceptanceTest extends AcceptanceTest {
     }
 
     private InventoryProduct 인벤토리에_있는_장비를_찾아온다(Product product, Member member) {
-        return inventoryProductRepository.findByMemberAndProduct(member, product).get();
+        return inventoryProductRepository.findWithProductByMemberAndProduct(member, product).get();
     }
 }

--- a/backend/src/test/java/com/woowacourse/f12/application/inventoryproduct/InventoryProductServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/application/inventoryproduct/InventoryProductServiceTest.java
@@ -48,7 +48,7 @@ class InventoryProductServiceTest {
         List<Long> selectedInventoryProductIds = List.of(2L);
         ProfileProductRequest profileProductRequest = new ProfileProductRequest(selectedInventoryProductIds);
         InventoryProduct inventoryProduct = UNSELECTED_INVENTORY_PRODUCT.생성(2L, null, KEYBOARD_1.생성(1L));
-        Member member = CORINNE.인벤토리를_추가해서_생성(1L, inventoryProduct);
+        Member member = CORINNE.인벤토리를_추가해서_생성(1L, List.of(inventoryProduct));
         given(memberRepository.findById(1L))
                 .willReturn(Optional.of(member));
         given(inventoryProductRepository.findAllById(selectedInventoryProductIds))
@@ -97,7 +97,7 @@ class InventoryProductServiceTest {
         InventoryProduct inventoryProduct = SELECTED_INVENTORY_PRODUCT.생성(1L, null, KEYBOARD_1.생성());
         InventoryProduct duplicatedCategoryInventoryProduct = UNSELECTED_INVENTORY_PRODUCT.생성(2L, null,
                 KEYBOARD_2.생성());
-        Member member = CORINNE.인벤토리를_추가해서_생성(1L, inventoryProduct, duplicatedCategoryInventoryProduct);
+        Member member = CORINNE.인벤토리를_추가해서_생성(1L, List.of(inventoryProduct, duplicatedCategoryInventoryProduct));
         duplicatedCategoryInventoryProduct = SELECTED_INVENTORY_PRODUCT.생성(2L, null, KEYBOARD_2.생성());
 
         given(memberRepository.findById(1L))
@@ -119,7 +119,8 @@ class InventoryProductServiceTest {
         // given
         List<Long> selectedInventoryProductIds = List.of(1L, 2L);
         ProfileProductRequest profileProductRequest = new ProfileProductRequest(selectedInventoryProductIds);
-        Member member = CORINNE.인벤토리를_추가해서_생성(1L, SELECTED_INVENTORY_PRODUCT.생성(2L, null, KEYBOARD_1.생성(1L)));
+        InventoryProduct selectedInventoryProduct = SELECTED_INVENTORY_PRODUCT.생성(2L, null, KEYBOARD_1.생성(1L));
+        Member member = CORINNE.인벤토리를_추가해서_생성(1L, List.of(selectedInventoryProduct));
         InventoryProduct inventoryProduct1 = SELECTED_INVENTORY_PRODUCT.생성(1L, member, SOFTWARE_1.생성());
         InventoryProduct inventoryProduct2 = UNSELECTED_INVENTORY_PRODUCT.생성(2L, member, KEYBOARD_2.생성());
 

--- a/backend/src/test/java/com/woowacourse/f12/application/inventoryproduct/InventoryProductServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/application/inventoryproduct/InventoryProductServiceTest.java
@@ -1,18 +1,5 @@
 package com.woowacourse.f12.application.inventoryproduct;
 
-import static com.woowacourse.f12.support.fixture.InventoryProductFixtures.SELECTED_INVENTORY_PRODUCT;
-import static com.woowacourse.f12.support.fixture.InventoryProductFixtures.UNSELECTED_INVENTORY_PRODUCT;
-import static com.woowacourse.f12.support.fixture.MemberFixture.CORINNE;
-import static com.woowacourse.f12.support.fixture.ProductFixture.KEYBOARD_1;
-import static com.woowacourse.f12.support.fixture.ProductFixture.KEYBOARD_2;
-import static com.woowacourse.f12.support.fixture.ProductFixture.SOFTWARE_1;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.verify;
-import static org.mockito.Mockito.times;
-
 import com.woowacourse.f12.domain.inventoryproduct.InventoryProduct;
 import com.woowacourse.f12.domain.inventoryproduct.InventoryProductRepository;
 import com.woowacourse.f12.domain.member.Member;
@@ -23,13 +10,25 @@ import com.woowacourse.f12.dto.response.inventoryproduct.InventoryProductsRespon
 import com.woowacourse.f12.exception.badrequest.DuplicatedProfileProductCategoryException;
 import com.woowacourse.f12.exception.badrequest.InvalidProfileProductCategoryException;
 import com.woowacourse.f12.exception.badrequest.InvalidProfileProductUpdateException;
-import java.util.List;
-import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.woowacourse.f12.support.fixture.InventoryProductFixtures.SELECTED_INVENTORY_PRODUCT;
+import static com.woowacourse.f12.support.fixture.InventoryProductFixtures.UNSELECTED_INVENTORY_PRODUCT;
+import static com.woowacourse.f12.support.fixture.MemberFixture.CORINNE;
+import static com.woowacourse.f12.support.fixture.ProductFixture.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.verify;
+import static org.mockito.Mockito.times;
 
 @ExtendWith(MockitoExtension.class)
 class InventoryProductServiceTest {
@@ -146,7 +145,7 @@ class InventoryProductServiceTest {
         InventoryProduct inventoryProduct = SELECTED_INVENTORY_PRODUCT.생성(1L, member, KEYBOARD_1.생성(1L));
         given(memberRepository.existsById(1L))
                 .willReturn(true);
-        given(inventoryProductRepository.findByMemberId(memberId))
+        given(inventoryProductRepository.findWithProductByMemberId(memberId))
                 .willReturn(List.of(inventoryProduct));
 
         // when
@@ -158,7 +157,7 @@ class InventoryProductServiceTest {
                         .usingRecursiveFieldByFieldElementComparator()
                         .containsOnly(InventoryProductResponse.from(inventoryProduct)),
                 () -> verify(memberRepository).existsById(memberId),
-                () -> verify(inventoryProductRepository).findByMemberId(memberId)
+                () -> verify(inventoryProductRepository).findWithProductByMemberId(memberId)
         );
     }
 }

--- a/backend/src/test/java/com/woowacourse/f12/application/member/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/application/member/MemberServiceTest.java
@@ -24,6 +24,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.domain.Sort;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -163,6 +164,7 @@ class MemberServiceTest {
         // then
         assertAll(
                 () -> verify(memberRepository).findBySearchConditions("cheese", SENIOR, BACKEND, pageable),
+                () -> verify(inventoryProductRepository).findWithProductByMembers(List.of(member)),
                 () -> assertThat(memberPageResponse.isHasNext()).isFalse(),
                 () -> assertThat(memberPageResponse.getItems()).usingRecursiveFieldByFieldElementComparator()
                         .containsOnly(MemberWithProfileProductResponse.of(member, false))
@@ -196,6 +198,8 @@ class MemberServiceTest {
         // then
         assertAll(
                 () -> verify(memberRepository).findBySearchConditions("cheese", SENIOR, BACKEND, pageable),
+                () -> verify(inventoryProductRepository).findWithProductByMembers(List.of(member)),
+                () -> verify(followingRepository).findByFollowerIdAndFollowingIdIn(loggedInId, List.of(member.getId())),
                 () -> assertThat(memberPageResponse.isHasNext()).isFalse(),
                 () -> assertThat(memberPageResponse.getItems()).usingRecursiveFieldByFieldElementComparator()
                         .containsOnly(MemberWithProfileProductResponse.of(member, true))
@@ -416,6 +420,8 @@ class MemberServiceTest {
 
         given(memberRepository.findFollowingsBySearchConditions(loggedInId, null, null, null, pageable))
                 .willReturn(new SliceImpl<>(List.of(member), pageable, false));
+        given(inventoryProductRepository.findWithProductByMembers(List.of(member)))
+                .willReturn(Collections.emptyList());
 
         // when
         MemberPageResponse memberPageResponse = memberService.findFollowingsByConditions(loggedInId,
@@ -423,6 +429,8 @@ class MemberServiceTest {
 
         // then
         assertAll(
+                () -> verify(memberRepository).findFollowingsBySearchConditions(loggedInId, null, null, null, pageable),
+                () -> verify(inventoryProductRepository).findWithProductByMembers(List.of(member)),
                 () -> assertThat(memberPageResponse.isHasNext()).isFalse(),
                 () -> assertThat(memberPageResponse.getItems()).usingRecursiveFieldByFieldElementComparator()
                         .containsOnly(MemberWithProfileProductResponse.of(member, true))

--- a/backend/src/test/java/com/woowacourse/f12/application/member/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/application/member/MemberServiceTest.java
@@ -149,7 +149,7 @@ class MemberServiceTest {
         // given
         Pageable pageable = PageRequest.of(0, 10);
         InventoryProduct inventoryProduct = SELECTED_INVENTORY_PRODUCT.생성(CORINNE.생성(1L), KEYBOARD_1.생성(1L));
-        Member member = CORINNE.인벤토리를_추가해서_생성(1L, inventoryProduct);
+        Member member = CORINNE.인벤토리를_추가해서_생성(1L, List.of(inventoryProduct));
 
         given(memberRepository.findBySearchConditions("cheese", SENIOR, BACKEND, pageable))
                 .willReturn(new SliceImpl<>(List.of(member), pageable, false));
@@ -174,7 +174,7 @@ class MemberServiceTest {
         // given
         Pageable pageable = PageRequest.of(0, 10);
         InventoryProduct inventoryProduct = SELECTED_INVENTORY_PRODUCT.생성(CORINNE.생성(1L), KEYBOARD_1.생성(1L));
-        Member member = CORINNE.인벤토리를_추가해서_생성(1L, inventoryProduct);
+        Member member = CORINNE.인벤토리를_추가해서_생성(1L, List.of(inventoryProduct));
 
         Long loggedInId = 2L;
         Following following = Following.builder()

--- a/backend/src/test/java/com/woowacourse/f12/application/member/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/application/member/MemberServiceTest.java
@@ -1,5 +1,32 @@
 package com.woowacourse.f12.application.member;
 
+import com.woowacourse.f12.domain.inventoryproduct.InventoryProduct;
+import com.woowacourse.f12.domain.inventoryproduct.InventoryProductRepository;
+import com.woowacourse.f12.domain.member.Following;
+import com.woowacourse.f12.domain.member.FollowingRepository;
+import com.woowacourse.f12.domain.member.Member;
+import com.woowacourse.f12.domain.member.MemberRepository;
+import com.woowacourse.f12.dto.request.member.MemberRequest;
+import com.woowacourse.f12.dto.request.member.MemberSearchRequest;
+import com.woowacourse.f12.dto.response.member.MemberPageResponse;
+import com.woowacourse.f12.dto.response.member.MemberResponse;
+import com.woowacourse.f12.dto.response.member.MemberWithProfileProductResponse;
+import com.woowacourse.f12.exception.badrequest.AlreadyFollowingException;
+import com.woowacourse.f12.exception.badrequest.NotFollowingException;
+import com.woowacourse.f12.exception.notfound.MemberNotFoundException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.data.domain.Sort;
+
+import java.util.List;
+import java.util.Optional;
+
 import static com.woowacourse.f12.domain.member.CareerLevel.SENIOR;
 import static com.woowacourse.f12.domain.member.JobType.BACKEND;
 import static com.woowacourse.f12.presentation.member.CareerLevelConstant.JUNIOR_CONSTANT;
@@ -14,35 +41,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.verify;
-import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.*;
 import static org.mockito.Mockito.times;
-
-import com.woowacourse.f12.domain.inventoryproduct.InventoryProduct;
-import com.woowacourse.f12.domain.member.Following;
-import com.woowacourse.f12.domain.member.FollowingRepository;
-import com.woowacourse.f12.domain.member.Member;
-import com.woowacourse.f12.domain.member.MemberRepository;
-import com.woowacourse.f12.dto.request.member.MemberRequest;
-import com.woowacourse.f12.dto.request.member.MemberSearchRequest;
-import com.woowacourse.f12.dto.response.member.MemberPageResponse;
-import com.woowacourse.f12.dto.response.member.MemberResponse;
-import com.woowacourse.f12.dto.response.member.MemberWithProfileProductResponse;
-import com.woowacourse.f12.exception.badrequest.AlreadyFollowingException;
-import com.woowacourse.f12.exception.badrequest.NotFollowingException;
-import com.woowacourse.f12.exception.notfound.MemberNotFoundException;
-import java.util.List;
-import java.util.Optional;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.SliceImpl;
-import org.springframework.data.domain.Sort;
 
 @ExtendWith(MockitoExtension.class)
 class MemberServiceTest {
@@ -52,6 +52,9 @@ class MemberServiceTest {
 
     @Mock
     private FollowingRepository followingRepository;
+
+    @Mock
+    private InventoryProductRepository inventoryProductRepository;
 
     @InjectMocks
     private MemberService memberService;
@@ -150,6 +153,8 @@ class MemberServiceTest {
 
         given(memberRepository.findBySearchConditions("cheese", SENIOR, BACKEND, pageable))
                 .willReturn(new SliceImpl<>(List.of(member), pageable, false));
+        given(inventoryProductRepository.findWithProductByMembers(List.of(member)))
+                .willReturn(List.of(inventoryProduct));
 
         // when
         MemberSearchRequest memberSearchRequest = new MemberSearchRequest("cheese", SENIOR_CONSTANT, BACKEND_CONSTANT);
@@ -179,6 +184,8 @@ class MemberServiceTest {
 
         given(memberRepository.findBySearchConditions("cheese", SENIOR, BACKEND, pageable))
                 .willReturn(new SliceImpl<>(List.of(member), pageable, false));
+        given(inventoryProductRepository.findWithProductByMembers(List.of(member)))
+                .willReturn(List.of(inventoryProduct));
         given(followingRepository.findByFollowerIdAndFollowingIdIn(loggedInId, List.of(member.getId())))
                 .willReturn(List.of(following));
 

--- a/backend/src/test/java/com/woowacourse/f12/application/review/ReviewServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/application/review/ReviewServiceTest.java
@@ -440,7 +440,7 @@ class ReviewServiceTest {
                 .willReturn(Optional.of(review));
         willDoNothing().given(reviewRepository)
                 .delete(any(Review.class));
-        given(inventoryProductRepository.findByMemberAndProduct(member, product))
+        given(inventoryProductRepository.findWithProductByMemberAndProduct(member, product))
                 .willReturn(Optional.of(inventoryProduct));
         willDoNothing().given(inventoryProductRepository)
                 .delete(any(InventoryProduct.class));
@@ -451,7 +451,7 @@ class ReviewServiceTest {
                 () -> verify(memberRepository).findById(memberId),
                 () -> verify(reviewRepository).findById(reviewId),
                 () -> verify(reviewRepository).delete(review),
-                () -> verify(inventoryProductRepository).findByMemberAndProduct(member, product),
+                () -> verify(inventoryProductRepository).findWithProductByMemberAndProduct(member, product),
                 () -> verify(inventoryProductRepository).delete(inventoryProduct)
         );
     }
@@ -535,7 +535,7 @@ class ReviewServiceTest {
                 .willReturn(Optional.of(review));
         willDoNothing().given(reviewRepository)
                 .delete(any(Review.class));
-        given(inventoryProductRepository.findByMemberAndProduct(member, product))
+        given(inventoryProductRepository.findWithProductByMemberAndProduct(member, product))
                 .willReturn(Optional.empty());
 
         // when, then
@@ -545,7 +545,7 @@ class ReviewServiceTest {
                 () -> verify(memberRepository).findById(memberId),
                 () -> verify(reviewRepository).findById(reviewId),
                 () -> verify(reviewRepository).delete(any(Review.class)),
-                () -> verify(inventoryProductRepository).findByMemberAndProduct(member, product),
+                () -> verify(inventoryProductRepository).findWithProductByMemberAndProduct(member, product),
                 () -> verify(inventoryProductRepository, times(0)).delete(any(InventoryProduct.class))
         );
     }

--- a/backend/src/test/java/com/woowacourse/f12/domain/inventoryproduct/InventoryProductRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/domain/inventoryproduct/InventoryProductRepositoryTest.java
@@ -1,5 +1,18 @@
 package com.woowacourse.f12.domain.inventoryproduct;
 
+import com.woowacourse.f12.config.JpaConfig;
+import com.woowacourse.f12.domain.member.Member;
+import com.woowacourse.f12.domain.member.MemberRepository;
+import com.woowacourse.f12.domain.product.Product;
+import com.woowacourse.f12.domain.product.ProductRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import java.util.List;
+import java.util.Optional;
+
 import static com.woowacourse.f12.support.fixture.InventoryProductFixtures.SELECTED_INVENTORY_PRODUCT;
 import static com.woowacourse.f12.support.fixture.InventoryProductFixtures.UNSELECTED_INVENTORY_PRODUCT;
 import static com.woowacourse.f12.support.fixture.MemberFixture.CORINNE;
@@ -7,18 +20,6 @@ import static com.woowacourse.f12.support.fixture.MemberFixture.MINCHO;
 import static com.woowacourse.f12.support.fixture.ProductFixture.KEYBOARD_1;
 import static com.woowacourse.f12.support.fixture.ProductFixture.KEYBOARD_2;
 import static org.assertj.core.api.Assertions.assertThat;
-
-import com.woowacourse.f12.config.JpaConfig;
-import com.woowacourse.f12.domain.member.Member;
-import com.woowacourse.f12.domain.member.MemberRepository;
-import com.woowacourse.f12.domain.product.Product;
-import com.woowacourse.f12.domain.product.ProductRepository;
-import java.util.List;
-import java.util.Optional;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.Import;
 
 @DataJpaTest
 @Import(JpaConfig.class)
@@ -45,7 +46,7 @@ class InventoryProductRepositoryTest {
         inventoryProductRepository.saveAll(List.of(inventoryProduct1, inventoryProduct2));
 
         // when
-        List<InventoryProduct> inventoryProducts = inventoryProductRepository.findByMemberId(me.getId());
+        List<InventoryProduct> inventoryProducts = inventoryProductRepository.findWithProductByMemberId(me.getId());
 
         // then
         assertThat(inventoryProducts).containsOnly(inventoryProduct1);
@@ -56,8 +57,7 @@ class InventoryProductRepositoryTest {
         // given다
         Member member = 회원을_저장한다(CORINNE.생성());
         Product product = 제품을_저장한다(KEYBOARD_1.생성());
-        InventoryProduct inventoryProduct = SELECTED_INVENTORY_PRODUCT.생성(member, product);
-        inventoryProductRepository.save(inventoryProduct);
+        장비를_등록한다(SELECTED_INVENTORY_PRODUCT.생성(member, product));
 
         // when
         boolean actual = inventoryProductRepository.existsByMemberAndProduct(member, product);
@@ -71,8 +71,7 @@ class InventoryProductRepositoryTest {
         // given
         Member member = 회원을_저장한다(CORINNE.생성());
         Product product = 제품을_저장한다(KEYBOARD_1.생성());
-        InventoryProduct inventoryProduct = UNSELECTED_INVENTORY_PRODUCT.생성(member, product);
-        inventoryProductRepository.save(inventoryProduct);
+        장비를_등록한다(UNSELECTED_INVENTORY_PRODUCT.생성(member, product));
 
         // when
         int actual = inventoryProductRepository.updateBulkProfileProductByMember(member, false);
@@ -86,8 +85,7 @@ class InventoryProductRepositoryTest {
         // given
         Member member = 회원을_저장한다(CORINNE.생성());
         Product product = 제품을_저장한다(KEYBOARD_1.생성());
-        InventoryProduct inventoryProduct = UNSELECTED_INVENTORY_PRODUCT.생성(member, product);
-        inventoryProductRepository.save(inventoryProduct);
+        InventoryProduct inventoryProduct = 장비를_등록한다(UNSELECTED_INVENTORY_PRODUCT.생성(member, product));
 
         // when
         int actual = inventoryProductRepository.updateBulkProfileProductByMemberAndIds(member,
@@ -102,14 +100,30 @@ class InventoryProductRepositoryTest {
         // given
         Member member = 회원을_저장한다(CORINNE.생성());
         Product product = 제품을_저장한다(KEYBOARD_1.생성());
-        InventoryProduct inventoryProduct = UNSELECTED_INVENTORY_PRODUCT.생성(member, product);
-        inventoryProductRepository.save(inventoryProduct);
+        장비를_등록한다(UNSELECTED_INVENTORY_PRODUCT.생성(member, product));
 
         // when
-        Optional<InventoryProduct> actual = inventoryProductRepository.findByMemberAndProduct(member, product);
+        Optional<InventoryProduct> actual = inventoryProductRepository.findWithProductByMemberAndProduct(member, product);
 
         // then
         assertThat(actual).isPresent();
+    }
+
+    @Test
+    void 멤버_목록으로_제품이_포함된_인벤토리를_조회한다() {
+        // given
+        Member corinne = 회원을_저장한다(CORINNE.생성());
+        Member mincho = 회원을_저장한다(MINCHO.생성());
+        Product product = 제품을_저장한다(KEYBOARD_1.생성());
+        InventoryProduct inventoryProduct = 장비를_등록한다(UNSELECTED_INVENTORY_PRODUCT.생성(corinne, product));
+
+        // when
+        List<InventoryProduct> actual = inventoryProductRepository.findWithProductByMembers(List.of(corinne, mincho));
+
+        // then
+        assertThat(actual).usingRecursiveFieldByFieldElementComparator()
+                .hasSize(1)
+                .containsExactly(inventoryProduct);
     }
 
     private Product 제품을_저장한다(Product product) {
@@ -118,5 +132,9 @@ class InventoryProductRepositoryTest {
 
     private Member 회원을_저장한다(Member member) {
         return memberRepository.save(member);
+    }
+
+    private InventoryProduct 장비를_등록한다(InventoryProduct inventoryProduct) {
+        return inventoryProductRepository.save(inventoryProduct);
     }
 }

--- a/backend/src/test/java/com/woowacourse/f12/domain/member/MemberRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/domain/member/MemberRepositoryTest.java
@@ -1,20 +1,6 @@
 package com.woowacourse.f12.domain.member;
 
-import static com.woowacourse.f12.domain.member.CareerLevel.JUNIOR;
-import static com.woowacourse.f12.domain.member.CareerLevel.SENIOR;
-import static com.woowacourse.f12.domain.member.JobType.BACKEND;
-import static com.woowacourse.f12.domain.member.JobType.FRONTEND;
-import static com.woowacourse.f12.support.fixture.MemberFixture.CORINNE;
-import static com.woowacourse.f12.support.fixture.MemberFixture.MINCHO;
-import static com.woowacourse.f12.support.fixture.MemberFixture.NOT_ADDITIONAL_INFO;
-import static com.woowacourse.f12.support.fixture.MemberFixture.OHZZI;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
-
 import com.woowacourse.f12.config.JpaConfig;
-import java.util.List;
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
@@ -25,6 +11,18 @@ import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import java.util.List;
+
+import static com.woowacourse.f12.domain.member.CareerLevel.JUNIOR;
+import static com.woowacourse.f12.domain.member.CareerLevel.SENIOR;
+import static com.woowacourse.f12.domain.member.JobType.BACKEND;
+import static com.woowacourse.f12.domain.member.JobType.FRONTEND;
+import static com.woowacourse.f12.support.fixture.MemberFixture.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 @DataJpaTest
 @Import({JpaConfig.class})

--- a/backend/src/test/java/com/woowacourse/f12/presentation/member/MemberControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/member/MemberControllerTest.java
@@ -1,30 +1,5 @@
 package com.woowacourse.f12.presentation.member;
 
-import static com.woowacourse.f12.presentation.member.CareerLevelConstant.JUNIOR_CONSTANT;
-import static com.woowacourse.f12.presentation.member.CareerLevelConstant.NONE_CONSTANT;
-import static com.woowacourse.f12.presentation.member.JobTypeConstant.BACKEND_CONSTANT;
-import static com.woowacourse.f12.presentation.member.JobTypeConstant.ETC_CONSTANT;
-import static com.woowacourse.f12.support.fixture.InventoryProductFixtures.SELECTED_INVENTORY_PRODUCT;
-import static com.woowacourse.f12.support.fixture.MemberFixture.CORINNE;
-import static com.woowacourse.f12.support.fixture.ProductFixture.KEYBOARD_1;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.isNull;
-import static org.mockito.ArgumentMatchers.refEq;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.willDoNothing;
-import static org.mockito.BDDMockito.willThrow;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.woowacourse.f12.application.auth.JwtProvider;
 import com.woowacourse.f12.application.member.MemberService;
@@ -41,9 +16,6 @@ import com.woowacourse.f12.exception.badrequest.NotFollowingException;
 import com.woowacourse.f12.exception.badrequest.SelfFollowException;
 import com.woowacourse.f12.exception.notfound.MemberNotFoundException;
 import com.woowacourse.f12.presentation.PresentationTest;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -56,6 +28,27 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.woowacourse.f12.presentation.member.CareerLevelConstant.JUNIOR_CONSTANT;
+import static com.woowacourse.f12.presentation.member.CareerLevelConstant.NONE_CONSTANT;
+import static com.woowacourse.f12.presentation.member.JobTypeConstant.BACKEND_CONSTANT;
+import static com.woowacourse.f12.presentation.member.JobTypeConstant.ETC_CONSTANT;
+import static com.woowacourse.f12.support.fixture.InventoryProductFixtures.SELECTED_INVENTORY_PRODUCT;
+import static com.woowacourse.f12.support.fixture.MemberFixture.CORINNE;
+import static com.woowacourse.f12.support.fixture.ProductFixture.KEYBOARD_1;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(MemberController.class)
 class MemberControllerTest extends PresentationTest {
@@ -303,7 +296,7 @@ class MemberControllerTest extends PresentationTest {
         Pageable pageable = PageRequest.of(0, 10, Sort.by("id").descending());
         InventoryProduct inventoryProduct = SELECTED_INVENTORY_PRODUCT.생성(CORINNE.생성(1L),
                 KEYBOARD_1.생성(1L));
-        Member member = CORINNE.인벤토리를_추가해서_생성(1L, inventoryProduct);
+        Member member = CORINNE.인벤토리를_추가해서_생성(1L, List.of(inventoryProduct));
 
         MemberPageResponse memberPageResponse =
                 MemberPageResponse.ofByFollowingCondition(new SliceImpl<>(List.of(member), pageable, false),
@@ -331,7 +324,7 @@ class MemberControllerTest extends PresentationTest {
         Pageable pageable = PageRequest.of(0, 10, Sort.by("id").descending());
         InventoryProduct inventoryProduct = SELECTED_INVENTORY_PRODUCT.생성(CORINNE.생성(1L),
                 KEYBOARD_1.생성(1L));
-        Member member = CORINNE.인벤토리를_추가해서_생성(1L, inventoryProduct);
+        Member member = CORINNE.인벤토리를_추가해서_생성(1L, List.of(inventoryProduct));
         Long loggedInId = 2L;
         Following following = Following.builder()
                 .followerId(loggedInId)
@@ -387,7 +380,7 @@ class MemberControllerTest extends PresentationTest {
         Pageable pageable = PageRequest.of(0, 10, Sort.by("id").descending());
         InventoryProduct inventoryProduct = SELECTED_INVENTORY_PRODUCT.생성(CORINNE.생성(1L),
                 KEYBOARD_1.생성(1L));
-        Member member = CORINNE.인벤토리를_추가해서_생성(1L, inventoryProduct);
+        Member member = CORINNE.인벤토리를_추가해서_생성(1L, List.of(inventoryProduct));
 
         MemberPageResponse memberPageResponse =
                 MemberPageResponse.ofByFollowingCondition(new SliceImpl<>(List.of(member), pageable, false),

--- a/backend/src/test/java/com/woowacourse/f12/support/fixture/MemberFixture.java
+++ b/backend/src/test/java/com/woowacourse/f12/support/fixture/MemberFixture.java
@@ -1,17 +1,18 @@
 package com.woowacourse.f12.support.fixture;
 
-import static com.woowacourse.f12.domain.member.CareerLevel.JUNIOR;
-import static com.woowacourse.f12.domain.member.CareerLevel.SENIOR;
-import static com.woowacourse.f12.domain.member.JobType.BACKEND;
-import static com.woowacourse.f12.domain.member.JobType.FRONTEND;
-
 import com.woowacourse.f12.domain.inventoryproduct.InventoryProduct;
 import com.woowacourse.f12.domain.inventoryproduct.InventoryProducts;
 import com.woowacourse.f12.domain.member.CareerLevel;
 import com.woowacourse.f12.domain.member.JobType;
 import com.woowacourse.f12.domain.member.Member;
 import com.woowacourse.f12.dto.response.auth.GitHubProfileResponse;
+
 import java.util.List;
+
+import static com.woowacourse.f12.domain.member.CareerLevel.JUNIOR;
+import static com.woowacourse.f12.domain.member.CareerLevel.SENIOR;
+import static com.woowacourse.f12.domain.member.JobType.BACKEND;
+import static com.woowacourse.f12.domain.member.JobType.FRONTEND;
 
 public enum MemberFixture {
 
@@ -55,7 +56,7 @@ public enum MemberFixture {
         return new GitHubProfileResponse(this.gitHubId, this.name, this.imageUrl);
     }
 
-    public Member 인벤토리를_추가해서_생성(final Long id, final InventoryProduct... inventoryProducts) {
+    public Member 인벤토리를_추가해서_생성(final Long id, final List<InventoryProduct> inventoryProducts) {
         return Member.builder()
                 .id(id)
                 .gitHubId(this.gitHubId)
@@ -63,7 +64,19 @@ public enum MemberFixture {
                 .imageUrl(this.imageUrl)
                 .careerLevel(this.careerLevel)
                 .jobType(this.jobType)
-                .inventoryProducts(new InventoryProducts(List.of(inventoryProducts)))
+                .inventoryProducts(new InventoryProducts(inventoryProducts))
+                .build();
+    }
+
+    public Member 추가정보와_인벤토리를_추가해서_생성(final Long id, final CareerLevel careerLevel, final JobType jobType, final List<InventoryProduct> inventoryProducts) {
+        return Member.builder()
+                .id(id)
+                .gitHubId(this.gitHubId)
+                .name(this.name)
+                .imageUrl(this.imageUrl)
+                .careerLevel(careerLevel)
+                .jobType(jobType)
+                .inventoryProducts(new InventoryProducts(inventoryProducts))
                 .build();
     }
 


### PR DESCRIPTION
# 작업 내용
- InventoryProducts에 적용된 `@BatchSize`를 제거했다.
- InventoryProduct 내에서 Fetch EAGER 연관관계를 갖던 Product를 Fetch LAZY로 변경했다.
- 그 외, Product와 항상 같이 쓰이는 InventoryProduct 조회 쿼리에 대해서 Product와의 fetch join을 적용했다.