### PR TITLE
[BE] 리뷰 수정, 삭제 시 제품의 평점이 업데이트가 안되는 현상 수정

### DIFF
--- a/backend/src/main/java/com/woowacourse/f12/application/review/ReviewService.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/review/ReviewService.java
@@ -20,12 +20,11 @@ import com.woowacourse.f12.exception.notfound.InventoryProductNotFoundException;
 import com.woowacourse.f12.exception.notfound.MemberNotFoundException;
 import com.woowacourse.f12.exception.notfound.ProductNotFoundException;
 import com.woowacourse.f12.exception.notfound.ReviewNotFoundException;
+import java.util.Objects;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Objects;
 
 @Service
 @Transactional(readOnly = true)
@@ -66,6 +65,7 @@ public class ReviewService {
     private Long saveReview(final ReviewRequest reviewRequest, final Member member, final Product product) {
         validateNotWritten(member, product);
         final Review review = reviewRequest.toReview(product, member);
+        review.reflectToProductWhenWritten();
         return reviewRepository.save(review)
                 .getId();
     }
@@ -118,6 +118,7 @@ public class ReviewService {
     @Transactional
     public void delete(final Long reviewId, final Long memberId) {
         final Review review = findTarget(reviewId, memberId);
+        review.reflectToProductBeforeDelete();
         reviewRepository.delete(review);
         final InventoryProduct inventoryProduct = inventoryProductRepository.findWithProductByMemberAndProduct(
                         review.getMember(), review.getProduct())

--- a/backend/src/main/java/com/woowacourse/f12/domain/product/Product.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/product/Product.java
@@ -63,17 +63,29 @@ public class Product {
         return this.category == category;
     }
 
-    public void reflectReviewRating(final int reviewRating) {
-        increaseReviewCount();
-        calculateRatings(reviewRating);
-    }
-
-    private void increaseReviewCount() {
+    public void increaseReviewCount() {
         reviewCount++;
     }
 
-    private void calculateRatings(final int reviewRating) {
-        totalRating += reviewRating;
+    public void decreaseReviewCount() {
+        reviewCount--;
+    }
+
+    public void increaseRating(final int rating) {
+        this.totalRating += rating;
+        calculateRating();
+    }
+
+    public void decreaseRating(final int rating) {
+        this.totalRating -= rating;
+        calculateRating();
+    }
+
+    private void calculateRating() {
+        if (reviewCount == 0) {
+            rating = 0;
+            return;
+        }
         rating = (double) totalRating / reviewCount;
     }
 

--- a/backend/src/main/java/com/woowacourse/f12/domain/review/Review.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/review/Review.java
@@ -68,7 +68,6 @@ public class Review {
         this.product = product;
         this.member = member;
         this.createdAt = createdAt;
-        reflectToProduct();
     }
 
     private void validateContent(final String content) {
@@ -86,8 +85,15 @@ public class Review {
         }
     }
 
-    private void reflectToProduct() {
-        product.reflectReviewRating(rating);
+    public void reflectToProductWhenWritten() {
+        product.increaseReviewCount();
+        product.increaseRating(rating);
+    }
+
+    public void reflectToProductBeforeDelete() {
+        product.decreaseReviewCount();
+        ;
+        product.decreaseRating(rating);
     }
 
     public boolean isWrittenBy(final Member member) {
@@ -95,8 +101,10 @@ public class Review {
     }
 
     public void update(final Review updateReview) {
-        this.content = updateReview.getContent();
-        this.rating = updateReview.getRating();
+        product.decreaseRating(rating);
+        content = updateReview.getContent();
+        rating = updateReview.getRating();
+        product.increaseRating(rating);
     }
 
     @Override

--- a/backend/src/test/java/com/woowacourse/f12/application/review/ReviewServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/application/review/ReviewServiceTest.java
@@ -207,6 +207,7 @@ class ReviewServiceTest {
         Member member = CORINNE.생성(1L);
         Pageable pageable = PageRequest.of(0, 1, Sort.by(Order.desc("createdAt")));
         Review review = REVIEW_RATING_5.작성(1L, product, member);
+        review.reflectToProductWhenWritten();
         Slice<Review> slice = new SliceImpl<>(List.of(review), pageable, true);
 
         given(productRepository.existsById(productId))
@@ -236,6 +237,7 @@ class ReviewServiceTest {
         Member member = CORINNE.생성(1L);
         Pageable pageable = PageRequest.of(0, 1, Sort.by(Order.desc("createdAt")));
         Review review = REVIEW_RATING_5.작성(1L, product, member);
+        review.reflectToProductWhenWritten();
         Slice<Review> slice = new SliceImpl<>(List.of(review), pageable, true);
 
         given(productRepository.existsById(productId))
@@ -267,6 +269,7 @@ class ReviewServiceTest {
         Member member = CORINNE.생성(1L);
         Pageable pageable = PageRequest.of(0, 1, Sort.by(Order.desc("createdAt")));
         Review review = REVIEW_RATING_5.작성(1L, product, member);
+        review.reflectToProductWhenWritten();
         Slice<Review> slice = new SliceImpl<>(List.of(review), pageable, true);
 
         given(productRepository.existsById(productId))
@@ -310,7 +313,9 @@ class ReviewServiceTest {
         Pageable pageable = PageRequest.of(0, 2, Sort.by(Order.desc("createdAt")));
         Member member = CORINNE.생성(1L);
         Review review1 = REVIEW_RATING_5.작성(3L, KEYBOARD_1.생성(), member);
+        review1.reflectToProductWhenWritten();
         Review review2 = REVIEW_RATING_5.작성(2L, KEYBOARD_2.생성(), member);
+        review2.reflectToProductWhenWritten();
         Slice<Review> slice = new SliceImpl<>(List.of(review1, review2), pageable, true);
 
         given(reviewRepository.findPageBy(pageable))
@@ -339,6 +344,7 @@ class ReviewServiceTest {
         Member member = CORINNE.생성(memberId);
         Product product = KEYBOARD_1.생성();
         Review review = REVIEW_RATING_5.작성(reviewId, product, member);
+        review.reflectToProductWhenWritten();
         ReviewRequest updateRequest = new ReviewRequest("수정할 내용", 4);
 
         given(memberRepository.findById(memberId))
@@ -354,6 +360,7 @@ class ReviewServiceTest {
                 () -> assertThat(review).usingRecursiveComparison()
                         .comparingOnlyFields("content", "rating")
                         .isEqualTo(updateRequest.toReview(product, member)),
+                () -> assertThat(product.getRating()).isEqualTo(4.0),
                 () -> verify(memberRepository).findById(memberId),
                 () -> verify(reviewRepository).findById(reviewId)
         );
@@ -434,6 +441,7 @@ class ReviewServiceTest {
         Member member = CORINNE.생성(memberId);
         Product product = KEYBOARD_1.생성(productId);
         Review review = REVIEW_RATING_5.작성(reviewId, product, member);
+        review.reflectToProductWhenWritten();
         InventoryProduct inventoryProduct = SELECTED_INVENTORY_PRODUCT.생성(1L, member, product);
 
         given(memberRepository.findById(memberId))
@@ -450,6 +458,7 @@ class ReviewServiceTest {
         // when, then
         assertAll(
                 () -> assertDoesNotThrow(() -> reviewService.delete(reviewId, memberId)),
+                () -> assertThat(product.getReviewCount()).isZero(),
                 () -> verify(memberRepository).findById(memberId),
                 () -> verify(reviewRepository).findById(reviewId),
                 () -> verify(reviewRepository).delete(review),

--- a/backend/src/test/java/com/woowacourse/f12/domain/product/ProductRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/domain/product/ProductRepositoryTest.java
@@ -191,6 +191,7 @@ class ProductRepositoryTest {
     }
 
     private Review 리뷰_저장(Review review) {
+        review.reflectToProductWhenWritten();
         return reviewRepository.save(review);
     }
 }

--- a/backend/src/test/java/com/woowacourse/f12/domain/review/ReviewRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/domain/review/ReviewRepositoryTest.java
@@ -294,6 +294,7 @@ class ReviewRepositoryTest {
     }
 
     private Review 리뷰_저장(Review review) {
+        review.reflectToProductWhenWritten();
         return reviewRepository.save(review);
     }
 }

--- a/backend/src/test/java/com/woowacourse/f12/domain/review/ReviewTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/domain/review/ReviewTest.java
@@ -126,6 +126,8 @@ class ReviewTest {
                 .rating(5)
                 .product(product)
                 .build();
+        review.reflectToProductWhenWritten();
+
         Review updateReview = Review.builder()
                 .id(2L)
                 .content("수정한 내용")
@@ -140,29 +142,58 @@ class ReviewTest {
         assertAll(
                 () -> assertThat(review.getId()).isEqualTo(1L),
                 () -> assertThat(review).usingRecursiveComparison()
-                        .ignoringFields("id")
-                        .isEqualTo(updateReview)
+                        .ignoringFields("id", "product")
+                        .isEqualTo(updateReview),
+                () -> assertThat(review.getProduct().getReviewCount()).isOne(),
+                () -> assertThat(review.getProduct().getTotalRating()).isEqualTo(4),
+                () -> assertThat(review.getProduct().getRating()).isEqualTo(4.0)
         );
     }
 
     @Test
-    void 리뷰_작성_시_제품에_정보를_반영한다() {
+    void 리뷰_작성_시_리뷰_대상_제품의_리뷰_개수와_평점을_증가시킨다() {
         // given
         Product product = Product.builder()
                 .build();
 
-        // when
         Review review = Review.builder()
                 .content("내용")
                 .rating(5)
                 .product(product)
                 .build();
 
+        // when
+        review.reflectToProductWhenWritten();
+
         // then
         assertAll(
                 () -> assertThat(product.getReviewCount()).isOne(),
                 () -> assertThat(product.getTotalRating()).isEqualTo(5),
                 () -> assertThat(product.getRating()).isEqualTo(5.0)
+        );
+    }
+
+    @Test
+    void 리뷰_삭제_전에_리뷰_대상_제품의_리뷰_개수와_평점을_감소시킨다() {
+        // given
+        Product product = Product.builder()
+                .build();
+
+        Review review = Review.builder()
+                .content("내용")
+                .rating(5)
+                .product(product)
+                .build();
+        review.reflectToProductWhenWritten();
+
+        // when
+        review.reflectToProductBeforeDelete();
+
+        // then
+        assertAll(
+                () -> assertThat(product.getReviewCount()).isZero(),
+                () -> assertThat(product.getTotalRating()).isEqualTo(0),
+                () -> assertThat(product.getRating()).isEqualTo(0)
         );
     }
 }


### PR DESCRIPTION
# issue: #659 

# 작업 내용
- 리뷰 생성, 수정, 삭제 시 리뷰 반영 메서드를 직접 호출하는 것으로 문제 해결