### PR TITLE
[BugFix/BE] CORS exposeHeaders에 Set-Cookie 추가 (#631)

### DIFF
--- a/backend/src/main/java/com/woowacourse/f12/config/WebConfig.java
+++ b/backend/src/main/java/com/woowacourse/f12/config/WebConfig.java
@@ -37,7 +37,7 @@ public class WebConfig implements WebMvcConfigurer {
                 .allowedMethods(CORS_ALLOWED_METHODS.split(","))
                 .allowedOrigins(MAIN_SERVER_DOMAIN, MAIN_SERVER_WWW_DOMAIN, TEST_SERVER_DOMAIN, FRONTEND_LOCALHOST)
                 .allowCredentials(true)
-                .exposedHeaders(HttpHeaders.LOCATION);
+                .exposedHeaders(HttpHeaders.LOCATION, HttpHeaders.SET_COOKIE);
     }
 
     @Override

--- a/backend/src/test/java/com/woowacourse/f12/config/WebConfigTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/config/WebConfigTest.java
@@ -19,6 +19,7 @@ import org.springframework.test.web.servlet.MockMvc;
 class WebConfigTest {
 
     private static final String CORS_ALLOWED_METHODS = "GET,POST,HEAD,PUT,PATCH,DELETE,TRACE,OPTIONS";
+    private static final String CORS_ALLOWED_HEADERS = String.join(", ", HttpHeaders.LOCATION, HttpHeaders.SET_COOKIE);
 
     @Autowired
     private MockMvc mockMvc;
@@ -34,7 +35,7 @@ class WebConfigTest {
                 .andExpect(status().isOk())
                 .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, origin))
                 .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS, CORS_ALLOWED_METHODS))
-                .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS, HttpHeaders.LOCATION))
+                .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS, CORS_ALLOWED_HEADERS))
                 .andDo(print());
     }
 


### PR DESCRIPTION
# issue: closes #629 

# 작업 내용
- WebConfig CORS 설정에 exposeHeaders에 Set-Cookie 헤더 추가