### PR TITLE
[BE] 스프린트5에 대한 버퍼를 진행한다

### DIFF
--- a/backend/src/main/java/com/woowacourse/f12/application/member/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/member/MemberService.java
@@ -78,8 +78,9 @@ public class MemberService {
                 .orElseThrow(MemberNotFoundException::new);
     }
 
-    public MemberPageResponse findByContains(@Nullable final Long loggedInId,
-                                             final MemberSearchRequest memberSearchRequest, final Pageable pageable) {
+    public MemberPageResponse findBySearchConditions(@Nullable final Long loggedInId,
+                                                     final MemberSearchRequest memberSearchRequest,
+                                                     final Pageable pageable) {
         final Slice<Member> slice = findBySearchConditions(memberSearchRequest, pageable);
         if (slice.isEmpty()) {
             return MemberPageResponse.ofByFollowingCondition(slice, false);

--- a/backend/src/main/java/com/woowacourse/f12/application/member/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/member/MemberService.java
@@ -3,7 +3,12 @@ package com.woowacourse.f12.application.member;
 
 import com.woowacourse.f12.domain.inventoryproduct.InventoryProduct;
 import com.woowacourse.f12.domain.inventoryproduct.InventoryProductRepository;
-import com.woowacourse.f12.domain.member.*;
+import com.woowacourse.f12.domain.member.CareerLevel;
+import com.woowacourse.f12.domain.member.Following;
+import com.woowacourse.f12.domain.member.FollowingRepository;
+import com.woowacourse.f12.domain.member.JobType;
+import com.woowacourse.f12.domain.member.Member;
+import com.woowacourse.f12.domain.member.MemberRepository;
 import com.woowacourse.f12.dto.request.member.MemberRequest;
 import com.woowacourse.f12.dto.request.member.MemberSearchRequest;
 import com.woowacourse.f12.dto.response.member.LoggedInMemberResponse;
@@ -14,15 +19,14 @@ import com.woowacourse.f12.exception.badrequest.NotFollowingException;
 import com.woowacourse.f12.exception.notfound.MemberNotFoundException;
 import com.woowacourse.f12.presentation.member.CareerLevelConstant;
 import com.woowacourse.f12.presentation.member.JobTypeConstant;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
 
 @Service
 @Transactional(readOnly = true)
@@ -77,6 +81,9 @@ public class MemberService {
     public MemberPageResponse findByContains(@Nullable final Long loggedInId,
                                              final MemberSearchRequest memberSearchRequest, final Pageable pageable) {
         final Slice<Member> slice = findBySearchConditions(memberSearchRequest, pageable);
+        if (slice.isEmpty()) {
+            return MemberPageResponse.ofByFollowingCondition(slice, false);
+        }
         setInventoryProductsToMembers(slice);
         if (isNotLoggedIn(loggedInId)) {
             return MemberPageResponse.ofByFollowingCondition(slice, false);
@@ -170,9 +177,14 @@ public class MemberService {
         return followingRepository.findByFollowerIdAndFollowingId(followerId, followingId)
                 .orElseThrow(NotFollowingException::new);
     }
-    public MemberPageResponse findFollowingsByConditions(final Long loggedInId, final MemberSearchRequest memberSearchRequest,
+
+    public MemberPageResponse findFollowingsByConditions(final Long loggedInId,
+                                                         final MemberSearchRequest memberSearchRequest,
                                                          final Pageable pageable) {
         final Slice<Member> slice = findFollowingsBySearchConditions(loggedInId, memberSearchRequest, pageable);
+        if (slice.isEmpty()) {
+            return MemberPageResponse.ofByFollowingCondition(slice, false);
+        }
         setInventoryProductsToMembers(slice);
         return MemberPageResponse.ofByFollowingCondition(slice, true);
     }

--- a/backend/src/main/java/com/woowacourse/f12/domain/member/MemberRepositoryCustomImpl.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/member/MemberRepositoryCustomImpl.java
@@ -108,10 +108,8 @@ public class MemberRepositoryCustomImpl implements MemberRepositoryCustom {
     }
 
     private List<Long> findFollowingMemberIds(final Long loggedInId) {
-        return jpaQueryFactory.select(member.id)
-                .from(member)
-                .join(following)
-                .on(member.id.eq(following.followingId))
+        return jpaQueryFactory.select(following.followingId)
+                .from(following)
                 .where(
                         following.followerId.eq(loggedInId)
                 ).fetch();

--- a/backend/src/main/java/com/woowacourse/f12/presentation/member/MemberController.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/member/MemberController.java
@@ -41,7 +41,8 @@ public class MemberController {
 
     @GetMapping("/{memberId}")
     @Login(required = false)
-    public ResponseEntity<MemberResponse> show(@PathVariable final Long memberId, @VerifiedMember @Nullable final Long loggedInMemberId) {
+    public ResponseEntity<MemberResponse> show(@PathVariable final Long memberId,
+                                               @VerifiedMember @Nullable final Long loggedInMemberId) {
         final MemberResponse memberResponse = memberService.find(memberId, loggedInMemberId);
         return ResponseEntity.ok(memberResponse);
     }
@@ -59,13 +60,15 @@ public class MemberController {
     public ResponseEntity<MemberPageResponse> searchMembers(@VerifiedMember @Nullable final Long loggedInId,
                                                             @ModelAttribute final MemberSearchRequest memberSearchRequest,
                                                             final Pageable pageable) {
-        final MemberPageResponse memberPageResponse = memberService.findByContains(loggedInId, memberSearchRequest, pageable);
+        final MemberPageResponse memberPageResponse = memberService.findBySearchConditions(loggedInId,
+                memberSearchRequest, pageable);
         return ResponseEntity.ok(memberPageResponse);
     }
 
     @PostMapping("/{memberId}/following")
     @Login
-    public ResponseEntity<Void> follow(@VerifiedMember final Long followerId, @PathVariable("memberId") final Long followingId) {
+    public ResponseEntity<Void> follow(@VerifiedMember final Long followerId,
+                                       @PathVariable("memberId") final Long followingId) {
         memberService.follow(followerId, followingId);
         return ResponseEntity.noContent()
                 .build();
@@ -73,7 +76,8 @@ public class MemberController {
 
     @DeleteMapping("/{memberId}/following")
     @Login
-    public ResponseEntity<Void> unfollow(@VerifiedMember final Long followerId, @PathVariable("memberId") final Long followingId) {
+    public ResponseEntity<Void> unfollow(@VerifiedMember final Long followerId,
+                                         @PathVariable("memberId") final Long followingId) {
         memberService.unfollow(followerId, followingId);
         return ResponseEntity.noContent()
                 .build();

--- a/backend/src/test/java/com/woowacourse/f12/application/member/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/application/member/MemberServiceTest.java
@@ -271,7 +271,7 @@ class MemberServiceTest {
     }
 
     @Test
-    void 회원목록을_검색하여_조회할때_해당_결과가_없으면_다음_로직이_일어나지_않는다() {
+    void 회원목록을_검색하여_조회할때_해당_결과가_없으면_다음_로직이_실행되지_않는다() {
         // given
         Pageable pageable = PageRequest.of(0, 10);
         InventoryProduct inventoryProduct = SELECTED_INVENTORY_PRODUCT.생성(CORINNE.생성(1L), KEYBOARD_1.생성(1L));
@@ -621,7 +621,7 @@ class MemberServiceTest {
     }
 
     @Test
-    void 팔로잉하는_회원목록을_검색할때_결과가_없으면_다음_로직이_일어나지_않는다() {
+    void 팔로잉하는_회원목록을_검색할때_결과가_없으면_다음_로직이_실행되지_않는다() {
         // given
         Long loggedInId = 1L;
         Pageable pageable = PageRequest.of(0, 10, Sort.by("id").descending());

--- a/backend/src/test/java/com/woowacourse/f12/application/member/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/application/member/MemberServiceTest.java
@@ -169,7 +169,8 @@ class MemberServiceTest {
 
         // when
         MemberSearchRequest memberSearchRequest = new MemberSearchRequest(null, null, null);
-        MemberPageResponse memberPageResponse = memberService.findByContains(null, memberSearchRequest, pageable);
+        MemberPageResponse memberPageResponse = memberService.findBySearchConditions(null, memberSearchRequest,
+                pageable);
 
         // then
         assertAll(
@@ -194,7 +195,8 @@ class MemberServiceTest {
 
         // when
         MemberSearchRequest memberSearchRequest = new MemberSearchRequest(null, SENIOR_CONSTANT, BACKEND_CONSTANT);
-        MemberPageResponse memberPageResponse = memberService.findByContains(null, memberSearchRequest, pageable);
+        MemberPageResponse memberPageResponse = memberService.findBySearchConditions(null, memberSearchRequest,
+                pageable);
 
         // then
         assertAll(
@@ -219,7 +221,8 @@ class MemberServiceTest {
 
         // when
         MemberSearchRequest memberSearchRequest = new MemberSearchRequest("cheese", SENIOR_CONSTANT, BACKEND_CONSTANT);
-        MemberPageResponse memberPageResponse = memberService.findByContains(null, memberSearchRequest, pageable);
+        MemberPageResponse memberPageResponse = memberService.findBySearchConditions(null, memberSearchRequest,
+                pageable);
 
         // then
         assertAll(
@@ -253,7 +256,8 @@ class MemberServiceTest {
 
         // when
         MemberSearchRequest memberSearchRequest = new MemberSearchRequest("cheese", SENIOR_CONSTANT, BACKEND_CONSTANT);
-        MemberPageResponse memberPageResponse = memberService.findByContains(loggedInId, memberSearchRequest, pageable);
+        MemberPageResponse memberPageResponse = memberService.findBySearchConditions(loggedInId, memberSearchRequest,
+                pageable);
 
         // then
         assertAll(
@@ -280,7 +284,8 @@ class MemberServiceTest {
         // when
         MemberSearchRequest memberSearchRequest = new MemberSearchRequest("invalid", JUNIOR_CONSTANT,
                 FRONTEND_CONSTANT);
-        MemberPageResponse memberPageResponse = memberService.findByContains(loggedInId, memberSearchRequest, pageable);
+        MemberPageResponse memberPageResponse = memberService.findBySearchConditions(loggedInId, memberSearchRequest,
+                pageable);
 
         // then
         assertAll(


### PR DESCRIPTION
#677 

# 작업 내용

- 검색 조건 없이 나의 following 목록 조회 시 following_id 목록 조회하는 부분 join절 없앨 것
- 사용자 검색 시 결과 값이 없는 경우 (로그인 여부 상관 X, 팔로잉 검색, 기본 검색 상관 모두) 
  - 해당 회원의 inventoryProduct를 조회하지 않을 것
  - 팔로잉 여부를 확인하는 쿼리를 보내지 않을 것 