### PR TITLE
[BE] Member 조회에 대한 쿼리 성능을 개선

### DIFF
--- a/backend/src/main/java/com/woowacourse/f12/application/member/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/member/MemberService.java
@@ -97,9 +97,6 @@ public class MemberService {
         if (memberSearchRequest.getQuery() == null && careerLevel == null && jobType == null) {
             return memberRepository.findWithOutSearchConditions(pageable);
         }
-        if (memberSearchRequest.getQuery() == null && careerLevel != null && jobType != null) {
-            return memberRepository.findWithOnlyOptions(careerLevel, jobType, pageable);
-        }
         return memberRepository.findWithSearchConditions(memberSearchRequest.getQuery(), careerLevel,
                 jobType, pageable);
     }
@@ -187,9 +184,6 @@ public class MemberService {
         final JobType jobType = parseJobType(memberSearchRequest);
         if (memberSearchRequest.getQuery() == null && careerLevel == null && jobType == null) {
             return memberRepository.findFollowingsWithOutSearchConditions(loggedInId, pageable);
-        }
-        if (memberSearchRequest.getQuery() == null && careerLevel != null && jobType != null) {
-            return memberRepository.findFollowingsWithOnlyOptions(loggedInId, careerLevel, jobType, pageable);
         }
         return memberRepository.findFollowingsWithSearchConditions(loggedInId, memberSearchRequest.getQuery(),
                 careerLevel, jobType, pageable);

--- a/backend/src/main/java/com/woowacourse/f12/application/member/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/member/MemberService.java
@@ -3,7 +3,12 @@ package com.woowacourse.f12.application.member;
 
 import com.woowacourse.f12.domain.inventoryproduct.InventoryProduct;
 import com.woowacourse.f12.domain.inventoryproduct.InventoryProductRepository;
-import com.woowacourse.f12.domain.member.*;
+import com.woowacourse.f12.domain.member.CareerLevel;
+import com.woowacourse.f12.domain.member.Following;
+import com.woowacourse.f12.domain.member.FollowingRepository;
+import com.woowacourse.f12.domain.member.JobType;
+import com.woowacourse.f12.domain.member.Member;
+import com.woowacourse.f12.domain.member.MemberRepository;
 import com.woowacourse.f12.dto.request.member.MemberRequest;
 import com.woowacourse.f12.dto.request.member.MemberSearchRequest;
 import com.woowacourse.f12.dto.response.member.LoggedInMemberResponse;
@@ -14,15 +19,14 @@ import com.woowacourse.f12.exception.badrequest.NotFollowingException;
 import com.woowacourse.f12.exception.notfound.MemberNotFoundException;
 import com.woowacourse.f12.presentation.member.CareerLevelConstant;
 import com.woowacourse.f12.presentation.member.JobTypeConstant;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
 
 @Service
 @Transactional(readOnly = true)
@@ -34,7 +38,8 @@ public class MemberService {
     private final FollowingRepository followingRepository;
     private final InventoryProductRepository inventoryProductRepository;
 
-    public MemberService(final MemberRepository memberRepository, final FollowingRepository followingRepository, final InventoryProductRepository inventoryProductRepository) {
+    public MemberService(final MemberRepository memberRepository, final FollowingRepository followingRepository,
+                         final InventoryProductRepository inventoryProductRepository) {
         this.memberRepository = memberRepository;
         this.followingRepository = followingRepository;
         this.inventoryProductRepository = inventoryProductRepository;
@@ -73,23 +78,26 @@ public class MemberService {
                 .orElseThrow(MemberNotFoundException::new);
     }
 
-    public MemberPageResponse findByContains(@Nullable final Long loggedInId, final MemberSearchRequest memberSearchRequest, final Pageable pageable) {
-        final CareerLevel careerLevel = parseCareerLevel(memberSearchRequest);
-        final JobType jobType = parseJobType(memberSearchRequest);
-        final Slice<Member> slice = getSlice(memberSearchRequest, pageable, careerLevel, jobType);
+    public MemberPageResponse findByContains(@Nullable final Long loggedInId,
+                                             final MemberSearchRequest memberSearchRequest, final Pageable pageable) {
+        final Slice<Member> slice = findBySearchConditions(memberSearchRequest, pageable);
         setInventoryProductsToMembers(slice);
         if (isNotLoggedIn(loggedInId)) {
             return MemberPageResponse.ofByFollowingCondition(slice, false);
         }
-        final List<Following> followings = followingRepository.findByFollowerIdAndFollowingIdIn(loggedInId, extractMemberIds(slice.getContent()));
+        final List<Following> followings = followingRepository.findByFollowerIdAndFollowingIdIn(loggedInId,
+                extractMemberIds(slice.getContent()));
         return MemberPageResponse.of(slice, followings);
     }
 
-    private Slice<Member> getSlice(final MemberSearchRequest memberSearchRequest, final Pageable pageable, final CareerLevel careerLevel, final JobType jobType) {
+    private Slice<Member> findBySearchConditions(final MemberSearchRequest memberSearchRequest,
+                                                 final Pageable pageable) {
+        final CareerLevel careerLevel = parseCareerLevel(memberSearchRequest);
+        final JobType jobType = parseJobType(memberSearchRequest);
         if (memberSearchRequest.getQuery() == null && careerLevel == null && jobType == null) {
             return memberRepository.findWithOutSearchConditions(pageable);
         }
-        if (memberSearchRequest.getQuery() == null && careerLevel != null && jobType != null){
+        if (memberSearchRequest.getQuery() == null && careerLevel != null && jobType != null) {
             return memberRepository.findWithOnlyOptions(careerLevel, jobType, pageable);
         }
         return memberRepository.findWithSearchConditions(memberSearchRequest.getQuery(), careerLevel,
@@ -97,7 +105,8 @@ public class MemberService {
     }
 
     private void setInventoryProductsToMembers(final Slice<Member> slice) {
-        final List<InventoryProduct> mixedInventoryProducts = inventoryProductRepository.findWithProductByMembers(slice.getContent());
+        final List<InventoryProduct> mixedInventoryProducts = inventoryProductRepository.findWithProductByMembers(
+                slice.getContent());
         for (Member member : slice.getContent()) {
             final List<InventoryProduct> memberInventoryProducts = mixedInventoryProducts.stream()
                     .filter(it -> it.getMember().isSameId(member.getId()))
@@ -166,8 +175,7 @@ public class MemberService {
     public MemberPageResponse findFollowingsByConditions(final Long loggedInId,
                                                          final MemberSearchRequest memberSearchRequest,
                                                          final Pageable pageable) {
-        final Slice<Member> slice = findFollowingsBySearchConditions(loggedInId,
-                memberSearchRequest, pageable);
+        final Slice<Member> slice = findFollowingsBySearchConditions(loggedInId, memberSearchRequest, pageable);
         setInventoryProductsToMembers(slice);
         return MemberPageResponse.ofByFollowingCondition(slice, true);
     }
@@ -177,7 +185,13 @@ public class MemberService {
                                                            final Pageable pageable) {
         final CareerLevel careerLevel = parseCareerLevel(memberSearchRequest);
         final JobType jobType = parseJobType(memberSearchRequest);
-        return memberRepository.findFollowingsBySearchConditions(loggedInId, memberSearchRequest.getQuery(),
+        if (memberSearchRequest.getQuery() == null && careerLevel == null && jobType == null) {
+            return memberRepository.findFollowingsWithOutSearchConditions(loggedInId, pageable);
+        }
+        if (memberSearchRequest.getQuery() == null && careerLevel != null && jobType != null) {
+            return memberRepository.findFollowingsWithOnlyOptions(loggedInId, careerLevel, jobType, pageable);
+        }
+        return memberRepository.findFollowingsWithSearchConditions(loggedInId, memberSearchRequest.getQuery(),
                 careerLevel, jobType, pageable);
     }
 }

--- a/backend/src/main/java/com/woowacourse/f12/application/review/ReviewService.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/review/ReviewService.java
@@ -20,11 +20,12 @@ import com.woowacourse.f12.exception.notfound.InventoryProductNotFoundException;
 import com.woowacourse.f12.exception.notfound.MemberNotFoundException;
 import com.woowacourse.f12.exception.notfound.ProductNotFoundException;
 import com.woowacourse.f12.exception.notfound.ReviewNotFoundException;
-import java.util.Objects;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Objects;
 
 @Service
 @Transactional(readOnly = true)
@@ -57,7 +58,7 @@ public class ReviewService {
     }
 
     private void validateRegisterCompleted(final Member member) {
-        if (!member.isRegisterCompleted()) {
+        if (!member.isRegistered()) {
             throw new RegisterNotCompletedException();
         }
     }

--- a/backend/src/main/java/com/woowacourse/f12/domain/member/Member.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/member/Member.java
@@ -31,6 +31,9 @@ public class Member {
     @Column(name = "image_url", length = 65535, nullable = false)
     private String imageUrl;
 
+    @Column(name = "registered", nullable = false)
+    private boolean registered;
+
     @Column(name = "career_level")
     @Enumerated(EnumType.STRING)
     private CareerLevel careerLevel;
@@ -49,12 +52,13 @@ public class Member {
     protected Member() {
     }
 
-    private Member(final Long id, final String gitHubId, final String name, final String imageUrl, final CareerLevel careerLevel,
+    private Member(final Long id, final String gitHubId, final String name, final String imageUrl, final boolean registered, final CareerLevel careerLevel,
                    final JobType jobType, final InventoryProducts inventoryProducts, final int followerCount) {
         this.id = id;
         this.gitHubId = gitHubId;
         this.name = name;
         this.imageUrl = imageUrl;
+        this.registered = registered;
         this.careerLevel = careerLevel;
         this.jobType = jobType;
         this.inventoryProducts = inventoryProducts;
@@ -66,6 +70,7 @@ public class Member {
         updateImageUrl(updateMember.imageUrl);
         updateCareerLevel(updateMember.careerLevel);
         updateJobType(updateMember.jobType);
+        updateRegistered(updateMember.registered);
     }
 
     private void updateName(final String name) {
@@ -92,8 +97,11 @@ public class Member {
         }
     }
 
-    public boolean isRegisterCompleted() {
-        return Objects.nonNull(this.careerLevel) && Objects.nonNull(this.jobType);
+    private void updateRegistered(final boolean registered) {
+        if (this.registered) {
+            return;
+        }
+        this.registered = registered;
     }
 
     public List<InventoryProduct> getProfileProduct() {

--- a/backend/src/main/java/com/woowacourse/f12/domain/member/MemberRepositoryCustom.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/member/MemberRepositoryCustom.java
@@ -7,14 +7,9 @@ public interface MemberRepositoryCustom {
 
     Slice<Member> findWithOutSearchConditions(Pageable pageable);
 
-    Slice<Member> findWithOnlyOptions(CareerLevel careerLevel, JobType jobType, Pageable pageable);
-
     Slice<Member> findWithSearchConditions(String keyword, CareerLevel careerLevel, JobType jobType, Pageable pageable);
 
     Slice<Member> findFollowingsWithOutSearchConditions(Long loggedInId, Pageable pageable);
-
-    Slice<Member> findFollowingsWithOnlyOptions(Long loggedInId, CareerLevel careerLevel, JobType jobType,
-                                                Pageable pageable);
 
     Slice<Member> findFollowingsWithSearchConditions(Long loggedInId, String keyword, CareerLevel careerLevel,
                                                      JobType jobType,

--- a/backend/src/main/java/com/woowacourse/f12/domain/member/MemberRepositoryCustom.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/member/MemberRepositoryCustom.java
@@ -11,6 +11,12 @@ public interface MemberRepositoryCustom {
 
     Slice<Member> findWithSearchConditions(String keyword, CareerLevel careerLevel, JobType jobType, Pageable pageable);
 
-    Slice<Member> findFollowingsBySearchConditions(Long loggedInId, String keyword, CareerLevel careerLevel, JobType jobType,
-                                                   Pageable pageable);
+    Slice<Member> findFollowingsWithOutSearchConditions(Long loggedInId, Pageable pageable);
+
+    Slice<Member> findFollowingsWithOnlyOptions(Long loggedInId, CareerLevel careerLevel, JobType jobType,
+                                                Pageable pageable);
+
+    Slice<Member> findFollowingsWithSearchConditions(Long loggedInId, String keyword, CareerLevel careerLevel,
+                                                     JobType jobType,
+                                                     Pageable pageable);
 }

--- a/backend/src/main/java/com/woowacourse/f12/domain/member/MemberRepositoryCustom.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/member/MemberRepositoryCustom.java
@@ -5,7 +5,11 @@ import org.springframework.data.domain.Slice;
 
 public interface MemberRepositoryCustom {
 
-    Slice<Member> findBySearchConditions(String keyword, CareerLevel careerLevel, JobType jobType, Pageable pageable);
+    Slice<Member> findWithOutSearchConditions(Pageable pageable);
+
+    Slice<Member> findWithOnlyOptions(CareerLevel careerLevel, JobType jobType, Pageable pageable);
+
+    Slice<Member> findWithSearchConditions(String keyword, CareerLevel careerLevel, JobType jobType, Pageable pageable);
 
     Slice<Member> findFollowingsBySearchConditions(Long loggedInId, String keyword, CareerLevel careerLevel, JobType jobType,
                                                    Pageable pageable);

--- a/backend/src/main/java/com/woowacourse/f12/domain/member/MemberRepositoryCustomImpl.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/member/MemberRepositoryCustomImpl.java
@@ -1,16 +1,14 @@
 package com.woowacourse.f12.domain.member;
 
-import static com.woowacourse.f12.domain.member.QFollowing.following;
-import static com.woowacourse.f12.domain.member.QMember.member;
-import static com.woowacourse.f12.support.RepositorySupport.makeOrderSpecifiers;
-import static com.woowacourse.f12.support.RepositorySupport.toContainsExpression;
-import static com.woowacourse.f12.support.RepositorySupport.toEqExpression;
-import static com.woowacourse.f12.support.RepositorySupport.toSlice;
-
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+
+import static com.woowacourse.f12.domain.member.QFollowing.following;
+import static com.woowacourse.f12.domain.member.QMember.member;
+import static com.woowacourse.f12.support.RepositorySupport.*;
 
 public class MemberRepositoryCustomImpl implements MemberRepositoryCustom {
 
@@ -20,9 +18,46 @@ public class MemberRepositoryCustomImpl implements MemberRepositoryCustom {
         this.jpaQueryFactory = jpaQueryFactory;
     }
 
-    public Slice<Member> findBySearchConditions(final String keyword, final CareerLevel careerLevel,
-                                                final JobType jobType,
-                                                final Pageable pageable) {
+    public Slice<Member> findWithOutSearchConditions(final Pageable pageable) {
+        final JPAQuery<Member> jpaQuery = jpaQueryFactory.selectFrom(member)
+                .where(toEqExpression(member.registered, true))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize() + 1)
+                .orderBy(makeOrderSpecifiers(member, pageable));
+
+        return toSlice(pageable, jpaQuery.fetch());
+    }
+
+    public Slice<Member> findWithOnlyOptions(final CareerLevel careerLevel, final JobType jobType, final Pageable pageable) {
+        final JPAQuery<Member> jpaQuery = jpaQueryFactory.selectFrom(member)
+                .where(
+                        eqCareerLevel(careerLevel),
+                        eqJobType(jobType)
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize() + 1)
+                .orderBy(makeOrderSpecifiers(member, pageable));
+
+        return toSlice(pageable, jpaQuery.fetch());
+    }
+
+    private BooleanExpression eqCareerLevel(final CareerLevel careerLevel) {
+        if (careerLevel == null) {
+            return member.careerLevel.isNotNull();
+        }
+        return member.careerLevel.eq(careerLevel);
+    }
+
+    private BooleanExpression eqJobType(final JobType jobType) {
+        if (jobType == null) {
+            return member.jobType.isNotNull();
+        }
+        return member.jobType.eq(jobType);
+    }
+
+    public Slice<Member> findWithSearchConditions(final String keyword, final CareerLevel careerLevel,
+                                                  final JobType jobType,
+                                                  final Pageable pageable) {
         final JPAQuery<Member> jpaQuery = jpaQueryFactory.selectFrom(member)
                 .where(
                         toContainsExpression(member.gitHubId, keyword),

--- a/backend/src/main/java/com/woowacourse/f12/dto/request/member/MemberRequest.java
+++ b/backend/src/main/java/com/woowacourse/f12/dto/request/member/MemberRequest.java
@@ -28,6 +28,7 @@ public class MemberRequest {
         return Member.builder()
                 .careerLevel(careerLevel.toCareerLevel())
                 .jobType(jobType.toJobType())
+                .registered(true)
                 .build();
     }
 }

--- a/backend/src/main/java/com/woowacourse/f12/dto/response/auth/LoginResponse.java
+++ b/backend/src/main/java/com/woowacourse/f12/dto/response/auth/LoginResponse.java
@@ -24,6 +24,6 @@ public class LoginResponse {
     public static LoginResponse from(final LoginResult loginResult) {
         final Member member = loginResult.getMember();
         final LoginMemberResponse loginMemberResponse = LoginMemberResponse.from(member);
-        return new LoginResponse(loginResult.getAccessToken(), member.isRegisterCompleted(), loginMemberResponse);
+        return new LoginResponse(loginResult.getAccessToken(), member.isRegistered(), loginMemberResponse);
     }
 }

--- a/backend/src/test/java/com/woowacourse/f12/acceptance/MemberAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/acceptance/MemberAcceptanceTest.java
@@ -215,7 +215,7 @@ class MemberAcceptanceTest extends AcceptanceTest {
         코린.로그인한_상태로(secondLoginResponse.getToken()).추가정보를_입력한다(memberRequest);
 
         // when
-        ExtractableResponse<Response> response = GET_요청을_보낸다("/api/v1/members?page=0&size=2");
+        ExtractableResponse<Response> response = GET_요청을_보낸다("/api/v1/members?page=0&size=2&sort=followerCount,desc");
 
         // then
         MemberPageResponse memberPageResponse = response.as(MemberPageResponse.class);

--- a/backend/src/test/java/com/woowacourse/f12/application/member/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/application/member/MemberServiceTest.java
@@ -179,7 +179,7 @@ class MemberServiceTest {
         InventoryProduct inventoryProduct = SELECTED_INVENTORY_PRODUCT.생성(CORINNE.생성(1L), KEYBOARD_1.생성(1L));
         Member member = CORINNE.인벤토리를_추가해서_생성(1L, List.of(inventoryProduct));
 
-        given(memberRepository.findWithOnlyOptions(SENIOR, BACKEND, pageable))
+        given(memberRepository.findWithSearchConditions(null, SENIOR, BACKEND, pageable))
                 .willReturn(new SliceImpl<>(List.of(member), pageable, false));
 
         // when
@@ -188,7 +188,7 @@ class MemberServiceTest {
 
         // then
         assertAll(
-                () -> verify(memberRepository).findWithOnlyOptions(SENIOR, BACKEND, pageable),
+                () -> verify(memberRepository).findWithSearchConditions(null, SENIOR, BACKEND, pageable),
                 () -> assertThat(memberPageResponse.isHasNext()).isFalse(),
                 () -> assertThat(memberPageResponse.getItems()).usingRecursiveFieldByFieldElementComparator()
                         .containsOnly(MemberWithProfileProductResponse.of(member, false)));
@@ -494,7 +494,7 @@ class MemberServiceTest {
         Member member = CORINNE.생성(2L);
         MemberSearchRequest memberSearchRequest = new MemberSearchRequest(null, SENIOR_CONSTANT, BACKEND_CONSTANT);
 
-        given(memberRepository.findFollowingsWithOnlyOptions(loggedInId, SENIOR, BACKEND, pageable))
+        given(memberRepository.findFollowingsWithSearchConditions(loggedInId, null, SENIOR, BACKEND, pageable))
                 .willReturn(new SliceImpl<>(List.of(member), pageable, false));
         given(inventoryProductRepository.findWithProductByMembers(List.of(member)))
                 .willReturn(Collections.emptyList());
@@ -505,7 +505,8 @@ class MemberServiceTest {
 
         // then
         assertAll(
-                () -> verify(memberRepository).findFollowingsWithOnlyOptions(loggedInId, SENIOR, BACKEND, pageable),
+                () -> verify(memberRepository).findFollowingsWithSearchConditions(loggedInId, null, SENIOR, BACKEND,
+                        pageable),
                 () -> verify(inventoryProductRepository).findWithProductByMembers(List.of(member)),
                 () -> assertThat(memberPageResponse.isHasNext()).isFalse(),
                 () -> assertThat(memberPageResponse.getItems()).usingRecursiveFieldByFieldElementComparator()

--- a/backend/src/test/java/com/woowacourse/f12/application/member/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/application/member/MemberServiceTest.java
@@ -24,7 +24,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.domain.Sort;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -135,14 +134,18 @@ class MemberServiceTest {
     @Test
     void 회원정보를_업데이트_한다() {
         // given
+        final Member corinne = CORINNE.생성(1L);
         given(memberRepository.findById(1L))
-                .willReturn(Optional.of(CORINNE.생성(1L)));
+                .willReturn(Optional.of(corinne));
 
         // when
         memberService.updateMember(1L, new MemberRequest(JUNIOR_CONSTANT, ETC_CONSTANT));
 
         // then
-        verify(memberRepository).findById(1L);
+        assertAll(
+                () -> verify(memberRepository).findById(1L),
+                () -> assertThat(corinne.isRegistered()).isTrue()
+        );
     }
 
     @Test

--- a/backend/src/test/java/com/woowacourse/f12/domain/member/MemberRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/domain/member/MemberRepositoryTest.java
@@ -81,7 +81,7 @@ class MemberRepositoryTest {
         memberRepository.saveAll(List.of(CORINNE.생성(), MINCHO.생성()));
 
         // when
-        final Slice<Member> slice = memberRepository.findWithOnlyOptions(SENIOR, null, PageRequest.of(0, 2));
+        Slice<Member> slice = memberRepository.findWithSearchConditions(null, SENIOR, null, PageRequest.of(0, 2));
 
         // then
         assertAll(
@@ -223,7 +223,7 @@ class MemberRepositoryTest {
                 .build();
 
         // when
-        Slice<Member> slice = memberRepository.findFollowingsWithOnlyOptions(corinne.getId(), null, FRONTEND,
+        Slice<Member> slice = memberRepository.findFollowingsWithSearchConditions(corinne.getId(), null, null, FRONTEND,
                 PageRequest.of(0, 1, Sort.by("id").descending()));
 
         // then

--- a/backend/src/test/java/com/woowacourse/f12/domain/member/MemberRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/domain/member/MemberRepositoryTest.java
@@ -63,7 +63,7 @@ class MemberRepositoryTest {
         memberRepository.saveAll(List.of(CORINNE.생성(), MINCHO.생성()));
 
         // when
-        Slice<Member> slice = memberRepository.findBySearchConditions(null, null, null, PageRequest.of(0, 2));
+        Slice<Member> slice = memberRepository.findWithOutSearchConditions(PageRequest.of(0, 2));
 
         // then
         assertAll(
@@ -74,12 +74,28 @@ class MemberRepositoryTest {
     }
 
     @Test
+    void 옵션만_입력하고_회원을_조회한다() {
+        // given
+        memberRepository.saveAll(List.of(CORINNE.생성(), MINCHO.생성()));
+
+        // when
+        final Slice<Member> slice = memberRepository.findWithOnlyOptions(SENIOR, null, PageRequest.of(0, 2));
+
+        // then
+        assertAll(
+                () -> assertThat(slice.hasNext()).isFalse(),
+                () -> assertThat(slice.getContent()).usingRecursiveFieldByFieldElementComparatorIgnoringFields("id")
+                        .containsOnly(CORINNE.생성())
+        );
+    }
+
+    @Test
     void 회원의_깃허브_아이디를_키워드로_조회한다() {
         // given
         memberRepository.saveAll(List.of(CORINNE.생성(), MINCHO.생성()));
 
         // when
-        Slice<Member> slice = memberRepository.findBySearchConditions("hamcheeseburger", null, null,
+        Slice<Member> slice = memberRepository.findWithSearchConditions("hamcheeseburger", null, null,
                 PageRequest.of(0, 2));
 
         // then
@@ -96,7 +112,7 @@ class MemberRepositoryTest {
         memberRepository.saveAll(List.of(CORINNE.생성(), MINCHO.생성()));
 
         // when
-        Slice<Member> slice = memberRepository.findBySearchConditions("cheese", null, null, PageRequest.of(0, 2));
+        Slice<Member> slice = memberRepository.findWithSearchConditions("cheese", null, null, PageRequest.of(0, 2));
 
         // then
         assertAll(
@@ -114,7 +130,7 @@ class MemberRepositoryTest {
         memberRepository.saveAll(List.of(CORINNE.생성(), MINCHO.생성()));
 
         // when
-        Slice<Member> slice = memberRepository.findBySearchConditions(keyword, SENIOR, null,
+        Slice<Member> slice = memberRepository.findWithSearchConditions(keyword, SENIOR, null,
                 PageRequest.of(0, 2));
 
         // then
@@ -133,7 +149,7 @@ class MemberRepositoryTest {
         memberRepository.saveAll(List.of(CORINNE.생성(), MINCHO.생성()));
 
         // when
-        Slice<Member> slice = memberRepository.findBySearchConditions(keyword, SENIOR, BACKEND,
+        Slice<Member> slice = memberRepository.findWithSearchConditions(keyword, SENIOR, BACKEND,
                 PageRequest.of(0, 2));
 
         // then
@@ -162,6 +178,7 @@ class MemberRepositoryTest {
                 .gitHubId(mincho.getGitHubId())
                 .name(mincho.getName())
                 .imageUrl(mincho.getImageUrl())
+                .registered(true)
                 .careerLevel(mincho.getCareerLevel())
                 .jobType(mincho.getJobType())
                 .followerCount(1)
@@ -185,7 +202,7 @@ class MemberRepositoryTest {
         memberRepository.save(NOT_ADDITIONAL_INFO.생성());
 
         // when
-        Slice<Member> slice = memberRepository.findBySearchConditions(null, null, null, PageRequest.of(0, 2));
+        Slice<Member> slice = memberRepository.findWithSearchConditions(null, null, null, PageRequest.of(0, 2));
 
         // then
         assertAll(

--- a/backend/src/test/java/com/woowacourse/f12/support/fixture/MemberFixture.java
+++ b/backend/src/test/java/com/woowacourse/f12/support/fixture/MemberFixture.java
@@ -16,23 +16,25 @@ import static com.woowacourse.f12.domain.member.JobType.FRONTEND;
 
 public enum MemberFixture {
 
-    CORINNE("hamcheeseburger", "유현지", "corinne_url", SENIOR, BACKEND),
-    MINCHO("jswith", "홍영민", "mincho_url", JUNIOR, FRONTEND),
-    OHZZI("Ohzzi", "오지훈", "Ohzzi_url", JUNIOR, BACKEND),
-    CORINNE_UPDATED("hamcheeseburger", "괴물개발자", "corinne_url", SENIOR, BACKEND),
-    NOT_ADDITIONAL_INFO("invalid", "invalid", "invalid", null, null);
+    CORINNE("hamcheeseburger", "유현지", "corinne_url", true, SENIOR, BACKEND),
+    MINCHO("jswith", "홍영민", "mincho_url", true, JUNIOR, FRONTEND),
+    OHZZI("Ohzzi", "오지훈", "Ohzzi_url", true, JUNIOR, BACKEND),
+    CORINNE_UPDATED("hamcheeseburger", "괴물개발자", "corinne_url", true, SENIOR, BACKEND),
+    NOT_ADDITIONAL_INFO("invalid", "invalid", "invalid", false, null, null);
 
     private final String gitHubId;
     private final String name;
     private final String imageUrl;
+    private final boolean registered;
     private final CareerLevel careerLevel;
     private final JobType jobType;
 
-    MemberFixture(final String gitHubId, final String name, final String imageUrl, final CareerLevel careerLevel,
+    MemberFixture(final String gitHubId, final String name, final String imageUrl, final boolean registered, final CareerLevel careerLevel,
                   final JobType jobType) {
         this.gitHubId = gitHubId;
         this.name = name;
         this.imageUrl = imageUrl;
+        this.registered = registered;
         this.careerLevel = careerLevel;
         this.jobType = jobType;
     }
@@ -47,6 +49,7 @@ public enum MemberFixture {
                 .gitHubId(this.gitHubId)
                 .name(this.name)
                 .imageUrl(this.imageUrl)
+                .registered(this.registered)
                 .careerLevel(this.careerLevel)
                 .jobType(this.jobType)
                 .build();
@@ -62,6 +65,7 @@ public enum MemberFixture {
                 .gitHubId(this.gitHubId)
                 .name(this.name)
                 .imageUrl(this.imageUrl)
+                .registered(this.registered)
                 .careerLevel(this.careerLevel)
                 .jobType(this.jobType)
                 .inventoryProducts(new InventoryProducts(inventoryProducts))
@@ -99,6 +103,7 @@ public enum MemberFixture {
                 .gitHubId(this.gitHubId)
                 .name(this.name)
                 .imageUrl(this.imageUrl)
+                .registered(this.registered)
                 .careerLevel(careerLevel)
                 .jobType(jobType)
                 .build();


### PR DESCRIPTION
# issue: #615

# 작업 내용
- Member 조회에 대한 쿼리 성능을 개선
- 전체 유저 검색
  - 키워드, 옵션이 없으면 커버링 인덱스 사용
  - 키워드, 혹은 옵션이 1개라도 있으면 where 절 사용
  - 옵션이 2개가 있다면 index를 타면서 매우 빠름
- 팔로잉 유저 검색
  - 팔로잉 유저에 대해서 미리 쿼리를 날려서 index를 이용해서 자르고 시작
  - 키워드, 옵션이 없으면 registered 사용해서 인덱스 탄다.
  - 키워드, 옵션이 1개라도 있으면 where 사용
  - 옵션이 2개가 있다면 index를 탄다.