### PR TITLE
[BE] 프로덕트 검색 조회 쿼리를 개선한다

### DIFF
--- a/backend/src/main/java/com/woowacourse/f12/application/product/ProductService.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/product/ProductService.java
@@ -18,7 +18,6 @@ import com.woowacourse.f12.presentation.product.CategoryConstant;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -42,10 +41,19 @@ public class ProductService {
         return ProductResponse.from(product);
     }
 
-    public ProductPageResponse findBySearchConditions(final ProductSearchRequest productSearchRequest, final Pageable pageable) {
-        final Category category = parseCategory(productSearchRequest);
-        final Slice<Product> slice = productRepository.findBySearchConditions(productSearchRequest.getQuery(), category, pageable);
+    public ProductPageResponse findBySearchConditions(final ProductSearchRequest productSearchRequest,
+                                                      final Pageable pageable) {
+        final Slice<Product> slice = findProductBySearchConditions(productSearchRequest, pageable);
         return ProductPageResponse.from(slice);
+    }
+
+    private Slice<Product> findProductBySearchConditions(final ProductSearchRequest productSearchRequest,
+                                                         final Pageable pageable) {
+        final Category category = parseCategory(productSearchRequest);
+        if (productSearchRequest.getQuery() == null && category == null) {
+            return productRepository.findWithoutSearchConditions(pageable);
+        }
+        return productRepository.findWithSearchConditions(productSearchRequest.getQuery(), category, pageable);
     }
 
     private Category parseCategory(final ProductSearchRequest productSearchRequest) {

--- a/backend/src/main/java/com/woowacourse/f12/application/review/ReviewService.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/review/ReviewService.java
@@ -65,7 +65,6 @@ public class ReviewService {
     private Long saveReview(final ReviewRequest reviewRequest, final Member member, final Product product) {
         validateNotWritten(member, product);
         final Review review = reviewRequest.toReview(product, member);
-        product.reflectReview(review);
         return reviewRepository.save(review)
                 .getId();
     }

--- a/backend/src/main/java/com/woowacourse/f12/domain/product/Product.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/product/Product.java
@@ -1,7 +1,5 @@
 package com.woowacourse.f12.domain.product;
 
-import com.woowacourse.f12.domain.review.Review;
-import com.woowacourse.f12.exception.internalserver.InvalidReflectReviewException;
 import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -65,17 +63,18 @@ public class Product {
         return this.category == category;
     }
 
-    public void reflectReview(final Review review) {
-        validateWrittenAboutThis(review);
-        reviewCount++;
-        totalRating += review.getRating();
-        rating = (double) totalRating / reviewCount;
+    public void reflectReviewRating(final int reviewRating) {
+        increaseReviewCount();
+        calculateRatings(reviewRating);
     }
 
-    private void validateWrittenAboutThis(final Review review) {
-        if (!review.isWrittenAbout(this)) {
-            throw new InvalidReflectReviewException();
-        }
+    private void increaseReviewCount() {
+        reviewCount++;
+    }
+
+    private void calculateRatings(final int reviewRating) {
+        totalRating += reviewRating;
+        rating = (double) totalRating / reviewCount;
     }
 
     @Override

--- a/backend/src/main/java/com/woowacourse/f12/domain/product/ProductRepositoryCustom.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/product/ProductRepositoryCustom.java
@@ -5,7 +5,7 @@ import org.springframework.data.domain.Slice;
 
 public interface ProductRepositoryCustom {
 
-    Slice<Product> findBySearchConditions(String keyword, Category category, Pageable pageable);
-
     Slice<Product> findWithoutSearchConditions(Pageable pageable);
+
+    Slice<Product> findWithSearchConditions(String keyword, Category category, Pageable pageable);
 }

--- a/backend/src/main/java/com/woowacourse/f12/domain/product/ProductRepositoryCustom.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/product/ProductRepositoryCustom.java
@@ -6,4 +6,6 @@ import org.springframework.data.domain.Slice;
 public interface ProductRepositoryCustom {
 
     Slice<Product> findBySearchConditions(String keyword, Category category, Pageable pageable);
+
+    Slice<Product> findWithoutSearchConditions(Pageable pageable);
 }

--- a/backend/src/main/java/com/woowacourse/f12/domain/product/ProductRepositoryCustomImpl.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/product/ProductRepositoryCustomImpl.java
@@ -1,12 +1,18 @@
 package com.woowacourse.f12.domain.product;
 
+import static com.woowacourse.f12.domain.product.QProduct.product;
+import static com.woowacourse.f12.support.RepositorySupport.makeOrderSpecifiers;
+import static com.woowacourse.f12.support.RepositorySupport.toContainsExpression;
+import static com.woowacourse.f12.support.RepositorySupport.toEqExpression;
+import static com.woowacourse.f12.support.RepositorySupport.toSlice;
+
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.ArrayList;
+import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
-
-import static com.woowacourse.f12.domain.product.QProduct.product;
-import static com.woowacourse.f12.support.RepositorySupport.*;
+import org.springframework.data.domain.SliceImpl;
 
 public class ProductRepositoryCustomImpl implements ProductRepositoryCustom {
 
@@ -17,7 +23,8 @@ public class ProductRepositoryCustomImpl implements ProductRepositoryCustom {
     }
 
     @Override
-    public Slice<Product> findBySearchConditions(final String keyword, final Category category, final Pageable pageable) {
+    public Slice<Product> findBySearchConditions(final String keyword, final Category category,
+                                                 final Pageable pageable) {
         final JPAQuery<Product> jpaQuery = jpaQueryFactory.selectFrom(product)
                 .where(
                         toContainsExpression(product.name, keyword),
@@ -25,6 +32,25 @@ public class ProductRepositoryCustomImpl implements ProductRepositoryCustom {
                 )
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize() + 1)
+                .orderBy(makeOrderSpecifiers(product, pageable));
+        return toSlice(pageable, jpaQuery.fetch());
+    }
+
+    @Override
+    public Slice<Product> findWithoutSearchConditions(final Pageable pageable) {
+        final List<Long> ids = jpaQueryFactory.select(product.id)
+                .from(product)
+                .orderBy(makeOrderSpecifiers(product, pageable))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize() + 1)
+                .fetch();
+
+        if (ids.isEmpty()) {
+            return new SliceImpl<>(new ArrayList<>(), pageable, false);
+        }
+
+        final JPAQuery<Product> jpaQuery = jpaQueryFactory.selectFrom(product)
+                .where(product.id.in(ids))
                 .orderBy(makeOrderSpecifiers(product, pageable));
         return toSlice(pageable, jpaQuery.fetch());
     }

--- a/backend/src/main/java/com/woowacourse/f12/domain/product/ProductRepositoryCustomImpl.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/product/ProductRepositoryCustomImpl.java
@@ -8,8 +8,7 @@ import static com.woowacourse.f12.support.RepositorySupport.toSlice;
 
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Collections;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
@@ -23,34 +22,35 @@ public class ProductRepositoryCustomImpl implements ProductRepositoryCustom {
     }
 
     @Override
-    public Slice<Product> findBySearchConditions(final String keyword, final Category category,
-                                                 final Pageable pageable) {
-        final JPAQuery<Product> jpaQuery = jpaQueryFactory.selectFrom(product)
-                .where(
-                        toContainsExpression(product.name, keyword),
-                        toEqExpression(product.category, category)
-                )
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize() + 1)
-                .orderBy(makeOrderSpecifiers(product, pageable));
-        return toSlice(pageable, jpaQuery.fetch());
-    }
-
-    @Override
     public Slice<Product> findWithoutSearchConditions(final Pageable pageable) {
-        final List<Long> ids = jpaQueryFactory.select(product.id)
+        final JPAQuery<Long> jpaLongQuery = jpaQueryFactory.select(product.id)
                 .from(product)
                 .orderBy(makeOrderSpecifiers(product, pageable))
                 .offset(pageable.getOffset())
-                .limit(pageable.getPageSize() + 1)
-                .fetch();
+                .limit(pageable.getPageSize() + 1);
 
-        if (ids.isEmpty()) {
-            return new SliceImpl<>(new ArrayList<>(), pageable, false);
+        final Slice<Long> slice = toSlice(pageable, jpaLongQuery.fetch());
+        if (slice.isEmpty()) {
+            return new SliceImpl<>(Collections.emptyList(), pageable, false);
         }
 
         final JPAQuery<Product> jpaQuery = jpaQueryFactory.selectFrom(product)
-                .where(product.id.in(ids))
+                .where(product.id.in(slice.getContent()))
+                .orderBy(makeOrderSpecifiers(product, pageable));
+
+        return new SliceImpl<>(jpaQuery.fetch(), pageable, slice.hasNext());
+    }
+
+    @Override
+    public Slice<Product> findWithSearchConditions(final String keyword, final Category category,
+                                                   final Pageable pageable) {
+        final JPAQuery<Product> jpaQuery = jpaQueryFactory.selectFrom(product)
+                .where(
+                        toEqExpression(product.category, category),
+                        toContainsExpression(product.name, keyword)
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize() + 1)
                 .orderBy(makeOrderSpecifiers(product, pageable));
         return toSlice(pageable, jpaQuery.fetch());
     }

--- a/backend/src/main/java/com/woowacourse/f12/domain/review/Review.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/review/Review.java
@@ -68,6 +68,7 @@ public class Review {
         this.product = product;
         this.member = member;
         this.createdAt = createdAt;
+        reflectToProduct();
     }
 
     private void validateContent(final String content) {
@@ -85,12 +86,12 @@ public class Review {
         }
     }
 
-    public boolean isWrittenBy(final Member member) {
-        return this.member.equals(member);
+    private void reflectToProduct() {
+        product.reflectReviewRating(rating);
     }
 
-    public boolean isWrittenAbout(final Product product) {
-        return this.product.equals(product);
+    public boolean isWrittenBy(final Member member) {
+        return this.member.equals(member);
     }
 
     public void update(final Review updateReview) {

--- a/backend/src/test/java/com/woowacourse/f12/acceptance/ProductAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/acceptance/ProductAcceptanceTest.java
@@ -61,7 +61,7 @@ class ProductAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
-    void 모든_제품_목록을_페이징하여_조회한다() {
+    void 모든_제품_목록을_키워드와_옵션없이_페이징하여_조회한다() {
         // given
         제품을_저장한다(KEYBOARD_1.생성());
         Product product = 제품을_저장한다(MOUSE_1.생성());

--- a/backend/src/test/java/com/woowacourse/f12/application/product/ProductServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/application/product/ProductServiceTest.java
@@ -118,11 +118,32 @@ class ProductServiceTest {
     }
 
     @Test
+    void 제품명과_카테고리_없이_제품_목록을_조회한다() {
+        // given
+        Product product = KEYBOARD_1.생성(1L);
+        Pageable pageable = PageRequest.of(0, 2);
+        ProductSearchRequest productSearchRequest = new ProductSearchRequest(null, null);
+        given(productRepository.findWithoutSearchConditions(pageable))
+                .willReturn(new SliceImpl<>(List.of(product), pageable, false));
+
+        // when
+        ProductPageResponse productPageResponse = productService.findBySearchConditions(productSearchRequest, pageable);
+
+        // then
+        assertAll(
+                () -> verify(productRepository).findWithoutSearchConditions(pageable),
+                () -> assertThat(productPageResponse.isHasNext()).isFalse(),
+                () -> assertThat(productPageResponse.getItems()).usingRecursiveFieldByFieldElementComparator()
+                        .containsExactly(ProductResponse.from(product))
+        );
+    }
+
+    @Test
     void 제품명과_카테고리로_제품_목록을_조회한다() {
         // given
         Product product = KEYBOARD_1.생성(1L);
         Pageable pageable = PageRequest.of(0, 2);
-        given(productRepository.findBySearchConditions("키보드1", KEYBOARD, pageable))
+        given(productRepository.findWithSearchConditions("키보드1", KEYBOARD, pageable))
                 .willReturn(new SliceImpl<>(List.of(product), pageable, false));
         ProductSearchRequest productSearchRequest = new ProductSearchRequest("키보드1", KEYBOARD_CONSTANT);
 
@@ -131,7 +152,7 @@ class ProductServiceTest {
 
         // then
         assertAll(
-                () -> verify(productRepository).findBySearchConditions("키보드1", KEYBOARD, pageable),
+                () -> verify(productRepository).findWithSearchConditions("키보드1", KEYBOARD, pageable),
                 () -> assertThat(productPageResponse.isHasNext()).isFalse(),
                 () -> assertThat(productPageResponse.getItems()).usingRecursiveFieldByFieldElementComparator()
                         .containsExactly(ProductResponse.from(product))

--- a/backend/src/test/java/com/woowacourse/f12/application/review/ReviewServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/application/review/ReviewServiceTest.java
@@ -91,7 +91,7 @@ class ReviewServiceTest {
                 .willReturn(false);
         given(inventoryProductRepository.save(inventoryProduct))
                 .willReturn(inventoryProduct);
-        given(reviewRepository.save(reviewRequest.toReview(product, member)))
+        given(reviewRepository.save(any(Review.class)))
                 .willReturn(REVIEW_RATING_5.작성(1L, product, member));
 
         // when
@@ -100,7 +100,7 @@ class ReviewServiceTest {
         // then
         assertAll(
                 () -> assertThat(reviewId).isEqualTo(1L),
-                () -> assertThat(product.getReviewCount()).isOne(),
+//                () -> assertThat(product.getReviewCount()).isOne(),
                 () -> verify(productRepository).findById(productId),
                 () -> verify(memberRepository).findById(memberId),
                 () -> verify(reviewRepository).save(any(Review.class)),
@@ -337,7 +337,8 @@ class ReviewServiceTest {
         Long reviewId = 1L;
         Long memberId = 1L;
         Member member = CORINNE.생성(memberId);
-        Review review = REVIEW_RATING_5.작성(reviewId, KEYBOARD_1.생성(), member);
+        Product product = KEYBOARD_1.생성();
+        Review review = REVIEW_RATING_5.작성(reviewId, product, member);
         ReviewRequest updateRequest = new ReviewRequest("수정할 내용", 4);
 
         given(memberRepository.findById(memberId))
@@ -352,7 +353,7 @@ class ReviewServiceTest {
         assertAll(
                 () -> assertThat(review).usingRecursiveComparison()
                         .comparingOnlyFields("content", "rating")
-                        .isEqualTo(updateRequest.toReview(null, null)),
+                        .isEqualTo(updateRequest.toReview(product, member)),
                 () -> verify(memberRepository).findById(memberId),
                 () -> verify(reviewRepository).findById(reviewId)
         );

--- a/backend/src/test/java/com/woowacourse/f12/domain/product/ProductRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/domain/product/ProductRepositoryTest.java
@@ -47,8 +47,6 @@ class ProductRepositoryTest {
         Member member = memberRepository.save(CORINNE.생성());
         Review review1 = REVIEW_RATING_4.작성(product, member);
         Review review2 = REVIEW_RATING_5.작성(product, member);
-        product.reflectReview(review1);
-        product.reflectReview(review2);
 
         리뷰_저장(review1);
         리뷰_저장(review2);
@@ -90,14 +88,11 @@ class ProductRepositoryTest {
 
         Review review1 = REVIEW_RATING_5.작성(product1, member);
         Review review2 = REVIEW_RATING_5.작성(product2, member);
-
-        product1.reflectReview(review1);
-        product2.reflectReview(review2);
-        product2.reflectReview(review2);
+        Review review3 = REVIEW_RATING_5.작성(product2, member);
 
         리뷰_저장(review1);
         리뷰_저장(review2);
-        리뷰_저장(review2);
+        리뷰_저장(review3);
 
         Pageable pageable = PageRequest.of(0, 1, Sort.by(Order.desc("reviewCount")));
 

--- a/backend/src/test/java/com/woowacourse/f12/domain/product/ProductRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/domain/product/ProductRepositoryTest.java
@@ -70,7 +70,7 @@ class ProductRepositoryTest {
         Pageable pageable = PageRequest.of(0, 1);
 
         // when
-        Slice<Product> slice = productRepository.findBySearchConditions(null, KEYBOARD, pageable);
+        Slice<Product> slice = productRepository.findWithSearchConditions(null, KEYBOARD, pageable);
 
         // then
         assertAll(
@@ -97,7 +97,7 @@ class ProductRepositoryTest {
         Pageable pageable = PageRequest.of(0, 1, Sort.by(Order.desc("reviewCount")));
 
         // when
-        Slice<Product> slice = productRepository.findBySearchConditions(null, KEYBOARD, pageable);
+        Slice<Product> slice = productRepository.findWithSearchConditions(null, KEYBOARD, pageable);
 
         // then
         assertAll(
@@ -121,7 +121,7 @@ class ProductRepositoryTest {
         Pageable pageable = PageRequest.of(0, 1, Sort.by(Order.desc("rating")));
 
         // when
-        Slice<Product> slice = productRepository.findBySearchConditions(null, KEYBOARD, pageable);
+        Slice<Product> slice = productRepository.findWithSearchConditions(null, KEYBOARD, pageable);
 
         // then
         assertAll(
@@ -139,7 +139,7 @@ class ProductRepositoryTest {
         Pageable pageable = PageRequest.of(0, 2);
 
         // when
-        Slice<Product> page = productRepository.findBySearchConditions("1", null, pageable);
+        Slice<Product> page = productRepository.findWithSearchConditions("1", null, pageable);
 
         // then
         assertAll(
@@ -157,7 +157,7 @@ class ProductRepositoryTest {
         Pageable pageable = PageRequest.of(0, 2);
 
         // when
-        Slice<Product> page = productRepository.findBySearchConditions("1", KEYBOARD, pageable);
+        Slice<Product> page = productRepository.findWithSearchConditions("1", KEYBOARD, pageable);
 
         // then
         assertAll(

--- a/backend/src/test/java/com/woowacourse/f12/domain/product/ProductRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/domain/product/ProductRepositoryTest.java
@@ -166,6 +166,26 @@ class ProductRepositoryTest {
         );
     }
 
+    @Test
+    void 제품들을_where_조건없이_조회한다() {
+        // given
+        Product keyboard1 = 제품_저장(KEYBOARD_1.생성());
+        Member member = memberRepository.save(CORINNE.생성());
+        제품_저장(KEYBOARD_2.생성());
+        리뷰_저장(REVIEW_RATING_5.작성(keyboard1, member));
+
+        Pageable pageable = PageRequest.of(0, 1, Sort.by(Order.desc("rating"), Order.desc("reviewCount")));
+
+        // when
+        Slice<Product> page = productRepository.findWithoutSearchConditions(pageable);
+
+        // then
+        assertAll(
+                () -> assertThat(page.hasNext()).isTrue(),
+                () -> assertThat(page.getContent()).containsOnly(keyboard1)
+        );
+    }
+
     private Product 제품_저장(Product product) {
         return productRepository.save(product);
     }

--- a/backend/src/test/java/com/woowacourse/f12/domain/product/ProductTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/domain/product/ProductTest.java
@@ -2,12 +2,7 @@ package com.woowacourse.f12.domain.product;
 
 import static com.woowacourse.f12.domain.product.Category.KEYBOARD;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
 
-import com.woowacourse.f12.domain.review.Review;
-import com.woowacourse.f12.exception.internalserver.InvalidReflectReviewException;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
@@ -26,56 +21,5 @@ class ProductTest {
 
         // then
         assertThat(actual).isEqualTo(expected);
-    }
-
-    @Test
-    void 작성한_리뷰를_제품_정보에_반영한다() {
-        // given
-        Product product = Product.builder()
-                .reviewCount(1)
-                .totalRating(5)
-                .rating(5)
-                .build();
-
-        Review review = Review.builder()
-                .content("내용")
-                .rating(4)
-                .product(product)
-                .build();
-
-        // when
-        product.reflectReview(review);
-
-        // then
-        assertAll(
-                () -> assertThat(product.getReviewCount()).isEqualTo(2),
-                () -> assertThat(product.getTotalRating()).isEqualTo(9),
-                () -> assertThat(product.getRating()).isEqualTo((double) 9 / 2)
-        );
-    }
-
-    @Test
-    void 리뷰_대상이_아닌_제품에_리뷰를_반영하려_하면_예외를_반환한다() {
-        // given
-        Product product = Product.builder()
-                .id(1L)
-                .reviewCount(1)
-                .totalRating(5)
-                .rating(5)
-                .build();
-
-        Product notTarget = Product.builder()
-                .id(2L)
-                .build();
-
-        Review review = Review.builder()
-                .content("내용")
-                .rating(4)
-                .product(notTarget)
-                .build();
-
-        // when, then
-        assertThatThrownBy(() -> product.reflectReview(review)).isExactlyInstanceOf(
-                InvalidReflectReviewException.class);
     }
 }

--- a/backend/src/test/java/com/woowacourse/f12/domain/review/ReviewTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/domain/review/ReviewTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.woowacourse.f12.domain.member.Member;
+import com.woowacourse.f12.domain.product.Product;
 import com.woowacourse.f12.exception.badrequest.BlankContentException;
 import com.woowacourse.f12.exception.badrequest.InvalidContentLengthException;
 import com.woowacourse.f12.exception.badrequest.InvalidRatingValueException;
@@ -19,10 +20,15 @@ class ReviewTest {
     @ParameterizedTest
     @ValueSource(ints = {1, 5})
     void 리뷰_평점_값이_1과_5_사이_정수면_생성된다(int rating) {
-        // given, when
+        // given
+        Product product = Product.builder()
+                .build();
+
+        // when
         Review review = Review.builder()
                 .rating(rating)
                 .content("내용")
+                .product(product)
                 .build();
 
         // then
@@ -43,12 +49,15 @@ class ReviewTest {
     @Test
     void 리뷰_내용의_길이가_1000자_이하면_생성된다() {
         // given
-        String invalidContent = "1".repeat(1000);
+        String validContent = "1".repeat(1000);
+        Product product = Product.builder()
+                .build();
 
         // when
         Review review = Review.builder()
                 .rating(5)
-                .content(invalidContent)
+                .content(validContent)
+                .product(product)
                 .build();
 
         // then
@@ -90,10 +99,13 @@ class ReviewTest {
         Member targetMember = Member.builder()
                 .id(targetMemberId)
                 .build();
+        Product product = Product.builder()
+                .build();
         Review review = Review.builder()
                 .member(author)
                 .content("내용")
                 .rating(5)
+                .product(product)
                 .build();
 
         // when
@@ -106,15 +118,19 @@ class ReviewTest {
     @Test
     void 리뷰를_수정한다() {
         // given
+        Product product = Product.builder()
+                .build();
         Review review = Review.builder()
                 .id(1L)
                 .content("내용")
                 .rating(5)
+                .product(product)
                 .build();
         Review updateReview = Review.builder()
                 .id(2L)
                 .content("수정한 내용")
                 .rating(4)
+                .product(product)
                 .build();
 
         // when
@@ -126,6 +142,27 @@ class ReviewTest {
                 () -> assertThat(review).usingRecursiveComparison()
                         .ignoringFields("id")
                         .isEqualTo(updateReview)
+        );
+    }
+
+    @Test
+    void 리뷰_작성_시_제품에_정보를_반영한다() {
+        // given
+        Product product = Product.builder()
+                .build();
+
+        // when
+        Review review = Review.builder()
+                .content("내용")
+                .rating(5)
+                .product(product)
+                .build();
+
+        // then
+        assertAll(
+                () -> assertThat(product.getReviewCount()).isOne(),
+                () -> assertThat(product.getTotalRating()).isEqualTo(5),
+                () -> assertThat(product.getRating()).isEqualTo(5.0)
         );
     }
 }


### PR DESCRIPTION
# issue: #648 

# 작업 내용
검색 키워드와 옵션이 모두 없는 경우
- 커버링 인덱스 활용

검색 키워드 혹은 옵션이 있는 경우
- 카테고리 옵션이 있다면 category 인덱스 활용
- 카테고리 옵션이 없다면 idx_rc_ar_id or idx_ar_rc_id 인덱스 활용
