### PR TITLE
[BE] 로그아웃 API 구현

### DIFF
--- a/backend/src/docs/asciidoc/auth.adoc
+++ b/backend/src/docs/asciidoc/auth.adoc
@@ -16,3 +16,11 @@ operation::auth-login[snippets='http-request,http-response']
 - 40104, 40105
 
 operation::auth-issue-access-token[snippets='http-request,http-response']
+
+=== 로그아웃
+
+==== 발생 가능 에러
+
+- 40105
+
+operation::auth-logout[snippets='http-request,http-response']

--- a/backend/src/test/java/com/woowacourse/f12/acceptance/AuthAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/acceptance/AuthAcceptanceTest.java
@@ -53,4 +53,27 @@ class AuthAcceptanceTest extends AcceptanceTest {
                 () -> assertThat(refreshTokenResponse.header("Set-cookie")).contains("refreshToken")
         );
     }
+
+    @Test
+    void 로그인_된_상태에서_로그아웃한다() {
+        // given
+        ExtractableResponse<Response> response = GET_요청을_보낸다(
+                "/api/v1/login?code=" + CORINNE_GITHUB.getCode());
+        String refreshToken = response.header("Set-cookie").split("=")[1];
+
+        // when
+        String url = "/api/v1/logout";
+        ExtractableResponse<Response> refreshTokenResponse = RestAssured.given().log().all()
+                .when()
+                .cookie("refreshToken", refreshToken)
+                .get(url)
+                .then().log().all()
+                .extract();
+
+        // then
+        assertAll(
+                () -> assertThat(refreshTokenResponse.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value()),
+                () -> assertThat(refreshTokenResponse.header("Set-cookie")).contains("refreshToken", "Max-Age=0")
+        );
+    }
 }

--- a/backend/src/test/java/com/woowacourse/f12/presentation/auth/AuthControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/auth/AuthControllerTest.java
@@ -172,4 +172,27 @@ class AuthControllerTest extends PresentationTest {
 
         verify(authService).issueAccessToken(any());
     }
+
+    @Test
+    void 리프레시_토큰이_있는_상태에서_로그아웃_요청_시_리프레시_쿠키_제거() throws Exception {
+        // given, when
+        final ResultActions resultActions = mockMvc.perform(get("/api/v1/logout")
+                .cookie(new Cookie("refreshToken", "refreshTokenValue")));
+
+        // then
+        resultActions.andExpect(status().isNoContent())
+                .andExpect(cookie().maxAge("refreshToken", 0))
+                .andDo(document("auth-logout"))
+                .andDo(print());
+    }
+
+    @Test
+    void 리프레시_토큰이_없는_상태에서_로그아웃_요청_시_예외_발생() throws Exception {
+        // given, when
+        final ResultActions resultActions = mockMvc.perform(get("/api/v1/logout"));
+
+        // then
+        resultActions.andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.errorCode").value(ErrorCode.NOT_EXIST_REFRESH_TOKEN.getValue()));
+    }
 }


### PR DESCRIPTION
# issue: #610 

# 작업 내용
- 리프레시 토큰을 가진 상태로 로그아웃 요청 시 쿠키 속 리프레시 토큰 max-age 를 0으로 해서 반환
- 리프레시 토큰이 없는 상태로 로그아웃 요청 시 예외 발생