### PR TITLE
[FE] 프로필 카드의 링크를 a 태그에서 Link 컴포넌트로 변경

### DIFF
--- a/frontend/src/components/Profile/ProfileCard/ProfileCard.style.tsx
+++ b/frontend/src/components/Profile/ProfileCard/ProfileCard.style.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom';
 import styled, { css } from 'styled-components';
 
 export const Container = styled.div<{ index: number }>`
@@ -93,7 +94,7 @@ export const RightButton = styled.button`
   font-size: 1.5rem;
 `;
 
-export const LinkWrapper = styled.a``;
+export const LinkWrapper = styled(Link)``;
 
 export const ProfileViewButton = styled.button`
   border: none;

--- a/frontend/src/components/Profile/ProfileCard/ProfileCard.tsx
+++ b/frontend/src/components/Profile/ProfileCard/ProfileCard.tsx
@@ -130,7 +130,7 @@ function ProfileCard({
           <S.UserNameWrapper>
             <S.UserName>{gitHubId}</S.UserName>
             <S.LinkWrapper
-              href={`${GITHUB_URL}${gitHubId}`}
+              to={`${GITHUB_URL}${gitHubId}`}
               target="_blank"
               rel="noopener noreferrer"
             >
@@ -186,7 +186,7 @@ function ProfileCard({
             <NextSign />
           </S.RightButton>
         </S.InventoryWrapper>
-        <S.LinkWrapper href={`${ROUTES.PROFILE}/${id}`}>
+        <S.LinkWrapper to={`${ROUTES.PROFILE}/${id}`}>
           <S.ProfileViewButton>프로필 보기</S.ProfileViewButton>
         </S.LinkWrapper>
       </S.RightSection>


### PR DESCRIPTION
# issue: #637 

# 작업 내용
- 프로필 카드의 링크를 a 태그에서 Link 컴포넌트로 변경
