### PR TITLE
[Bugfix/FE] inventory 훅에서 내 리뷰 목록 조회 시 토큰을 사용하도록 수정

### DIFF
--- a/frontend/src/hooks/useInventory.tsx
+++ b/frontend/src/hooks/useInventory.tsx
@@ -54,12 +54,12 @@ function useInventory({ memberId }: Props): Return {
   const ParamsWithMemberId = {
     ...CommonParams,
     url: ENDPOINTS.REVIEWS_BY_MEMBER_ID(Number(memberId)),
-    headers: hasToken ? { Authorization: `Bearer ${userData.token}` } : null,
   };
 
   const ParamsWithoutMemberId = {
     ...CommonParams,
     url: ENDPOINTS.MY_REVIEWS,
+    headers: hasToken ? { Authorization: `Bearer ${userData.token}` } : null,
   };
 
   const {


### PR DESCRIPTION
# 작업 내용
- 현재는 내 리뷰 목록 조회 요청에 토큰을 사용하도록 설정이 되어있지 않음