### PR TITLE
[Bugfix/BE] DatabaseCleanup SQL 생성 방식 변경

### DIFF
--- a/backend/src/main/java/com/woowacourse/f12/application/member/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/member/MemberService.java
@@ -3,7 +3,12 @@ package com.woowacourse.f12.application.member;
 
 import com.woowacourse.f12.domain.inventoryproduct.InventoryProduct;
 import com.woowacourse.f12.domain.inventoryproduct.InventoryProductRepository;
-import com.woowacourse.f12.domain.member.*;
+import com.woowacourse.f12.domain.member.CareerLevel;
+import com.woowacourse.f12.domain.member.Following;
+import com.woowacourse.f12.domain.member.FollowingRepository;
+import com.woowacourse.f12.domain.member.JobType;
+import com.woowacourse.f12.domain.member.Member;
+import com.woowacourse.f12.domain.member.MemberRepository;
 import com.woowacourse.f12.dto.request.member.MemberRequest;
 import com.woowacourse.f12.dto.request.member.MemberSearchRequest;
 import com.woowacourse.f12.dto.response.member.LoggedInMemberResponse;
@@ -14,15 +19,14 @@ import com.woowacourse.f12.exception.badrequest.NotFollowingException;
 import com.woowacourse.f12.exception.notfound.MemberNotFoundException;
 import com.woowacourse.f12.presentation.member.CareerLevelConstant;
 import com.woowacourse.f12.presentation.member.JobTypeConstant;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
 
 @Service
 @Transactional(readOnly = true)
@@ -74,9 +78,13 @@ public class MemberService {
                 .orElseThrow(MemberNotFoundException::new);
     }
 
-    public MemberPageResponse findByContains(@Nullable final Long loggedInId,
-                                             final MemberSearchRequest memberSearchRequest, final Pageable pageable) {
+    public MemberPageResponse findBySearchConditions(@Nullable final Long loggedInId,
+                                                     final MemberSearchRequest memberSearchRequest,
+                                                     final Pageable pageable) {
         final Slice<Member> slice = findBySearchConditions(memberSearchRequest, pageable);
+        if (slice.isEmpty()) {
+            return MemberPageResponse.ofByFollowingCondition(slice, false);
+        }
         setInventoryProductsToMembers(slice);
         if (isNotLoggedIn(loggedInId)) {
             return MemberPageResponse.ofByFollowingCondition(slice, false);
@@ -170,9 +178,14 @@ public class MemberService {
         return followingRepository.findByFollowerIdAndFollowingId(followerId, followingId)
                 .orElseThrow(NotFollowingException::new);
     }
-    public MemberPageResponse findFollowingsByConditions(final Long loggedInId, final MemberSearchRequest memberSearchRequest,
+
+    public MemberPageResponse findFollowingsByConditions(final Long loggedInId,
+                                                         final MemberSearchRequest memberSearchRequest,
                                                          final Pageable pageable) {
         final Slice<Member> slice = findFollowingsBySearchConditions(loggedInId, memberSearchRequest, pageable);
+        if (slice.isEmpty()) {
+            return MemberPageResponse.ofByFollowingCondition(slice, false);
+        }
         setInventoryProductsToMembers(slice);
         return MemberPageResponse.ofByFollowingCondition(slice, true);
     }

--- a/backend/src/main/java/com/woowacourse/f12/domain/member/MemberRepositoryCustomImpl.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/member/MemberRepositoryCustomImpl.java
@@ -108,10 +108,8 @@ public class MemberRepositoryCustomImpl implements MemberRepositoryCustom {
     }
 
     private List<Long> findFollowingMemberIds(final Long loggedInId) {
-        return jpaQueryFactory.select(member.id)
-                .from(member)
-                .join(following)
-                .on(member.id.eq(following.followingId))
+        return jpaQueryFactory.select(following.followingId)
+                .from(following)
                 .where(
                         following.followerId.eq(loggedInId)
                 ).fetch();

--- a/backend/src/main/java/com/woowacourse/f12/presentation/member/MemberController.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/member/MemberController.java
@@ -41,7 +41,8 @@ public class MemberController {
 
     @GetMapping("/{memberId}")
     @Login(required = false)
-    public ResponseEntity<MemberResponse> show(@PathVariable final Long memberId, @VerifiedMember @Nullable final Long loggedInMemberId) {
+    public ResponseEntity<MemberResponse> show(@PathVariable final Long memberId,
+                                               @VerifiedMember @Nullable final Long loggedInMemberId) {
         final MemberResponse memberResponse = memberService.find(memberId, loggedInMemberId);
         return ResponseEntity.ok(memberResponse);
     }
@@ -59,13 +60,15 @@ public class MemberController {
     public ResponseEntity<MemberPageResponse> searchMembers(@VerifiedMember @Nullable final Long loggedInId,
                                                             @ModelAttribute final MemberSearchRequest memberSearchRequest,
                                                             final Pageable pageable) {
-        final MemberPageResponse memberPageResponse = memberService.findByContains(loggedInId, memberSearchRequest, pageable);
+        final MemberPageResponse memberPageResponse = memberService.findBySearchConditions(loggedInId,
+                memberSearchRequest, pageable);
         return ResponseEntity.ok(memberPageResponse);
     }
 
     @PostMapping("/{memberId}/following")
     @Login
-    public ResponseEntity<Void> follow(@VerifiedMember final Long followerId, @PathVariable("memberId") final Long followingId) {
+    public ResponseEntity<Void> follow(@VerifiedMember final Long followerId,
+                                       @PathVariable("memberId") final Long followingId) {
         memberService.follow(followerId, followingId);
         return ResponseEntity.noContent()
                 .build();
@@ -73,7 +76,8 @@ public class MemberController {
 
     @DeleteMapping("/{memberId}/following")
     @Login
-    public ResponseEntity<Void> unfollow(@VerifiedMember final Long followerId, @PathVariable("memberId") final Long followingId) {
+    public ResponseEntity<Void> unfollow(@VerifiedMember final Long followerId,
+                                         @PathVariable("memberId") final Long followingId) {
         memberService.unfollow(followerId, followingId);
         return ResponseEntity.noContent()
                 .build();

--- a/backend/src/test/java/com/woowacourse/f12/acceptance/support/DatabaseCleanup.java
+++ b/backend/src/test/java/com/woowacourse/f12/acceptance/support/DatabaseCleanup.java
@@ -1,5 +1,7 @@
 package com.woowacourse.f12.acceptance.support;
 
+import static com.woowacourse.f12.acceptance.support.EscapeSqlUtil.escapeTableName;
+
 import java.util.List;
 import java.util.stream.Collectors;
 import javax.persistence.EntityManager;
@@ -31,8 +33,9 @@ public class DatabaseCleanup implements InitializingBean {
         entityManager.flush();
         entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY FALSE").executeUpdate();
         for (String tableName : tableNames) {
-            entityManager.createNativeQuery("TRUNCATE TABLE " + tableName).executeUpdate();
-            entityManager.createNativeQuery("ALTER TABLE " + tableName + " ALTER COLUMN ID RESTART WITH 1")
+            entityManager.createNativeQuery("TRUNCATE TABLE " + escapeTableName(tableName)).executeUpdate();
+            entityManager.createNativeQuery(
+                            "ALTER TABLE " + escapeTableName(tableName) + " ALTER COLUMN ID RESTART WITH 1")
                     .executeUpdate();
         }
         entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate();

--- a/backend/src/test/java/com/woowacourse/f12/acceptance/support/EscapeSqlUtil.java
+++ b/backend/src/test/java/com/woowacourse/f12/acceptance/support/EscapeSqlUtil.java
@@ -1,0 +1,12 @@
+package com.woowacourse.f12.acceptance.support;
+
+public class EscapeSqlUtil {
+
+    public static String escapeTableName(String tableName) {
+        if (tableName == null) {
+            return null;
+        }
+        return tableName.replace(" ", "")
+                .replace(";", "");
+    }
+}

--- a/backend/src/test/java/com/woowacourse/f12/application/member/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/application/member/MemberServiceTest.java
@@ -1,5 +1,28 @@
 package com.woowacourse.f12.application.member;
 
+import static com.woowacourse.f12.domain.member.CareerLevel.JUNIOR;
+import static com.woowacourse.f12.domain.member.CareerLevel.SENIOR;
+import static com.woowacourse.f12.domain.member.JobType.BACKEND;
+import static com.woowacourse.f12.domain.member.JobType.FRONTEND;
+import static com.woowacourse.f12.presentation.member.CareerLevelConstant.JUNIOR_CONSTANT;
+import static com.woowacourse.f12.presentation.member.CareerLevelConstant.SENIOR_CONSTANT;
+import static com.woowacourse.f12.presentation.member.JobTypeConstant.BACKEND_CONSTANT;
+import static com.woowacourse.f12.presentation.member.JobTypeConstant.ETC_CONSTANT;
+import static com.woowacourse.f12.presentation.member.JobTypeConstant.FRONTEND_CONSTANT;
+import static com.woowacourse.f12.support.fixture.InventoryProductFixtures.SELECTED_INVENTORY_PRODUCT;
+import static com.woowacourse.f12.support.fixture.MemberFixture.CORINNE;
+import static com.woowacourse.f12.support.fixture.MemberFixture.NOT_ADDITIONAL_INFO;
+import static com.woowacourse.f12.support.fixture.ProductFixture.KEYBOARD_1;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.verify;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.times;
+
 import com.woowacourse.f12.domain.inventoryproduct.InventoryProduct;
 import com.woowacourse.f12.domain.inventoryproduct.InventoryProductRepository;
 import com.woowacourse.f12.domain.member.Following;
@@ -15,6 +38,9 @@ import com.woowacourse.f12.exception.badrequest.AlreadyFollowingException;
 import com.woowacourse.f12.exception.badrequest.InvalidFollowerCountException;
 import com.woowacourse.f12.exception.badrequest.NotFollowingException;
 import com.woowacourse.f12.exception.notfound.MemberNotFoundException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -24,27 +50,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.domain.Sort;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-
-import static com.woowacourse.f12.domain.member.CareerLevel.SENIOR;
-import static com.woowacourse.f12.domain.member.JobType.BACKEND;
-import static com.woowacourse.f12.presentation.member.CareerLevelConstant.JUNIOR_CONSTANT;
-import static com.woowacourse.f12.presentation.member.CareerLevelConstant.SENIOR_CONSTANT;
-import static com.woowacourse.f12.presentation.member.JobTypeConstant.BACKEND_CONSTANT;
-import static com.woowacourse.f12.presentation.member.JobTypeConstant.ETC_CONSTANT;
-import static com.woowacourse.f12.support.fixture.InventoryProductFixtures.SELECTED_INVENTORY_PRODUCT;
-import static com.woowacourse.f12.support.fixture.MemberFixture.CORINNE;
-import static com.woowacourse.f12.support.fixture.MemberFixture.NOT_ADDITIONAL_INFO;
-import static com.woowacourse.f12.support.fixture.ProductFixture.KEYBOARD_1;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.*;
-import static org.mockito.Mockito.times;
 
 @ExtendWith(MockitoExtension.class)
 class MemberServiceTest {
@@ -159,14 +164,18 @@ class MemberServiceTest {
 
         given(memberRepository.findWithOutSearchConditions(pageable))
                 .willReturn(new SliceImpl<>(List.of(member), pageable, false));
+        given(inventoryProductRepository.findWithProductByMembers(List.of(member)))
+                .willReturn(List.of(inventoryProduct));
 
         // when
         MemberSearchRequest memberSearchRequest = new MemberSearchRequest(null, null, null);
-        MemberPageResponse memberPageResponse = memberService.findByContains(null, memberSearchRequest, pageable);
+        MemberPageResponse memberPageResponse = memberService.findBySearchConditions(null, memberSearchRequest,
+                pageable);
 
         // then
         assertAll(
                 () -> verify(memberRepository).findWithOutSearchConditions(pageable),
+                () -> verify(inventoryProductRepository).findWithProductByMembers(List.of(member)),
                 () -> assertThat(memberPageResponse.isHasNext()).isFalse(),
                 () -> assertThat(memberPageResponse.getItems()).usingRecursiveFieldByFieldElementComparator()
                         .containsOnly(MemberWithProfileProductResponse.of(member, false)));
@@ -181,14 +190,18 @@ class MemberServiceTest {
 
         given(memberRepository.findWithSearchConditions(null, SENIOR, BACKEND, pageable))
                 .willReturn(new SliceImpl<>(List.of(member), pageable, false));
+        given(inventoryProductRepository.findWithProductByMembers(List.of(member)))
+                .willReturn(List.of(inventoryProduct));
 
         // when
         MemberSearchRequest memberSearchRequest = new MemberSearchRequest(null, SENIOR_CONSTANT, BACKEND_CONSTANT);
-        MemberPageResponse memberPageResponse = memberService.findByContains(null, memberSearchRequest, pageable);
+        MemberPageResponse memberPageResponse = memberService.findBySearchConditions(null, memberSearchRequest,
+                pageable);
 
         // then
         assertAll(
                 () -> verify(memberRepository).findWithSearchConditions(null, SENIOR, BACKEND, pageable),
+                () -> verify(inventoryProductRepository).findWithProductByMembers(List.of(member)),
                 () -> assertThat(memberPageResponse.isHasNext()).isFalse(),
                 () -> assertThat(memberPageResponse.getItems()).usingRecursiveFieldByFieldElementComparator()
                         .containsOnly(MemberWithProfileProductResponse.of(member, false)));
@@ -208,7 +221,8 @@ class MemberServiceTest {
 
         // when
         MemberSearchRequest memberSearchRequest = new MemberSearchRequest("cheese", SENIOR_CONSTANT, BACKEND_CONSTANT);
-        MemberPageResponse memberPageResponse = memberService.findByContains(null, memberSearchRequest, pageable);
+        MemberPageResponse memberPageResponse = memberService.findBySearchConditions(null, memberSearchRequest,
+                pageable);
 
         // then
         assertAll(
@@ -242,7 +256,8 @@ class MemberServiceTest {
 
         // when
         MemberSearchRequest memberSearchRequest = new MemberSearchRequest("cheese", SENIOR_CONSTANT, BACKEND_CONSTANT);
-        MemberPageResponse memberPageResponse = memberService.findByContains(loggedInId, memberSearchRequest, pageable);
+        MemberPageResponse memberPageResponse = memberService.findBySearchConditions(loggedInId, memberSearchRequest,
+                pageable);
 
         // then
         assertAll(
@@ -252,6 +267,33 @@ class MemberServiceTest {
                 () -> assertThat(memberPageResponse.isHasNext()).isFalse(),
                 () -> assertThat(memberPageResponse.getItems()).usingRecursiveFieldByFieldElementComparator()
                         .containsOnly(MemberWithProfileProductResponse.of(member, true))
+        );
+    }
+
+    @Test
+    void 회원목록을_검색하여_조회할때_해당_결과가_없으면_다음_로직이_실행되지_않는다() {
+        // given
+        Pageable pageable = PageRequest.of(0, 10);
+        InventoryProduct inventoryProduct = SELECTED_INVENTORY_PRODUCT.생성(CORINNE.생성(1L), KEYBOARD_1.생성(1L));
+        Member member = CORINNE.인벤토리를_추가해서_생성(1L, List.of(inventoryProduct));
+        Long loggedInId = 2L;
+
+        given(memberRepository.findWithSearchConditions("invalid", JUNIOR, FRONTEND, pageable))
+                .willReturn(new SliceImpl<>(Collections.emptyList(), pageable, false));
+
+        // when
+        MemberSearchRequest memberSearchRequest = new MemberSearchRequest("invalid", JUNIOR_CONSTANT,
+                FRONTEND_CONSTANT);
+        MemberPageResponse memberPageResponse = memberService.findBySearchConditions(loggedInId, memberSearchRequest,
+                pageable);
+
+        // then
+        assertAll(
+                () -> verify(memberRepository).findWithSearchConditions("invalid", JUNIOR, FRONTEND, pageable),
+                () -> verify(inventoryProductRepository, times(0)).findWithProductByMembers(any()),
+                () -> verify(followingRepository, times(0)).findByFollowerIdAndFollowingIdIn(anyLong(), any()),
+                () -> assertThat(memberPageResponse.isHasNext()).isFalse(),
+                () -> assertThat(memberPageResponse.getItems()).isEmpty()
         );
     }
 
@@ -575,6 +617,31 @@ class MemberServiceTest {
                 () -> assertThat(memberPageResponse.isHasNext()).isFalse(),
                 () -> assertThat(memberPageResponse.getItems()).usingRecursiveFieldByFieldElementComparator()
                         .containsOnly(MemberWithProfileProductResponse.of(member, true))
+        );
+    }
+
+    @Test
+    void 팔로잉하는_회원목록을_검색할때_결과가_없으면_다음_로직이_실행되지_않는다() {
+        // given
+        Long loggedInId = 1L;
+        Pageable pageable = PageRequest.of(0, 10, Sort.by("id").descending());
+        MemberSearchRequest memberSearchRequest = new MemberSearchRequest("invalid", JUNIOR_CONSTANT,
+                FRONTEND_CONSTANT);
+
+        given(memberRepository.findFollowingsWithSearchConditions(loggedInId, "invalid", JUNIOR, FRONTEND, pageable))
+                .willReturn(new SliceImpl<>(Collections.emptyList(), pageable, false));
+
+        // when
+        MemberPageResponse memberPageResponse = memberService.findFollowingsByConditions(loggedInId,
+                memberSearchRequest, pageable);
+
+        // then
+        assertAll(
+                () -> verify(memberRepository).findFollowingsWithSearchConditions(loggedInId, "invalid", JUNIOR,
+                        FRONTEND, pageable),
+                () -> verify(inventoryProductRepository, times(0)).findWithProductByMembers(any()),
+                () -> assertThat(memberPageResponse.isHasNext()).isFalse(),
+                () -> assertThat(memberPageResponse.getItems()).isEmpty()
         );
     }
 }


### PR DESCRIPTION
# 작업 내용
인수테스트를 위한 Table을 truncate하는 로직에서 SQL을 생성하는 방식을 변경했다.
