### PR TITLE
[Bugfix/FE] errorCode를 문자열로 수정

### DIFF
--- a/frontend/src/constants/messages.ts
+++ b/frontend/src/constants/messages.ts
@@ -1,4 +1,4 @@
-export const API_ERROR_MESSAGES = {
+export const API_ERROR_MESSAGES: Record<string, string> = {
   40000: '유효하지 않은 검색 요청입니다.',
   40001: '유효하지 않은 페이지입니다.',
   40002: '소셜 로그인에 실패했습니다.',

--- a/frontend/src/hooks/api/useAxios.tsx
+++ b/frontend/src/hooks/api/useAxios.tsx
@@ -46,7 +46,7 @@ function useAxios(): Return {
     const errorResponseBody = error.response.data;
 
     // setError보다 먼저 와야 오류 화면이 표시되지 않음
-    if (errorResponseBody.errorCode === 40104) {
+    if (errorResponseBody.errorCode === '40104') {
       return await reissueTokenAndRetry(error);
     }
 
@@ -57,7 +57,7 @@ function useAxios(): Return {
       throw new Error(API_ERROR_CODE_EXCEPTION_MESSAGES.NO_CODE);
     }
 
-    if (errorResponseBody.errorCode === 40105) {
+    if (errorResponseBody.errorCode === '40105') {
       throw new Error(FAILURE_MESSAGES.NO_REFRESH_TOKEN);
     }
 

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -177,7 +177,7 @@ const getAccessToken = (req, res, ctx) => {
   const { shadowToken } = req.cookies;
 
   if (shadowToken !== 'true') {
-    return res(ctx.status(401), ctx.json({ errorCode: 40105 }));
+    return res(ctx.status(401), ctx.json({ errorCode: '40105' }));
   }
 
   const response = {


### PR DESCRIPTION
# issue: #627 

# 작업 내용
- errorCode를 백엔드는 문자열로 프론트엔드는 숫자로 받고 있어서 일치할 수 없는 문제 발생
- 프론트 쪽을 문자열로 수정