### PR TITLE
[BugFIx/BE] 리프레시 토큰 set cookie 헤더에 path, samesite, max age 설정

### DIFF
--- a/backend/src/main/java/com/woowacourse/f12/presentation/auth/RefreshTokenCookieProvider.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/auth/RefreshTokenCookieProvider.java
@@ -1,0 +1,53 @@
+package com.woowacourse.f12.presentation.auth;
+
+import com.woowacourse.f12.exception.unauthorized.RefreshTokenNotExistException;
+import java.time.Duration;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.server.Cookie.SameSite;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseCookie.ResponseCookieBuilder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.WebUtils;
+
+@Component
+public class RefreshTokenCookieProvider {
+
+    protected static final String REFRESH_TOKEN = "refreshToken";
+    private static final int REMOVAL_MAX_AGE = 0;
+
+    private final Long expiredTimeMillis;
+
+    public RefreshTokenCookieProvider(@Value("${security.refresh.expire-length}") final Long expiredTimeMillis) {
+        this.expiredTimeMillis = expiredTimeMillis;
+    }
+
+    public void setCookie(final HttpServletResponse response, final String value) {
+        final ResponseCookie responseCookie = createTokenCookieBuilder(value)
+                .maxAge(Duration.ofMillis(expiredTimeMillis))
+                .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, responseCookie.toString());
+    }
+
+    public void removeCookie(final HttpServletRequest request, final HttpServletResponse response) {
+        final Cookie cookie = WebUtils.getCookie(request, REFRESH_TOKEN);
+        if (cookie == null) {
+            throw new RefreshTokenNotExistException();
+        }
+        final ResponseCookie responseCookie = createTokenCookieBuilder(cookie.getValue())
+                .maxAge(REMOVAL_MAX_AGE)
+                .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, responseCookie.toString());
+    }
+
+    private ResponseCookieBuilder createTokenCookieBuilder(final String value) {
+        return ResponseCookie.from(REFRESH_TOKEN, value)
+                .httpOnly(true)
+                .secure(true)
+                .path("/")
+                .sameSite(SameSite.NONE.attributeValue());
+    }
+}

--- a/backend/src/test/java/com/woowacourse/f12/presentation/PresentationTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/PresentationTest.java
@@ -3,6 +3,7 @@ package com.woowacourse.f12.presentation;
 import com.woowacourse.f12.application.auth.JwtProvider;
 import com.woowacourse.f12.config.LoggingConfig;
 import com.woowacourse.f12.logging.ApiQueryCounter;
+import com.woowacourse.f12.presentation.auth.RefreshTokenCookieProvider;
 import com.woowacourse.f12.support.AuthTokenExtractor;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
@@ -11,6 +12,7 @@ import org.springframework.restdocs.RestDocumentationExtension;
 
 @AutoConfigureRestDocs
 @ExtendWith(RestDocumentationExtension.class)
-@Import({AuthTokenExtractor.class, JwtProvider.class, RestDocsConfig.class, LoggingConfig.class, ApiQueryCounter.class})
+@Import({AuthTokenExtractor.class, JwtProvider.class, RestDocsConfig.class, LoggingConfig.class, ApiQueryCounter.class,
+        RefreshTokenCookieProvider.class})
 public class PresentationTest {
 }

--- a/backend/src/test/java/com/woowacourse/f12/presentation/auth/RefreshTokenCookieProviderTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/auth/RefreshTokenCookieProviderTest.java
@@ -1,0 +1,77 @@
+package com.woowacourse.f12.presentation.auth;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+
+class RefreshTokenCookieProviderTest {
+
+    private static final int PER_SECOND = 1000;
+    private HttpServletRequest request;
+    private HttpServletResponse response;
+    private RefreshTokenCookieProvider provider;
+
+    @BeforeEach
+    void setUp() {
+        request = mock(HttpServletRequest.class);
+        response = mock(HttpServletResponse.class);
+    }
+
+    @Test
+    void 쿠키를_응답헤더에_세팅한다() {
+        // given
+        final long expiredTimeMillis = 1000L;
+        provider = new RefreshTokenCookieProvider(expiredTimeMillis);
+        final String refreshTokenValue = "refreshTokenValue";
+
+        // when
+        provider.setCookie(response, refreshTokenValue);
+
+        // then
+        verify(response)
+                .addHeader(eq(HttpHeaders.SET_COOKIE), argThat(
+                        argument -> argument.contains("refreshToken=" + refreshTokenValue)
+                                && argument.contains("Path=/")
+                                && argument.contains("Secure")
+                                && argument.contains("HttpOnly")
+                                && argument.contains("SameSite=None")
+                                && argument.contains("Max-Age=" + expiredTimeMillis / PER_SECOND))
+                );
+    }
+
+    @Test
+    void 쿠키_제거를_응답헤더에_세팅한다() {
+        // given
+        provider = new RefreshTokenCookieProvider(1000L);
+        String refreshTokenValue = "refreshTokenValue";
+        Cookie cookie = new Cookie("refreshToken", refreshTokenValue);
+        given(request.getCookies()).willReturn(new Cookie[]{cookie});
+
+        // when
+        provider.removeCookie(request, response);
+
+        // then
+        assertAll(
+                () -> verify(request).getCookies(),
+                () -> verify(response)
+                        .addHeader(eq(HttpHeaders.SET_COOKIE), argThat(
+                                argument -> argument.contains("refreshToken=" + refreshTokenValue)
+                                        && argument.contains("Path=/")
+                                        && argument.contains("Secure")
+                                        && argument.contains("HttpOnly")
+                                        && argument.contains("SameSite=None")
+                                        && argument.contains("Max-Age=0"))
+                        )
+        );
+    }
+}


### PR DESCRIPTION
# issue: closes #644 

# 작업 내용
- RefreshTokenCookieProvider를 통해 리프레시 토큰 set cookie 할 때 Path, same site, max age 설정
- 리프레시 토큰 쿠키 제거 시에도 RefreshTokenProvider를 활용.
