### PR TITLE
[BE] local 환경에서 repository test 시 쿼리 로그가 2번 남는 현상 수정

### DIFF
--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -11,7 +11,6 @@ spring:
   jpa:
     hibernate:
       ddl-auto: none
-    show-sql: true
     properties:
       hibernate:
         format_sql: true

--- a/backend/src/main/resources/log4j2/log4j2-local.xml
+++ b/backend/src/main/resources/log4j2/log4j2-local.xml
@@ -15,7 +15,7 @@
         <Logger name="org.hibernate.SQL" level="debug" additivity="false">
             <AppenderRef ref="ConsoleAppender"/>
         </Logger>
-        <Logger name="org.hibernate.type.descriptor.sql.BasicBinder" level="debug" additivity="false">
+        <Logger name="org.hibernate.type.descriptor.sql.BasicBinder" level="trace" additivity="false">
             <AppenderRef ref="ConsoleAppender"/>
         </Logger>
         <Root level="error">

--- a/backend/src/test/java/com/woowacourse/f12/domain/inventoryproduct/InventoryProductRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/domain/inventoryproduct/InventoryProductRepositoryTest.java
@@ -1,18 +1,5 @@
 package com.woowacourse.f12.domain.inventoryproduct;
 
-import com.woowacourse.f12.config.JpaConfig;
-import com.woowacourse.f12.domain.member.Member;
-import com.woowacourse.f12.domain.member.MemberRepository;
-import com.woowacourse.f12.domain.product.Product;
-import com.woowacourse.f12.domain.product.ProductRepository;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.Import;
-
-import java.util.List;
-import java.util.Optional;
-
 import static com.woowacourse.f12.support.fixture.InventoryProductFixtures.SELECTED_INVENTORY_PRODUCT;
 import static com.woowacourse.f12.support.fixture.InventoryProductFixtures.UNSELECTED_INVENTORY_PRODUCT;
 import static com.woowacourse.f12.support.fixture.MemberFixture.CORINNE;
@@ -21,7 +8,19 @@ import static com.woowacourse.f12.support.fixture.ProductFixture.KEYBOARD_1;
 import static com.woowacourse.f12.support.fixture.ProductFixture.KEYBOARD_2;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@DataJpaTest
+import com.woowacourse.f12.config.JpaConfig;
+import com.woowacourse.f12.domain.member.Member;
+import com.woowacourse.f12.domain.member.MemberRepository;
+import com.woowacourse.f12.domain.product.Product;
+import com.woowacourse.f12.domain.product.ProductRepository;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest(showSql = false)
 @Import(JpaConfig.class)
 class InventoryProductRepositoryTest {
 
@@ -103,7 +102,8 @@ class InventoryProductRepositoryTest {
         장비를_등록한다(UNSELECTED_INVENTORY_PRODUCT.생성(member, product));
 
         // when
-        Optional<InventoryProduct> actual = inventoryProductRepository.findWithProductByMemberAndProduct(member, product);
+        Optional<InventoryProduct> actual = inventoryProductRepository.findWithProductByMemberAndProduct(member,
+                product);
 
         // then
         assertThat(actual).isPresent();

--- a/backend/src/test/java/com/woowacourse/f12/domain/member/FollowingRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/domain/member/FollowingRepositoryTest.java
@@ -1,16 +1,15 @@
 package com.woowacourse.f12.domain.member;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.woowacourse.f12.config.JpaConfig;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
-@DataJpaTest
+@DataJpaTest(showSql = false)
 @Import(JpaConfig.class)
 class FollowingRepositoryTest {
 

--- a/backend/src/test/java/com/woowacourse/f12/domain/member/MemberRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/domain/member/MemberRepositoryTest.java
@@ -1,6 +1,20 @@
 package com.woowacourse.f12.domain.member;
 
+import static com.woowacourse.f12.domain.member.CareerLevel.JUNIOR;
+import static com.woowacourse.f12.domain.member.CareerLevel.SENIOR;
+import static com.woowacourse.f12.domain.member.JobType.BACKEND;
+import static com.woowacourse.f12.domain.member.JobType.FRONTEND;
+import static com.woowacourse.f12.support.fixture.MemberFixture.CORINNE;
+import static com.woowacourse.f12.support.fixture.MemberFixture.MINCHO;
+import static com.woowacourse.f12.support.fixture.MemberFixture.NOT_ADDITIONAL_INFO;
+import static com.woowacourse.f12.support.fixture.MemberFixture.OHZZI;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
 import com.woowacourse.f12.config.JpaConfig;
+import java.util.List;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
@@ -12,19 +26,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
-import java.util.List;
-
-import static com.woowacourse.f12.domain.member.CareerLevel.JUNIOR;
-import static com.woowacourse.f12.domain.member.CareerLevel.SENIOR;
-import static com.woowacourse.f12.domain.member.JobType.BACKEND;
-import static com.woowacourse.f12.domain.member.JobType.FRONTEND;
-import static com.woowacourse.f12.support.fixture.MemberFixture.*;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
-
-@DataJpaTest
+@DataJpaTest(showSql = false)
 @Import({JpaConfig.class})
 class MemberRepositoryTest {
 

--- a/backend/src/test/java/com/woowacourse/f12/domain/product/ProductRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/domain/product/ProductRepositoryTest.java
@@ -27,7 +27,7 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Order;
 
-@DataJpaTest
+@DataJpaTest(showSql = false)
 @Import(JpaConfig.class)
 class ProductRepositoryTest {
 

--- a/backend/src/test/java/com/woowacourse/f12/domain/review/ReviewRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/domain/review/ReviewRepositoryTest.java
@@ -35,7 +35,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 
-@DataJpaTest
+@DataJpaTest(showSql = false)
 @Import(JpaConfig.class)
 class ReviewRepositoryTest {
 


### PR DESCRIPTION
# issue: #694 

# 작업 내용
local 환경에서 respository test 시 쿼리 로그가 2번 남는 현상 수정

1. 처음에는 JPA의 로그를 활용하지 않고, log4j2의 로그를 활용하도록 수정하려고 했으나, format_sql이 지켜지지 않고 한줄로 나옴.
-> 실패
2. format_sql = true & show_sql=false로 설정하더라도 해당 현상이 해결되지 않음. (show-sql 설정이 무시되는 것 같음)
-> 실패
3. local 환경에서는 log4j2의 sql 로그를 활용하지 않고, JPA의 로그를 활용하려고 했음. Repository Test에서 쿼리 로그가 2번 남는 현상은 고쳐졌지만, release, main 환경에서 log4j2의 로그는 파일에 남겨지고 있지만, JPA의 로그는 스프링 부트 로그에 남고 있을 것이라 판단(nohup.output 에 기록되고 있을 것이다.)
-> 완벽하지 않은 성공

따라서 log4j2의 로그를 활용하기로 하고, JPA의 로그 남기는 옵션을 끄기로 했음.
방법은 문제가 되는 `@DataJpaTest` 어노테이션을 사용하는 테스트에서 show-sql을 false로 설정

