### PR TITLE
[BE] 제품 페이징 조회 세컨더리 정렬 기준 추가 기능

### DIFF
--- a/backend/src/main/java/com/woowacourse/f12/presentation/auth/RefreshTokenCookieProvider.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/auth/RefreshTokenCookieProvider.java
@@ -1,0 +1,53 @@
+package com.woowacourse.f12.presentation.auth;
+
+import com.woowacourse.f12.exception.unauthorized.RefreshTokenNotExistException;
+import java.time.Duration;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.server.Cookie.SameSite;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseCookie.ResponseCookieBuilder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.WebUtils;
+
+@Component
+public class RefreshTokenCookieProvider {
+
+    protected static final String REFRESH_TOKEN = "refreshToken";
+    private static final int REMOVAL_MAX_AGE = 0;
+
+    private final Long expiredTimeMillis;
+
+    public RefreshTokenCookieProvider(@Value("${security.refresh.expire-length}") final Long expiredTimeMillis) {
+        this.expiredTimeMillis = expiredTimeMillis;
+    }
+
+    public void setCookie(final HttpServletResponse response, final String value) {
+        final ResponseCookie responseCookie = createTokenCookieBuilder(value)
+                .maxAge(Duration.ofMillis(expiredTimeMillis))
+                .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, responseCookie.toString());
+    }
+
+    public void removeCookie(final HttpServletRequest request, final HttpServletResponse response) {
+        final Cookie cookie = WebUtils.getCookie(request, REFRESH_TOKEN);
+        if (cookie == null) {
+            throw new RefreshTokenNotExistException();
+        }
+        final ResponseCookie responseCookie = createTokenCookieBuilder(cookie.getValue())
+                .maxAge(REMOVAL_MAX_AGE)
+                .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, responseCookie.toString());
+    }
+
+    private ResponseCookieBuilder createTokenCookieBuilder(final String value) {
+        return ResponseCookie.from(REFRESH_TOKEN, value)
+                .httpOnly(true)
+                .secure(true)
+                .path("/")
+                .sameSite(SameSite.NONE.attributeValue());
+    }
+}

--- a/backend/src/test/java/com/woowacourse/f12/acceptance/ProductAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/acceptance/ProductAcceptanceTest.java
@@ -129,27 +129,29 @@ class ProductAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
-    void 리뷰_개수가_같은_상태에서_제품_목록을_리뷰가_많은_순서로_페이징하여_조회하면_id_역순으로_조회된다() {
+    void 리뷰_개수가_같은_상태에서_제품_목록을_리뷰가_많은_순서로_페이징하여_조회하면_평점_높은순_id_역순으로_조회된다() {
         // given
         Product product1 = 제품을_저장한다(KEYBOARD_1.생성());
         Product product2 = 제품을_저장한다(KEYBOARD_2.생성());
+        Product product3 = 제품을_저장한다(MOUSE_1.생성());
         MemberRequest memberRequest = new MemberRequest(SENIOR_CONSTANT, BACKEND_CONSTANT);
         String token = 코린.로그인을_한다().getToken();
         코린.로그인한_상태로(token).추가정보를_입력한다(memberRequest);
 
         코린.로그인한_상태로(token).리뷰를_작성한다(product1.getId(), REVIEW_RATING_5);
         코린.로그인한_상태로(token).리뷰를_작성한다(product2.getId(), REVIEW_RATING_3);
+        코린.로그인한_상태로(token).리뷰를_작성한다(product3.getId(), REVIEW_RATING_5);
 
         // when
         ExtractableResponse<Response> response = GET_요청을_보낸다(
-                "/api/v1/products?category=keyboard&page=0&size=2&sort=reviewCount,desc");
+                "/api/v1/products?page=0&size=3&sort=reviewCount,desc");
 
         // then
         assertAll(
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
                 () -> assertThat(response.as(ProductPageResponse.class).getItems())
                         .extracting("id")
-                        .containsExactly(product2.getId(), product1.getId()),
+                        .containsExactly(product3.getId(), product1.getId(), product2.getId()),
                 () -> assertThat(response.as(ProductPageResponse.class).isHasNext()).isFalse()
         );
     }

--- a/backend/src/test/java/com/woowacourse/f12/presentation/CustomPageableArgumentResolverTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/CustomPageableArgumentResolverTest.java
@@ -99,4 +99,38 @@ public class CustomPageableArgumentResolverTest extends PresentationTest {
         // then
         verify(productService).findBySearchConditions(refEq(productSearchRequest), eq(pageable));
     }
+
+    @Test
+    void 평점순으로_제품_조회_API_요청_시_리뷰순을_세컨더리_정렬_기준_추가() throws Exception {
+        // given
+        Pageable pageable = PageRequest.of(0, 10, Sort.by("rating", "reviewCount", "id").descending());
+        given(productService.findBySearchConditions(any(ProductSearchRequest.class), eq(pageable)))
+                .willReturn(ProductPageResponse.from(new SliceImpl<>(List.of())));
+
+        // when
+        mockMvc.perform(
+                        get("/api/v1/products?page=0&size=10&sort=rating,desc"))
+                .andExpect(status().isOk())
+                .andDo(print());
+
+        // then
+        verify(productService).findBySearchConditions(any(ProductSearchRequest.class), eq(pageable));
+    }
+
+    @Test
+    void 리뷰순으로_제품_조회_API_요청_시_평점순을_세컨더리_정렬_기준_추가() throws Exception {
+        // given
+        Pageable pageable = PageRequest.of(0, 10, Sort.by("reviewCount", "rating", "id").descending());
+        given(productService.findBySearchConditions(any(ProductSearchRequest.class), eq(pageable)))
+                .willReturn(ProductPageResponse.from(new SliceImpl<>(List.of())));
+
+        // when
+        mockMvc.perform(
+                        get("/api/v1/products?page=0&size=10&sort=reviewCount,desc"))
+                .andExpect(status().isOk())
+                .andDo(print());
+
+        // then
+        verify(productService).findBySearchConditions(any(ProductSearchRequest.class), eq(pageable));
+    }
 }

--- a/backend/src/test/java/com/woowacourse/f12/presentation/PresentationTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/PresentationTest.java
@@ -3,6 +3,7 @@ package com.woowacourse.f12.presentation;
 import com.woowacourse.f12.application.auth.JwtProvider;
 import com.woowacourse.f12.config.LoggingConfig;
 import com.woowacourse.f12.logging.ApiQueryCounter;
+import com.woowacourse.f12.presentation.auth.RefreshTokenCookieProvider;
 import com.woowacourse.f12.support.AuthTokenExtractor;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
@@ -11,6 +12,7 @@ import org.springframework.restdocs.RestDocumentationExtension;
 
 @AutoConfigureRestDocs
 @ExtendWith(RestDocumentationExtension.class)
-@Import({AuthTokenExtractor.class, JwtProvider.class, RestDocsConfig.class, LoggingConfig.class, ApiQueryCounter.class})
+@Import({AuthTokenExtractor.class, JwtProvider.class, RestDocsConfig.class, LoggingConfig.class, ApiQueryCounter.class,
+        RefreshTokenCookieProvider.class})
 public class PresentationTest {
 }

--- a/backend/src/test/java/com/woowacourse/f12/presentation/auth/RefreshTokenCookieProviderTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/auth/RefreshTokenCookieProviderTest.java
@@ -1,0 +1,77 @@
+package com.woowacourse.f12.presentation.auth;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+
+class RefreshTokenCookieProviderTest {
+
+    private static final int PER_SECOND = 1000;
+    private HttpServletRequest request;
+    private HttpServletResponse response;
+    private RefreshTokenCookieProvider provider;
+
+    @BeforeEach
+    void setUp() {
+        request = mock(HttpServletRequest.class);
+        response = mock(HttpServletResponse.class);
+    }
+
+    @Test
+    void 쿠키를_응답헤더에_세팅한다() {
+        // given
+        final long expiredTimeMillis = 1000L;
+        provider = new RefreshTokenCookieProvider(expiredTimeMillis);
+        final String refreshTokenValue = "refreshTokenValue";
+
+        // when
+        provider.setCookie(response, refreshTokenValue);
+
+        // then
+        verify(response)
+                .addHeader(eq(HttpHeaders.SET_COOKIE), argThat(
+                        argument -> argument.contains("refreshToken=" + refreshTokenValue)
+                                && argument.contains("Path=/")
+                                && argument.contains("Secure")
+                                && argument.contains("HttpOnly")
+                                && argument.contains("SameSite=None")
+                                && argument.contains("Max-Age=" + expiredTimeMillis / PER_SECOND))
+                );
+    }
+
+    @Test
+    void 쿠키_제거를_응답헤더에_세팅한다() {
+        // given
+        provider = new RefreshTokenCookieProvider(1000L);
+        String refreshTokenValue = "refreshTokenValue";
+        Cookie cookie = new Cookie("refreshToken", refreshTokenValue);
+        given(request.getCookies()).willReturn(new Cookie[]{cookie});
+
+        // when
+        provider.removeCookie(request, response);
+
+        // then
+        assertAll(
+                () -> verify(request).getCookies(),
+                () -> verify(response)
+                        .addHeader(eq(HttpHeaders.SET_COOKIE), argThat(
+                                argument -> argument.contains("refreshToken=" + refreshTokenValue)
+                                        && argument.contains("Path=/")
+                                        && argument.contains("Secure")
+                                        && argument.contains("HttpOnly")
+                                        && argument.contains("SameSite=None")
+                                        && argument.contains("Max-Age=0"))
+                        )
+        );
+    }
+}

--- a/backend/src/test/java/com/woowacourse/f12/presentation/product/ProductControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/product/ProductControllerTest.java
@@ -57,7 +57,7 @@ class ProductControllerTest extends PresentationTest {
     void 키보드_목록_페이지_조회_성공() throws Exception {
         // given
         ProductSearchRequest productSearchRequest = new ProductSearchRequest(null, KEYBOARD_CONSTANT);
-        Pageable pageable = PageRequest.of(0, 150, Sort.by("rating", "id").descending());
+        Pageable pageable = PageRequest.of(0, 150, Sort.by("rating", "reviewCount", "id").descending());
         given(productService.findBySearchConditions(any(ProductSearchRequest.class), any(Pageable.class)))
                 .willReturn(ProductPageResponse.from(new SliceImpl<>(List.of(KEYBOARD_1.생성(1L)))));
 
@@ -76,7 +76,7 @@ class ProductControllerTest extends PresentationTest {
     void 제품_목록_페이지_조회_성공() throws Exception {
         // given
         ProductSearchRequest productSearchRequest = new ProductSearchRequest(null, null);
-        Pageable pageable = PageRequest.of(0, 150, Sort.by("rating", "id").descending());
+        Pageable pageable = PageRequest.of(0, 150, Sort.by("rating", "reviewCount", "id").descending());
         given(productService.findBySearchConditions(any(ProductSearchRequest.class), any(Pageable.class)))
                 .willReturn(ProductPageResponse.from(new SliceImpl<>(List.of(KEYBOARD_1.생성(1L)))));
 


### PR DESCRIPTION
# issue: #647 

# 작업 내용
- CustomPageableArgumentResolver 에서 `/api/v1/products` 로 제품 페이징 조회 요청 시 정렬 기준에 `rating` 이 존재하면 세컨더리 정렬 기준으로 `reviewCount`를 추가하고, `reviewCount`가 존재하면 `rating`이 세컨더리 정렬 기준으로 추가되도록 구현.
- 추가된 기능에 맞게 테스트 수정