### PR TITLE
[Hotfix/FE] 깃허브 프로필 링크 오류 수정

### DIFF
--- a/frontend/src/components/Profile/ProfileCard/ProfileCard.style.tsx
+++ b/frontend/src/components/Profile/ProfileCard/ProfileCard.style.tsx
@@ -94,6 +94,7 @@ export const RightButton = styled.button`
   font-size: 1.5rem;
 `;
 
+export const OuterLinkWrapper = styled.a``;
 export const LinkWrapper = styled(Link)``;
 
 export const ProfileViewButton = styled.button`

--- a/frontend/src/components/Profile/ProfileCard/ProfileCard.tsx
+++ b/frontend/src/components/Profile/ProfileCard/ProfileCard.tsx
@@ -129,13 +129,13 @@ function ProfileCard({
         <S.UserInfoWrapper>
           <S.UserNameWrapper>
             <S.UserName>{gitHubId}</S.UserName>
-            <S.LinkWrapper
-              to={`${GITHUB_URL}${gitHubId}`}
+            <S.OuterLinkWrapper
+              href={`${GITHUB_URL}${gitHubId}`}
               target="_blank"
               rel="noopener noreferrer"
             >
               <GithubIcon />
-            </S.LinkWrapper>
+            </S.OuterLinkWrapper>
           </S.UserNameWrapper>
           <S.FollowerCountWrapper>{followerCount}명이 팔로우함</S.FollowerCountWrapper>
           <S.UserCareer>


### PR DESCRIPTION
# issue: closes #673 

# 작업 내용
- 깃허브 프로필 링크와 서비스 내 사용자 프로필 페이지 이동 링크가 공유되고 있어서 발생
- 깃허브 프로필 링크용 스타일드 컴포넌트는 별개로 다시 만들어서 문제 해결