### PR TITLE
[Feature/BE] 제품 페이징 조회 세컨더리 정렬 기준 추가 기능 (#649)

### DIFF
--- a/backend/src/test/java/com/woowacourse/f12/acceptance/ProductAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/acceptance/ProductAcceptanceTest.java
@@ -129,27 +129,29 @@ class ProductAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
-    void 리뷰_개수가_같은_상태에서_제품_목록을_리뷰가_많은_순서로_페이징하여_조회하면_id_역순으로_조회된다() {
+    void 리뷰_개수가_같은_상태에서_제품_목록을_리뷰가_많은_순서로_페이징하여_조회하면_평점_높은순_id_역순으로_조회된다() {
         // given
         Product product1 = 제품을_저장한다(KEYBOARD_1.생성());
         Product product2 = 제품을_저장한다(KEYBOARD_2.생성());
+        Product product3 = 제품을_저장한다(MOUSE_1.생성());
         MemberRequest memberRequest = new MemberRequest(SENIOR_CONSTANT, BACKEND_CONSTANT);
         String token = 코린.로그인을_한다().getToken();
         코린.로그인한_상태로(token).추가정보를_입력한다(memberRequest);
 
         코린.로그인한_상태로(token).리뷰를_작성한다(product1.getId(), REVIEW_RATING_5);
         코린.로그인한_상태로(token).리뷰를_작성한다(product2.getId(), REVIEW_RATING_3);
+        코린.로그인한_상태로(token).리뷰를_작성한다(product3.getId(), REVIEW_RATING_5);
 
         // when
         ExtractableResponse<Response> response = GET_요청을_보낸다(
-                "/api/v1/products?category=keyboard&page=0&size=2&sort=reviewCount,desc");
+                "/api/v1/products?page=0&size=3&sort=reviewCount,desc");
 
         // then
         assertAll(
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
                 () -> assertThat(response.as(ProductPageResponse.class).getItems())
                         .extracting("id")
-                        .containsExactly(product2.getId(), product1.getId()),
+                        .containsExactly(product3.getId(), product1.getId(), product2.getId()),
                 () -> assertThat(response.as(ProductPageResponse.class).isHasNext()).isFalse()
         );
     }

--- a/backend/src/test/java/com/woowacourse/f12/presentation/CustomPageableArgumentResolverTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/CustomPageableArgumentResolverTest.java
@@ -99,4 +99,38 @@ public class CustomPageableArgumentResolverTest extends PresentationTest {
         // then
         verify(productService).findBySearchConditions(refEq(productSearchRequest), eq(pageable));
     }
+
+    @Test
+    void 평점순으로_제품_조회_API_요청_시_리뷰순을_세컨더리_정렬_기준_추가() throws Exception {
+        // given
+        Pageable pageable = PageRequest.of(0, 10, Sort.by("rating", "reviewCount", "id").descending());
+        given(productService.findBySearchConditions(any(ProductSearchRequest.class), eq(pageable)))
+                .willReturn(ProductPageResponse.from(new SliceImpl<>(List.of())));
+
+        // when
+        mockMvc.perform(
+                        get("/api/v1/products?page=0&size=10&sort=rating,desc"))
+                .andExpect(status().isOk())
+                .andDo(print());
+
+        // then
+        verify(productService).findBySearchConditions(any(ProductSearchRequest.class), eq(pageable));
+    }
+
+    @Test
+    void 리뷰순으로_제품_조회_API_요청_시_평점순을_세컨더리_정렬_기준_추가() throws Exception {
+        // given
+        Pageable pageable = PageRequest.of(0, 10, Sort.by("reviewCount", "rating", "id").descending());
+        given(productService.findBySearchConditions(any(ProductSearchRequest.class), eq(pageable)))
+                .willReturn(ProductPageResponse.from(new SliceImpl<>(List.of())));
+
+        // when
+        mockMvc.perform(
+                        get("/api/v1/products?page=0&size=10&sort=reviewCount,desc"))
+                .andExpect(status().isOk())
+                .andDo(print());
+
+        // then
+        verify(productService).findBySearchConditions(any(ProductSearchRequest.class), eq(pageable));
+    }
 }

--- a/backend/src/test/java/com/woowacourse/f12/presentation/product/ProductControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/product/ProductControllerTest.java
@@ -57,7 +57,7 @@ class ProductControllerTest extends PresentationTest {
     void 키보드_목록_페이지_조회_성공() throws Exception {
         // given
         ProductSearchRequest productSearchRequest = new ProductSearchRequest(null, KEYBOARD_CONSTANT);
-        Pageable pageable = PageRequest.of(0, 150, Sort.by("rating", "id").descending());
+        Pageable pageable = PageRequest.of(0, 150, Sort.by("rating", "reviewCount", "id").descending());
         given(productService.findBySearchConditions(any(ProductSearchRequest.class), any(Pageable.class)))
                 .willReturn(ProductPageResponse.from(new SliceImpl<>(List.of(KEYBOARD_1.생성(1L)))));
 
@@ -76,7 +76,7 @@ class ProductControllerTest extends PresentationTest {
     void 제품_목록_페이지_조회_성공() throws Exception {
         // given
         ProductSearchRequest productSearchRequest = new ProductSearchRequest(null, null);
-        Pageable pageable = PageRequest.of(0, 150, Sort.by("rating", "id").descending());
+        Pageable pageable = PageRequest.of(0, 150, Sort.by("rating", "reviewCount", "id").descending());
         given(productService.findBySearchConditions(any(ProductSearchRequest.class), any(Pageable.class)))
                 .willReturn(ProductPageResponse.from(new SliceImpl<>(List.of(KEYBOARD_1.생성(1L)))));
 


### PR DESCRIPTION
# issue: closes #647 

# 작업 내용
- CustomPageableArgumentResolver 에서 `/api/v1/products` 로 제품 페이징 조회 요청 시 정렬 기준에 `rating` 이 존재하면 세컨더리 정렬 기준으로 `reviewCount`를 추가하고, `reviewCount`가 존재하면 `rating`이 세컨더리 정렬 기준으로 추가되도록 구현.
- 추가된 기능에 맞게 테스트 수정