### PR TITLE
[Bugfix/FE] following 페이지가 비회원이 접근할 수 없도록 설정

### DIFF
--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -58,10 +58,12 @@ export const PAGES: Route[] = [
           { path: ROUTES.PRODUCTS, element: <Products /> },
           { path: `${ROUTES.PRODUCT}/:productId`, element: <Product /> },
           { path: ROUTES.PROFILE_SEARCH, element: <ProfileSearch /> },
-          { path: ROUTES.FOLLOWING, element: <ProfileSearch type="following" /> },
           { path: `${ROUTES.PROFILE}/:memberId`, element: <Profile /> },
 
-          USER_ROUTES([{ path: ROUTES.MY_PROFILE, element: <Profile /> }]),
+          USER_ROUTES([
+            { path: ROUTES.MY_PROFILE, element: <Profile /> },
+            { path: ROUTES.FOLLOWING, element: <ProfileSearch type="following" /> },
+          ]),
           NON_USER_ROUTES([
             {
               element: <NonUserRoutes />,


### PR DESCRIPTION
# 작업 내용
- following 페이지에 대한 private 루트 설정 누락으로 비회원이 접근 가능한 것을 수정