### PR TITLE
[Hotfix/BE] 로그아웃 시 팔로워 수가 초기화 되는 현상을 수정한다

### DIFF
--- a/backend/src/main/java/com/woowacourse/f12/application/member/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/member/MemberService.java
@@ -3,12 +3,7 @@ package com.woowacourse.f12.application.member;
 
 import com.woowacourse.f12.domain.inventoryproduct.InventoryProduct;
 import com.woowacourse.f12.domain.inventoryproduct.InventoryProductRepository;
-import com.woowacourse.f12.domain.member.CareerLevel;
-import com.woowacourse.f12.domain.member.Following;
-import com.woowacourse.f12.domain.member.FollowingRepository;
-import com.woowacourse.f12.domain.member.JobType;
-import com.woowacourse.f12.domain.member.Member;
-import com.woowacourse.f12.domain.member.MemberRepository;
+import com.woowacourse.f12.domain.member.*;
 import com.woowacourse.f12.dto.request.member.MemberRequest;
 import com.woowacourse.f12.dto.request.member.MemberSearchRequest;
 import com.woowacourse.f12.dto.response.member.LoggedInMemberResponse;
@@ -19,14 +14,15 @@ import com.woowacourse.f12.exception.badrequest.NotFollowingException;
 import com.woowacourse.f12.exception.notfound.MemberNotFoundException;
 import com.woowacourse.f12.presentation.member.CareerLevelConstant;
 import com.woowacourse.f12.presentation.member.JobTypeConstant;
-import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional(readOnly = true)
@@ -136,7 +132,7 @@ public class MemberService {
 
     @Transactional
     public void follow(final Long followerId, final Long followingId) {
-        final Member followingMember = memberRepository.findById(followingId)
+        final Member targetMember = memberRepository.findById(followingId)
                 .orElseThrow(MemberNotFoundException::new);
         validateFollowingMembersExist(followerId);
         validateNotFollowing(followerId, followingId);
@@ -145,7 +141,7 @@ public class MemberService {
                 .followingId(followingId)
                 .build();
         followingRepository.save(following);
-        increaseFollowerCount(followingMember);
+        targetMember.follow();
     }
 
     private void validateFollowingMembersExist(final Long followerId) {
@@ -160,35 +156,20 @@ public class MemberService {
         }
     }
 
-    private void increaseFollowerCount(final Member followingMember) {
-        final Member updatedMember = Member.builder()
-                .followerCount(followingMember.getFollowerCount() + 1)
-                .build();
-        followingMember.update(updatedMember);
-    }
-
     @Transactional
     public void unfollow(final Long followerId, final Long followingId) {
-        final Member followingMember = memberRepository.findById(followingId)
+        final Member targetMember = memberRepository.findById(followingId)
                 .orElseThrow(MemberNotFoundException::new);
         validateFollowingMembersExist(followerId);
         final Following following = findFollowingRelation(followerId, followingId);
         followingRepository.delete(following);
-        decreaseFollowerCount(followingMember);
+        targetMember.unfollow();
     }
 
     private Following findFollowingRelation(final Long followerId, final Long followingId) {
         return followingRepository.findByFollowerIdAndFollowingId(followerId, followingId)
                 .orElseThrow(NotFollowingException::new);
     }
-
-    private void decreaseFollowerCount(final Member followingMember) {
-        final Member updatedMember = Member.builder()
-                .followerCount(followingMember.getFollowerCount() - 1)
-                .build();
-        followingMember.update(updatedMember);
-    }
-
     public MemberPageResponse findFollowingsByConditions(final Long loggedInId, final MemberSearchRequest memberSearchRequest,
                                                          final Pageable pageable) {
         final Slice<Member> slice = findFollowingsBySearchConditions(loggedInId, memberSearchRequest, pageable);

--- a/backend/src/main/java/com/woowacourse/f12/application/member/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/member/MemberService.java
@@ -141,7 +141,7 @@ public class MemberService {
                 .followingId(followingId)
                 .build();
         followingRepository.save(following);
-        targetMember.follow();
+        targetMember.increaseFollowerCount();
     }
 
     private void validateFollowingMembersExist(final Long followerId) {
@@ -163,7 +163,7 @@ public class MemberService {
         validateFollowingMembersExist(followerId);
         final Following following = findFollowingRelation(followerId, followingId);
         followingRepository.delete(following);
-        targetMember.unfollow();
+        targetMember.decreaseFollowerCount();
     }
 
     private Following findFollowingRelation(final Long followerId, final Long followingId) {

--- a/backend/src/main/java/com/woowacourse/f12/domain/member/Member.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/member/Member.java
@@ -70,7 +70,6 @@ public class Member {
         updateImageUrl(updateMember.imageUrl);
         updateCareerLevel(updateMember.careerLevel);
         updateJobType(updateMember.jobType);
-        updateFollowerCount(updateMember.followerCount);
         updateRegistered(updateMember.registered);
     }
 
@@ -98,11 +97,15 @@ public class Member {
         }
     }
 
-    private void updateFollowerCount(final int followerCount) {
-        if (followerCount < 0){
+    public void follow() {
+        this.followerCount += 1;
+    }
+
+    public void unfollow() {
+        if (this.followerCount == 0) {
             throw new InvalidFollowerCountException();
         }
-        this.followerCount = followerCount;
+        this.followerCount -= 1;
     }
 
     private void updateRegistered(final boolean registered) {

--- a/backend/src/main/java/com/woowacourse/f12/domain/member/Member.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/member/Member.java
@@ -97,11 +97,11 @@ public class Member {
         }
     }
 
-    public void follow() {
+    public void increaseFollowerCount() {
         this.followerCount += 1;
     }
 
-    public void unfollow() {
+    public void decreaseFollowerCount() {
         if (this.followerCount == 0) {
             throw new InvalidFollowerCountException();
         }

--- a/backend/src/test/java/com/woowacourse/f12/acceptance/MemberAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/acceptance/MemberAcceptanceTest.java
@@ -1,22 +1,5 @@
 package com.woowacourse.f12.acceptance;
 
-import static com.woowacourse.f12.acceptance.support.RestAssuredRequestUtil.GET_요청을_보낸다;
-import static com.woowacourse.f12.acceptance.support.RestAssuredRequestUtil.로그인된_상태로_DELETE_요청을_보낸다;
-import static com.woowacourse.f12.acceptance.support.RestAssuredRequestUtil.로그인된_상태로_GET_요청을_보낸다;
-import static com.woowacourse.f12.acceptance.support.RestAssuredRequestUtil.로그인된_상태로_PATCH_요청을_보낸다;
-import static com.woowacourse.f12.acceptance.support.RestAssuredRequestUtil.로그인된_상태로_POST_요청을_보낸다;
-import static com.woowacourse.f12.domain.member.CareerLevel.JUNIOR;
-import static com.woowacourse.f12.domain.member.CareerLevel.SENIOR;
-import static com.woowacourse.f12.domain.member.JobType.BACKEND;
-import static com.woowacourse.f12.presentation.member.CareerLevelConstant.JUNIOR_CONSTANT;
-import static com.woowacourse.f12.presentation.member.CareerLevelConstant.SENIOR_CONSTANT;
-import static com.woowacourse.f12.presentation.member.JobTypeConstant.BACKEND_CONSTANT;
-import static com.woowacourse.f12.support.fixture.AcceptanceFixture.민초;
-import static com.woowacourse.f12.support.fixture.AcceptanceFixture.오찌;
-import static com.woowacourse.f12.support.fixture.AcceptanceFixture.코린;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
-
 import com.woowacourse.f12.domain.inventoryproduct.InventoryProduct;
 import com.woowacourse.f12.domain.member.Member;
 import com.woowacourse.f12.domain.product.Product;
@@ -26,6 +9,7 @@ import com.woowacourse.f12.dto.response.auth.LoginMemberResponse;
 import com.woowacourse.f12.dto.response.auth.LoginResponse;
 import com.woowacourse.f12.dto.response.inventoryproduct.InventoryProductResponse;
 import com.woowacourse.f12.dto.response.inventoryproduct.InventoryProductsResponse;
+import com.woowacourse.f12.dto.response.member.LoggedInMemberResponse;
 import com.woowacourse.f12.dto.response.member.MemberPageResponse;
 import com.woowacourse.f12.dto.response.member.MemberResponse;
 import com.woowacourse.f12.dto.response.member.MemberWithProfileProductResponse;
@@ -34,10 +18,22 @@ import com.woowacourse.f12.support.fixture.ProductFixture;
 import com.woowacourse.f12.support.fixture.ReviewFixture;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
-import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
+
+import java.util.List;
+
+import static com.woowacourse.f12.acceptance.support.RestAssuredRequestUtil.*;
+import static com.woowacourse.f12.domain.member.CareerLevel.JUNIOR;
+import static com.woowacourse.f12.domain.member.CareerLevel.SENIOR;
+import static com.woowacourse.f12.domain.member.JobType.BACKEND;
+import static com.woowacourse.f12.presentation.member.CareerLevelConstant.JUNIOR_CONSTANT;
+import static com.woowacourse.f12.presentation.member.CareerLevelConstant.SENIOR_CONSTANT;
+import static com.woowacourse.f12.presentation.member.JobTypeConstant.BACKEND_CONSTANT;
+import static com.woowacourse.f12.support.fixture.AcceptanceFixture.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 class MemberAcceptanceTest extends AcceptanceTest {
 
@@ -638,6 +634,27 @@ class MemberAcceptanceTest extends AcceptanceTest {
                         .hasSize(1)
                         .containsExactly(followingResponse)
         );
+    }
+
+    @Test
+    void 재로그인_시_팔로워_수가_변하지_않는다() {
+        // given
+        MemberRequest memberRequest = new MemberRequest(SENIOR_CONSTANT, BACKEND_CONSTANT);
+        LoginResponse followingResponse = 민초.로그인을_한다();
+        민초.로그인한_상태로(followingResponse.getToken()).추가정보를_입력한다(memberRequest);
+
+        final LoginResponse followerResponse = 코린.로그인을_한다();
+        코린.로그인한_상태로(followerResponse.getToken()).추가정보를_입력한다(memberRequest);
+        코린.로그인한_상태로(followerResponse.getToken()).팔로우한다(followingResponse.getMember().getId());
+
+        final LoginResponse reLoggedInFollowingResponse = 민초.로그인을_한다();
+
+        // when
+        final LoggedInMemberResponse followingMemberResponse = 민초.로그인한_상태로(reLoggedInFollowingResponse.getToken()).자신의_프로필을_조회한다()
+                .as(LoggedInMemberResponse.class);
+
+        // then
+        assertThat(followingMemberResponse.getFollowerCount()).isOne();
     }
 
     private Product 제품을_저장한다(Product product) {

--- a/backend/src/test/java/com/woowacourse/f12/acceptance/MemberAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/acceptance/MemberAcceptanceTest.java
@@ -643,14 +643,14 @@ class MemberAcceptanceTest extends AcceptanceTest {
         LoginResponse followingResponse = 민초.로그인을_한다();
         민초.로그인한_상태로(followingResponse.getToken()).추가정보를_입력한다(memberRequest);
 
-        final LoginResponse followerResponse = 코린.로그인을_한다();
+        LoginResponse followerResponse = 코린.로그인을_한다();
         코린.로그인한_상태로(followerResponse.getToken()).추가정보를_입력한다(memberRequest);
         코린.로그인한_상태로(followerResponse.getToken()).팔로우한다(followingResponse.getMember().getId());
 
-        final LoginResponse reLoggedInFollowingResponse = 민초.로그인을_한다();
+        LoginResponse reLoggedInFollowingResponse = 민초.로그인을_한다();
 
         // when
-        final LoggedInMemberResponse followingMemberResponse = 민초.로그인한_상태로(reLoggedInFollowingResponse.getToken()).자신의_프로필을_조회한다()
+        LoggedInMemberResponse followingMemberResponse = 민초.로그인한_상태로(reLoggedInFollowingResponse.getToken()).자신의_프로필을_조회한다()
                 .as(LoggedInMemberResponse.class);
 
         // then

--- a/backend/src/test/java/com/woowacourse/f12/domain/member/MemberRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/domain/member/MemberRepositoryTest.java
@@ -47,10 +47,7 @@ class MemberRepositoryTest {
                 .followerId(corinne.getId())
                 .followingId(mincho.getId())
                 .build());
-        Member updateMember = Member.builder()
-                .followerCount(mincho.getFollowerCount() + 1)
-                .build();
-        mincho.update(updateMember);
+        mincho.follow();
         entityManager.flush();
         entityManager.clear();
 
@@ -176,9 +173,7 @@ class MemberRepositoryTest {
                 .followerId(corinne.getId())
                 .followingId(mincho.getId())
                 .build());
-        mincho.update(Member.builder()
-                .followerCount(mincho.getFollowerCount() + 1)
-                .build());
+        mincho.follow();
         entityManager.flush();
         entityManager.clear();
 
@@ -216,9 +211,7 @@ class MemberRepositoryTest {
                 .followerId(corinne.getId())
                 .followingId(mincho.getId())
                 .build());
-        mincho.update(Member.builder()
-                .followerCount(mincho.getFollowerCount() + 1)
-                .build());
+        mincho.follow();
         entityManager.flush();
         entityManager.clear();
 
@@ -256,10 +249,7 @@ class MemberRepositoryTest {
                 .followerId(corinne.getId())
                 .followingId(mincho.getId())
                 .build());
-        Member updateMember = Member.builder()
-                .followerCount(mincho.getFollowerCount() + 1)
-                .build();
-        mincho.update(updateMember);
+        mincho.follow();
         entityManager.flush();
         entityManager.clear();
 

--- a/backend/src/test/java/com/woowacourse/f12/domain/member/MemberRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/domain/member/MemberRepositoryTest.java
@@ -47,7 +47,7 @@ class MemberRepositoryTest {
                 .followerId(corinne.getId())
                 .followingId(mincho.getId())
                 .build());
-        mincho.follow();
+        mincho.increaseFollowerCount();
         entityManager.flush();
         entityManager.clear();
 
@@ -173,7 +173,7 @@ class MemberRepositoryTest {
                 .followerId(corinne.getId())
                 .followingId(mincho.getId())
                 .build());
-        mincho.follow();
+        mincho.increaseFollowerCount();
         entityManager.flush();
         entityManager.clear();
 
@@ -211,7 +211,7 @@ class MemberRepositoryTest {
                 .followerId(corinne.getId())
                 .followingId(mincho.getId())
                 .build());
-        mincho.follow();
+        mincho.increaseFollowerCount();
         entityManager.flush();
         entityManager.clear();
 
@@ -249,7 +249,7 @@ class MemberRepositoryTest {
                 .followerId(corinne.getId())
                 .followingId(mincho.getId())
                 .build());
-        mincho.follow();
+        mincho.increaseFollowerCount();
         entityManager.flush();
         entityManager.clear();
 

--- a/backend/src/test/java/com/woowacourse/f12/domain/member/MemberTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/domain/member/MemberTest.java
@@ -1,8 +1,10 @@
 package com.woowacourse.f12.domain.member;
 
+import com.woowacourse.f12.exception.badrequest.InvalidFollowerCountException;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class MemberTest {
 
@@ -54,5 +56,75 @@ class MemberTest {
         // then
         assertThat(member).usingRecursiveComparison()
                 .isEqualTo(expected);
+    }
+
+    @Test
+    void 팔로워_수를_증가한다() {
+        // given
+        Member member = Member.builder()
+                .id(1L)
+                .name("유현지")
+                .imageUrl("imageUrl")
+                .careerLevel(CareerLevel.SENIOR)
+                .jobType(JobType.BACKEND)
+                .build();
+        Member expected = Member.builder()
+                .id(1L)
+                .name("유현지")
+                .imageUrl("imageUrl")
+                .careerLevel(CareerLevel.SENIOR)
+                .jobType(JobType.BACKEND)
+                .followerCount(1)
+                .build();
+
+        // when
+        member.follow();
+
+        // then
+        assertThat(member).usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+
+    @Test
+    void 팔로워_수를_감소한다() {
+        // given
+        Member member = Member.builder()
+                .id(1L)
+                .name("유현지")
+                .imageUrl("imageUrl")
+                .careerLevel(CareerLevel.SENIOR)
+                .jobType(JobType.BACKEND)
+                .followerCount(1)
+                .build();
+        Member expected = Member.builder()
+                .id(1L)
+                .name("유현지")
+                .imageUrl("imageUrl")
+                .careerLevel(CareerLevel.SENIOR)
+                .jobType(JobType.BACKEND)
+                .build();
+
+        // when
+        member.unfollow();
+
+        // then
+        assertThat(member).usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+
+    @Test
+    void 팔로워_수가_0인_상태에서_팔로워_수를_감소하면_예외가_발생한다() {
+        // given
+        Member member = Member.builder()
+                .id(1L)
+                .name("유현지")
+                .imageUrl("imageUrl")
+                .careerLevel(CareerLevel.SENIOR)
+                .jobType(JobType.BACKEND)
+                .build();
+
+        // when, then
+        assertThatThrownBy(member::unfollow)
+                .isInstanceOf(InvalidFollowerCountException.class);
     }
 }

--- a/backend/src/test/java/com/woowacourse/f12/domain/member/MemberTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/domain/member/MemberTest.java
@@ -78,7 +78,7 @@ class MemberTest {
                 .build();
 
         // when
-        member.follow();
+        member.increaseFollowerCount();
 
         // then
         assertThat(member).usingRecursiveComparison()
@@ -105,7 +105,7 @@ class MemberTest {
                 .build();
 
         // when
-        member.unfollow();
+        member.decreaseFollowerCount();
 
         // then
         assertThat(member).usingRecursiveComparison()
@@ -124,7 +124,7 @@ class MemberTest {
                 .build();
 
         // when, then
-        assertThatThrownBy(member::unfollow)
+        assertThatThrownBy(member::decreaseFollowerCount)
                 .isInstanceOf(InvalidFollowerCountException.class);
     }
 }


### PR DESCRIPTION
# 작업 내용
-  follow, unfollow 로직 MemberUpdate와 분리
- 재로그인 시 팔로워 수가 변하지 않는지에 대한 인수테스트 추가