### PR TITLE
[BE] 리뷰 조회 시 커버링 인덱스를 사용한다.

### DIFF
--- a/backend/src/main/java/com/woowacourse/f12/domain/review/ReviewRepository.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/review/ReviewRepository.java
@@ -13,9 +13,6 @@ public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewRep
     @Query("select r from Review r join fetch r.member join fetch r.product where r.product.id = :productId")
     Slice<Review> findPageByProductId(Long productId, Pageable pageable);
 
-    @Query("select r from Review r join fetch r.member join fetch r.product")
-    Slice<Review> findPageBy(Pageable pageable);
-
     boolean existsByMemberAndProduct(Member member, Product product);
 
     Optional<Review> findByMemberAndProduct(Member member, Product product);

--- a/backend/src/main/java/com/woowacourse/f12/domain/review/ReviewRepositoryCustom.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/review/ReviewRepositoryCustom.java
@@ -1,8 +1,12 @@
 package com.woowacourse.f12.domain.review;
 
 import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 
 public interface ReviewRepositoryCustom {
+
+    Slice<Review> findPageBy(Pageable pageable);
 
     List<CareerLevelCount> findCareerLevelCountByProductId(Long productId);
 

--- a/backend/src/main/java/com/woowacourse/f12/domain/review/ReviewRepositoryCustomImpl.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/review/ReviewRepositoryCustomImpl.java
@@ -1,11 +1,18 @@
 package com.woowacourse.f12.domain.review;
 
-import com.querydsl.jpa.impl.JPAQueryFactory;
-
-import java.util.List;
-
 import static com.woowacourse.f12.domain.member.QMember.member;
+import static com.woowacourse.f12.domain.product.QProduct.product;
 import static com.woowacourse.f12.domain.review.QReview.review;
+import static com.woowacourse.f12.support.RepositorySupport.makeOrderSpecifiers;
+import static com.woowacourse.f12.support.RepositorySupport.toSlice;
+
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.Collections;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 
 public class ReviewRepositoryCustomImpl implements ReviewRepositoryCustom {
 
@@ -13,6 +20,29 @@ public class ReviewRepositoryCustomImpl implements ReviewRepositoryCustom {
 
     public ReviewRepositoryCustomImpl(final JPAQueryFactory jpaQueryFactory) {
         this.jpaQueryFactory = jpaQueryFactory;
+    }
+
+    @Override
+    public Slice<Review> findPageBy(final Pageable pageable) {
+        final JPAQuery<Long> coveringIndexQuery = jpaQueryFactory.select(review.id)
+                .from(review)
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize() + 1)
+                .orderBy(makeOrderSpecifiers(review, pageable));
+        final Slice<Long> reviewIds = toSlice(pageable, coveringIndexQuery.fetch());
+
+        if (reviewIds.isEmpty()) {
+            return new SliceImpl<>(Collections.emptyList(), pageable, false);
+        }
+
+        final JPAQuery<Review> query = jpaQueryFactory.selectFrom(review)
+                .where(review.id.in(reviewIds.getContent()))
+                .innerJoin(review.member, member)
+                .fetchJoin()
+                .innerJoin(review.product, product)
+                .fetchJoin()
+                .orderBy(makeOrderSpecifiers(review, pageable));
+        return new SliceImpl<>(query.fetch(), pageable, reviewIds.hasNext());
     }
 
     @Override

--- a/backend/src/test/java/com/woowacourse/f12/acceptance/ReviewAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/acceptance/ReviewAcceptanceTest.java
@@ -200,7 +200,7 @@ class ReviewAcceptanceTest extends AcceptanceTest {
                 코린.로그인한_상태로(loginToken).리뷰를_작성한다(product2.getId(), REVIEW_RATING_4));
 
         // when
-        ExtractableResponse<Response> response = GET_요청을_보낸다("/api/v1/reviews?page=0&size=2&sort=createdAt,desc");
+        ExtractableResponse<Response> response = GET_요청을_보낸다("/api/v1/reviews?page=0&size=2&sort=id,desc");
 
         // then
         ReviewWithAuthorAndProductPageResponse reviewWithAuthorAndProductPageResponse = response.as(

--- a/backend/src/test/java/com/woowacourse/f12/domain/review/ReviewRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/domain/review/ReviewRepositoryTest.java
@@ -99,7 +99,7 @@ class ReviewRepositoryTest {
         Product product1 = productRepository.save(KEYBOARD_1.생성());
         Product product2 = productRepository.save(KEYBOARD_2.생성());
         Member member = memberRepository.save(CORINNE.생성());
-        Pageable pageable = PageRequest.of(0, 1, Sort.by(desc("createdAt")));
+        Pageable pageable = PageRequest.of(0, 1, Sort.by(desc("id")));
         리뷰_저장(REVIEW_RATING_5.작성(product1, member));
         Review review = 리뷰_저장(REVIEW_RATING_5.작성(product2, member));
 


### PR DESCRIPTION
# issue: #660 

# 작업 내용
- QueryDSL 구현체에서 커버링 인덱스 데이터를 가져오는 쿼리를 실행하고 멤버와 제품 테이블과 페치조인한 쿼리를 실행하도록 구현