### PR TITLE
[BE] JWT 생성 방식 변경

### DIFF
--- a/backend/src/main/java/com/woowacourse/f12/application/auth/JwtProvider.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/auth/JwtProvider.java
@@ -44,7 +44,7 @@ public class JwtProvider {
                 .compact();
     }
 
-    public boolean validateToken(final String authorizationHeader) {
+    public boolean isValidToken(final String authorizationHeader) {
         final String token = authTokenExtractor.extractToken(authorizationHeader, TOKEN_TYPE);
         try {
             final Jws<Claims> claims = getClaimsJws(token);

--- a/backend/src/main/java/com/woowacourse/f12/application/auth/JwtProvider.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/auth/JwtProvider.java
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Component;
 public class JwtProvider {
 
     private static final String TOKEN_TYPE = "Bearer";
+    private static final String ACCESS_TOKEN_SUBJECT = "AccessToken";
 
     private final AuthTokenExtractor authTokenExtractor;
     private final Key secretKey;
@@ -35,9 +36,10 @@ public class JwtProvider {
         final Date validity = new Date(now.getTime() + validityInMilliseconds);
 
         return Jwts.builder()
-                .setSubject(id.toString())
+                .setSubject(ACCESS_TOKEN_SUBJECT)
                 .setIssuedAt(now)
                 .setExpiration(validity)
+                .claim("id", id.toString())
                 .signWith(secretKey, SignatureAlgorithm.HS256)
                 .compact();
     }
@@ -46,13 +48,23 @@ public class JwtProvider {
         final String token = authTokenExtractor.extractToken(authorizationHeader, TOKEN_TYPE);
         try {
             final Jws<Claims> claims = getClaimsJws(token);
-            return !claims
-                    .getBody()
-                    .getExpiration()
-                    .before(new Date());
+            return isAccessToken(claims) && isNotExpired(claims);
         } catch (JwtException | IllegalArgumentException e) {
             return false;
         }
+    }
+
+    private boolean isAccessToken(final Jws<Claims> claims) {
+        return claims.getBody()
+                .getSubject()
+                .equals(ACCESS_TOKEN_SUBJECT);
+    }
+
+    private boolean isNotExpired(final Jws<Claims> claims) {
+        return claims
+                .getBody()
+                .getExpiration()
+                .after(new Date());
     }
 
     private Jws<Claims> getClaimsJws(final String token) {
@@ -64,8 +76,8 @@ public class JwtProvider {
 
     public String getPayload(final String authorizationHeader) {
         final String token = authTokenExtractor.extractToken(authorizationHeader, TOKEN_TYPE);
-        return getClaimsJws(token)
+        return (String) getClaimsJws(token)
                 .getBody()
-                .getSubject();
+                .get("id");
     }
 }

--- a/backend/src/main/java/com/woowacourse/f12/application/member/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/member/MemberService.java
@@ -3,7 +3,12 @@ package com.woowacourse.f12.application.member;
 
 import com.woowacourse.f12.domain.inventoryproduct.InventoryProduct;
 import com.woowacourse.f12.domain.inventoryproduct.InventoryProductRepository;
-import com.woowacourse.f12.domain.member.*;
+import com.woowacourse.f12.domain.member.CareerLevel;
+import com.woowacourse.f12.domain.member.Following;
+import com.woowacourse.f12.domain.member.FollowingRepository;
+import com.woowacourse.f12.domain.member.JobType;
+import com.woowacourse.f12.domain.member.Member;
+import com.woowacourse.f12.domain.member.MemberRepository;
 import com.woowacourse.f12.dto.request.member.MemberRequest;
 import com.woowacourse.f12.dto.request.member.MemberSearchRequest;
 import com.woowacourse.f12.dto.response.member.LoggedInMemberResponse;
@@ -14,15 +19,14 @@ import com.woowacourse.f12.exception.badrequest.NotFollowingException;
 import com.woowacourse.f12.exception.notfound.MemberNotFoundException;
 import com.woowacourse.f12.presentation.member.CareerLevelConstant;
 import com.woowacourse.f12.presentation.member.JobTypeConstant;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
 
 @Service
 @Transactional(readOnly = true)
@@ -74,9 +78,13 @@ public class MemberService {
                 .orElseThrow(MemberNotFoundException::new);
     }
 
-    public MemberPageResponse findByContains(@Nullable final Long loggedInId,
-                                             final MemberSearchRequest memberSearchRequest, final Pageable pageable) {
+    public MemberPageResponse findBySearchConditions(@Nullable final Long loggedInId,
+                                                     final MemberSearchRequest memberSearchRequest,
+                                                     final Pageable pageable) {
         final Slice<Member> slice = findBySearchConditions(memberSearchRequest, pageable);
+        if (slice.isEmpty()) {
+            return MemberPageResponse.ofByFollowingCondition(slice, false);
+        }
         setInventoryProductsToMembers(slice);
         if (isNotLoggedIn(loggedInId)) {
             return MemberPageResponse.ofByFollowingCondition(slice, false);
@@ -170,9 +178,14 @@ public class MemberService {
         return followingRepository.findByFollowerIdAndFollowingId(followerId, followingId)
                 .orElseThrow(NotFollowingException::new);
     }
-    public MemberPageResponse findFollowingsByConditions(final Long loggedInId, final MemberSearchRequest memberSearchRequest,
+
+    public MemberPageResponse findFollowingsByConditions(final Long loggedInId,
+                                                         final MemberSearchRequest memberSearchRequest,
                                                          final Pageable pageable) {
         final Slice<Member> slice = findFollowingsBySearchConditions(loggedInId, memberSearchRequest, pageable);
+        if (slice.isEmpty()) {
+            return MemberPageResponse.ofByFollowingCondition(slice, false);
+        }
         setInventoryProductsToMembers(slice);
         return MemberPageResponse.ofByFollowingCondition(slice, true);
     }

--- a/backend/src/main/java/com/woowacourse/f12/domain/member/MemberRepositoryCustomImpl.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/member/MemberRepositoryCustomImpl.java
@@ -108,10 +108,8 @@ public class MemberRepositoryCustomImpl implements MemberRepositoryCustom {
     }
 
     private List<Long> findFollowingMemberIds(final Long loggedInId) {
-        return jpaQueryFactory.select(member.id)
-                .from(member)
-                .join(following)
-                .on(member.id.eq(following.followingId))
+        return jpaQueryFactory.select(following.followingId)
+                .from(following)
                 .where(
                         following.followerId.eq(loggedInId)
                 ).fetch();

--- a/backend/src/main/java/com/woowacourse/f12/presentation/auth/AuthInterceptor.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/auth/AuthInterceptor.java
@@ -48,7 +48,7 @@ public class AuthInterceptor implements HandlerInterceptor {
 
     private void validateAuthorization(final HttpServletRequest request) {
         final String authorizationHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
-        if (!jwtProvider.validateToken(authorizationHeader)) {
+        if (!jwtProvider.isValidToken(authorizationHeader)) {
             throw new TokenExpiredException();
         }
     }

--- a/backend/src/main/java/com/woowacourse/f12/presentation/member/MemberController.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/member/MemberController.java
@@ -41,7 +41,8 @@ public class MemberController {
 
     @GetMapping("/{memberId}")
     @Login(required = false)
-    public ResponseEntity<MemberResponse> show(@PathVariable final Long memberId, @VerifiedMember @Nullable final Long loggedInMemberId) {
+    public ResponseEntity<MemberResponse> show(@PathVariable final Long memberId,
+                                               @VerifiedMember @Nullable final Long loggedInMemberId) {
         final MemberResponse memberResponse = memberService.find(memberId, loggedInMemberId);
         return ResponseEntity.ok(memberResponse);
     }
@@ -59,13 +60,15 @@ public class MemberController {
     public ResponseEntity<MemberPageResponse> searchMembers(@VerifiedMember @Nullable final Long loggedInId,
                                                             @ModelAttribute final MemberSearchRequest memberSearchRequest,
                                                             final Pageable pageable) {
-        final MemberPageResponse memberPageResponse = memberService.findByContains(loggedInId, memberSearchRequest, pageable);
+        final MemberPageResponse memberPageResponse = memberService.findBySearchConditions(loggedInId,
+                memberSearchRequest, pageable);
         return ResponseEntity.ok(memberPageResponse);
     }
 
     @PostMapping("/{memberId}/following")
     @Login
-    public ResponseEntity<Void> follow(@VerifiedMember final Long followerId, @PathVariable("memberId") final Long followingId) {
+    public ResponseEntity<Void> follow(@VerifiedMember final Long followerId,
+                                       @PathVariable("memberId") final Long followingId) {
         memberService.follow(followerId, followingId);
         return ResponseEntity.noContent()
                 .build();
@@ -73,7 +76,8 @@ public class MemberController {
 
     @DeleteMapping("/{memberId}/following")
     @Login
-    public ResponseEntity<Void> unfollow(@VerifiedMember final Long followerId, @PathVariable("memberId") final Long followingId) {
+    public ResponseEntity<Void> unfollow(@VerifiedMember final Long followerId,
+                                         @PathVariable("memberId") final Long followingId) {
         memberService.unfollow(followerId, followingId);
         return ResponseEntity.noContent()
                 .build();

--- a/backend/src/test/java/com/woowacourse/f12/application/auth/JwtProviderTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/application/auth/JwtProviderTest.java
@@ -30,7 +30,7 @@ class JwtProviderTest {
         String authorizationHeader = "Bearer " + token;
 
         // when, then
-        assertThat(jwtProvider.validateToken(authorizationHeader)).isTrue();
+        assertThat(jwtProvider.isValidToken(authorizationHeader)).isTrue();
     }
 
     @Test
@@ -43,7 +43,7 @@ class JwtProviderTest {
         String authorizationHeader = "Bearer " + token;
 
         // when, then
-        assertThat(jwtProvider.validateToken(authorizationHeader)).isFalse();
+        assertThat(jwtProvider.isValidToken(authorizationHeader)).isFalse();
     }
 
     @Test
@@ -52,7 +52,7 @@ class JwtProviderTest {
         String authorizationHeader = "Bearer invalidToken";
 
         // when, then
-        assertThat(jwtProvider.validateToken(authorizationHeader)).isFalse();
+        assertThat(jwtProvider.isValidToken(authorizationHeader)).isFalse();
     }
 
     @Test
@@ -65,7 +65,7 @@ class JwtProviderTest {
         String authorizationHeader = "Bearer " + token;
 
         // when, then
-        assertThat(jwtProvider.validateToken(authorizationHeader)).isFalse();
+        assertThat(jwtProvider.isValidToken(authorizationHeader)).isFalse();
     }
 
     @Test

--- a/backend/src/test/java/com/woowacourse/f12/application/member/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/application/member/MemberServiceTest.java
@@ -1,5 +1,28 @@
 package com.woowacourse.f12.application.member;
 
+import static com.woowacourse.f12.domain.member.CareerLevel.JUNIOR;
+import static com.woowacourse.f12.domain.member.CareerLevel.SENIOR;
+import static com.woowacourse.f12.domain.member.JobType.BACKEND;
+import static com.woowacourse.f12.domain.member.JobType.FRONTEND;
+import static com.woowacourse.f12.presentation.member.CareerLevelConstant.JUNIOR_CONSTANT;
+import static com.woowacourse.f12.presentation.member.CareerLevelConstant.SENIOR_CONSTANT;
+import static com.woowacourse.f12.presentation.member.JobTypeConstant.BACKEND_CONSTANT;
+import static com.woowacourse.f12.presentation.member.JobTypeConstant.ETC_CONSTANT;
+import static com.woowacourse.f12.presentation.member.JobTypeConstant.FRONTEND_CONSTANT;
+import static com.woowacourse.f12.support.fixture.InventoryProductFixtures.SELECTED_INVENTORY_PRODUCT;
+import static com.woowacourse.f12.support.fixture.MemberFixture.CORINNE;
+import static com.woowacourse.f12.support.fixture.MemberFixture.NOT_ADDITIONAL_INFO;
+import static com.woowacourse.f12.support.fixture.ProductFixture.KEYBOARD_1;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.verify;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.times;
+
 import com.woowacourse.f12.domain.inventoryproduct.InventoryProduct;
 import com.woowacourse.f12.domain.inventoryproduct.InventoryProductRepository;
 import com.woowacourse.f12.domain.member.Following;
@@ -15,6 +38,9 @@ import com.woowacourse.f12.exception.badrequest.AlreadyFollowingException;
 import com.woowacourse.f12.exception.badrequest.InvalidFollowerCountException;
 import com.woowacourse.f12.exception.badrequest.NotFollowingException;
 import com.woowacourse.f12.exception.notfound.MemberNotFoundException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -24,27 +50,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.domain.Sort;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-
-import static com.woowacourse.f12.domain.member.CareerLevel.SENIOR;
-import static com.woowacourse.f12.domain.member.JobType.BACKEND;
-import static com.woowacourse.f12.presentation.member.CareerLevelConstant.JUNIOR_CONSTANT;
-import static com.woowacourse.f12.presentation.member.CareerLevelConstant.SENIOR_CONSTANT;
-import static com.woowacourse.f12.presentation.member.JobTypeConstant.BACKEND_CONSTANT;
-import static com.woowacourse.f12.presentation.member.JobTypeConstant.ETC_CONSTANT;
-import static com.woowacourse.f12.support.fixture.InventoryProductFixtures.SELECTED_INVENTORY_PRODUCT;
-import static com.woowacourse.f12.support.fixture.MemberFixture.CORINNE;
-import static com.woowacourse.f12.support.fixture.MemberFixture.NOT_ADDITIONAL_INFO;
-import static com.woowacourse.f12.support.fixture.ProductFixture.KEYBOARD_1;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.*;
-import static org.mockito.Mockito.times;
 
 @ExtendWith(MockitoExtension.class)
 class MemberServiceTest {
@@ -159,14 +164,18 @@ class MemberServiceTest {
 
         given(memberRepository.findWithOutSearchConditions(pageable))
                 .willReturn(new SliceImpl<>(List.of(member), pageable, false));
+        given(inventoryProductRepository.findWithProductByMembers(List.of(member)))
+                .willReturn(List.of(inventoryProduct));
 
         // when
         MemberSearchRequest memberSearchRequest = new MemberSearchRequest(null, null, null);
-        MemberPageResponse memberPageResponse = memberService.findByContains(null, memberSearchRequest, pageable);
+        MemberPageResponse memberPageResponse = memberService.findBySearchConditions(null, memberSearchRequest,
+                pageable);
 
         // then
         assertAll(
                 () -> verify(memberRepository).findWithOutSearchConditions(pageable),
+                () -> verify(inventoryProductRepository).findWithProductByMembers(List.of(member)),
                 () -> assertThat(memberPageResponse.isHasNext()).isFalse(),
                 () -> assertThat(memberPageResponse.getItems()).usingRecursiveFieldByFieldElementComparator()
                         .containsOnly(MemberWithProfileProductResponse.of(member, false)));
@@ -181,14 +190,18 @@ class MemberServiceTest {
 
         given(memberRepository.findWithSearchConditions(null, SENIOR, BACKEND, pageable))
                 .willReturn(new SliceImpl<>(List.of(member), pageable, false));
+        given(inventoryProductRepository.findWithProductByMembers(List.of(member)))
+                .willReturn(List.of(inventoryProduct));
 
         // when
         MemberSearchRequest memberSearchRequest = new MemberSearchRequest(null, SENIOR_CONSTANT, BACKEND_CONSTANT);
-        MemberPageResponse memberPageResponse = memberService.findByContains(null, memberSearchRequest, pageable);
+        MemberPageResponse memberPageResponse = memberService.findBySearchConditions(null, memberSearchRequest,
+                pageable);
 
         // then
         assertAll(
                 () -> verify(memberRepository).findWithSearchConditions(null, SENIOR, BACKEND, pageable),
+                () -> verify(inventoryProductRepository).findWithProductByMembers(List.of(member)),
                 () -> assertThat(memberPageResponse.isHasNext()).isFalse(),
                 () -> assertThat(memberPageResponse.getItems()).usingRecursiveFieldByFieldElementComparator()
                         .containsOnly(MemberWithProfileProductResponse.of(member, false)));
@@ -208,7 +221,8 @@ class MemberServiceTest {
 
         // when
         MemberSearchRequest memberSearchRequest = new MemberSearchRequest("cheese", SENIOR_CONSTANT, BACKEND_CONSTANT);
-        MemberPageResponse memberPageResponse = memberService.findByContains(null, memberSearchRequest, pageable);
+        MemberPageResponse memberPageResponse = memberService.findBySearchConditions(null, memberSearchRequest,
+                pageable);
 
         // then
         assertAll(
@@ -242,7 +256,8 @@ class MemberServiceTest {
 
         // when
         MemberSearchRequest memberSearchRequest = new MemberSearchRequest("cheese", SENIOR_CONSTANT, BACKEND_CONSTANT);
-        MemberPageResponse memberPageResponse = memberService.findByContains(loggedInId, memberSearchRequest, pageable);
+        MemberPageResponse memberPageResponse = memberService.findBySearchConditions(loggedInId, memberSearchRequest,
+                pageable);
 
         // then
         assertAll(
@@ -252,6 +267,33 @@ class MemberServiceTest {
                 () -> assertThat(memberPageResponse.isHasNext()).isFalse(),
                 () -> assertThat(memberPageResponse.getItems()).usingRecursiveFieldByFieldElementComparator()
                         .containsOnly(MemberWithProfileProductResponse.of(member, true))
+        );
+    }
+
+    @Test
+    void 회원목록을_검색하여_조회할때_해당_결과가_없으면_다음_로직이_실행되지_않는다() {
+        // given
+        Pageable pageable = PageRequest.of(0, 10);
+        InventoryProduct inventoryProduct = SELECTED_INVENTORY_PRODUCT.생성(CORINNE.생성(1L), KEYBOARD_1.생성(1L));
+        Member member = CORINNE.인벤토리를_추가해서_생성(1L, List.of(inventoryProduct));
+        Long loggedInId = 2L;
+
+        given(memberRepository.findWithSearchConditions("invalid", JUNIOR, FRONTEND, pageable))
+                .willReturn(new SliceImpl<>(Collections.emptyList(), pageable, false));
+
+        // when
+        MemberSearchRequest memberSearchRequest = new MemberSearchRequest("invalid", JUNIOR_CONSTANT,
+                FRONTEND_CONSTANT);
+        MemberPageResponse memberPageResponse = memberService.findBySearchConditions(loggedInId, memberSearchRequest,
+                pageable);
+
+        // then
+        assertAll(
+                () -> verify(memberRepository).findWithSearchConditions("invalid", JUNIOR, FRONTEND, pageable),
+                () -> verify(inventoryProductRepository, times(0)).findWithProductByMembers(any()),
+                () -> verify(followingRepository, times(0)).findByFollowerIdAndFollowingIdIn(anyLong(), any()),
+                () -> assertThat(memberPageResponse.isHasNext()).isFalse(),
+                () -> assertThat(memberPageResponse.getItems()).isEmpty()
         );
     }
 
@@ -575,6 +617,31 @@ class MemberServiceTest {
                 () -> assertThat(memberPageResponse.isHasNext()).isFalse(),
                 () -> assertThat(memberPageResponse.getItems()).usingRecursiveFieldByFieldElementComparator()
                         .containsOnly(MemberWithProfileProductResponse.of(member, true))
+        );
+    }
+
+    @Test
+    void 팔로잉하는_회원목록을_검색할때_결과가_없으면_다음_로직이_실행되지_않는다() {
+        // given
+        Long loggedInId = 1L;
+        Pageable pageable = PageRequest.of(0, 10, Sort.by("id").descending());
+        MemberSearchRequest memberSearchRequest = new MemberSearchRequest("invalid", JUNIOR_CONSTANT,
+                FRONTEND_CONSTANT);
+
+        given(memberRepository.findFollowingsWithSearchConditions(loggedInId, "invalid", JUNIOR, FRONTEND, pageable))
+                .willReturn(new SliceImpl<>(Collections.emptyList(), pageable, false));
+
+        // when
+        MemberPageResponse memberPageResponse = memberService.findFollowingsByConditions(loggedInId,
+                memberSearchRequest, pageable);
+
+        // then
+        assertAll(
+                () -> verify(memberRepository).findFollowingsWithSearchConditions(loggedInId, "invalid", JUNIOR,
+                        FRONTEND, pageable),
+                () -> verify(inventoryProductRepository, times(0)).findWithProductByMembers(any()),
+                () -> assertThat(memberPageResponse.isHasNext()).isFalse(),
+                () -> assertThat(memberPageResponse.getItems()).isEmpty()
         );
     }
 }

--- a/backend/src/test/java/com/woowacourse/f12/presentation/auth/AuthInterceptorTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/auth/AuthInterceptorTest.java
@@ -52,7 +52,7 @@ class AuthInterceptorTest extends PresentationTest {
         // given
         ReviewRequest reviewRequest = new ReviewRequest("content", 5);
         String authorizationHeader = "Bearer Token";
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(false);
         given(reviewService.saveReviewAndInventoryProduct(anyLong(), anyLong(), any(ReviewRequest.class)))
                 .willReturn(1L);
@@ -69,7 +69,7 @@ class AuthInterceptorTest extends PresentationTest {
 
         // then
         assertAll(
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(reviewService, times(0)).saveReviewAndInventoryProduct(eq(1L), eq(1L),
                         any(ReviewRequest.class))
         );
@@ -79,7 +79,7 @@ class AuthInterceptorTest extends PresentationTest {
     void 인증_인가가_필수가_아닌_경우에_만료된_액세스_토큰으로_요청보내면_예외발생() throws Exception {
         // given
         String authorizationHeader = "Bearer InvalidToken";
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(false);
         given(reviewService.findPageByProductId(anyLong(), anyLong(), any()))
                 .willReturn(null);
@@ -94,7 +94,7 @@ class AuthInterceptorTest extends PresentationTest {
 
         // then
         assertAll(
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(reviewService, times(0)).findPageByProductId(any(), any(), any())
         );
     }
@@ -102,7 +102,7 @@ class AuthInterceptorTest extends PresentationTest {
     @Test
     void 인증_인가가_필수인_경우에_토큰이_없는_경우_예외_발생() throws Exception {
         // given
-        given(jwtProvider.validateToken(any()))
+        given(jwtProvider.isValidToken(any()))
                 .willReturn(false);
         willDoNothing().given(reviewService).delete(anyLong(), anyLong());
 
@@ -114,7 +114,7 @@ class AuthInterceptorTest extends PresentationTest {
 
         // then
         assertAll(
-                () -> verify(jwtProvider, times(0)).validateToken(any()),
+                () -> verify(jwtProvider, times(0)).isValidToken(any()),
                 () -> verify(reviewService, times(0)).delete(any(), any())
         );
     }

--- a/backend/src/test/java/com/woowacourse/f12/presentation/inventoryproduct/InventoryProductControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/inventoryproduct/InventoryProductControllerTest.java
@@ -56,7 +56,7 @@ class InventoryProductControllerTest extends PresentationTest {
     void 대표_장비_등록_성공() throws Exception {
         // given
         String authorizationHeader = "Bearer Token";
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn("1");
@@ -79,7 +79,7 @@ class InventoryProductControllerTest extends PresentationTest {
                 );
 
         assertAll(
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(jwtProvider).getPayload(authorizationHeader),
                 () -> verify(inventoryProductService).updateProfileProducts(anyLong(), any(ProfileProductRequest.class))
         );
@@ -89,7 +89,7 @@ class InventoryProductControllerTest extends PresentationTest {
     void 대표_장비_등록_실패_인벤토리_상품_id가_없는_경우() throws Exception {
         // given
         String authorizationHeader = "Bearer Token";
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn("1");
@@ -110,7 +110,7 @@ class InventoryProductControllerTest extends PresentationTest {
                 .andDo(print());
 
         assertAll(
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(jwtProvider).getPayload(authorizationHeader),
                 () -> verify(inventoryProductService).updateProfileProducts(anyLong(), any(ProfileProductRequest.class))
         );
@@ -120,7 +120,7 @@ class InventoryProductControllerTest extends PresentationTest {
     void 대표_장비_등록_실패_요청된_장비가_모두_null인_경우() throws Exception {
         // given
         String authorizationHeader = "Bearer Token";
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         ProfileProductRequest profileProductRequest = new ProfileProductRequest(null);
 
@@ -137,7 +137,7 @@ class InventoryProductControllerTest extends PresentationTest {
                 .andDo(print());
 
         assertAll(
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(jwtProvider, times(0)).getPayload(authorizationHeader),
                 () -> verify(inventoryProductService, times(0)).updateProfileProducts(anyLong(),
                         any(ProfileProductRequest.class))
@@ -148,7 +148,7 @@ class InventoryProductControllerTest extends PresentationTest {
     void 대표_장비_등록_실패_요청된_장비가_중복된_카테고리인_경우() throws Exception {
         // given
         String authorizationHeader = "Bearer Token";
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn("1");
@@ -169,7 +169,7 @@ class InventoryProductControllerTest extends PresentationTest {
                 .andDo(print());
 
         assertAll(
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(jwtProvider).getPayload(authorizationHeader),
                 () -> verify(inventoryProductService).updateProfileProducts(anyLong(), any(ProfileProductRequest.class))
         );
@@ -179,7 +179,7 @@ class InventoryProductControllerTest extends PresentationTest {
     void 대표_장비_등록_실패_요청된_장비에_소프트웨어_카테고리가_포함된_경우() throws Exception {
         // given
         String authorizationHeader = "Bearer Token";
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn("1");
@@ -200,7 +200,7 @@ class InventoryProductControllerTest extends PresentationTest {
                 .andDo(print());
 
         assertAll(
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(jwtProvider).getPayload(authorizationHeader),
                 () -> verify(inventoryProductService).updateProfileProducts(anyLong(), any(ProfileProductRequest.class))
         );
@@ -213,7 +213,7 @@ class InventoryProductControllerTest extends PresentationTest {
         Member member = CORINNE.생성(memberId);
         InventoryProduct inventoryProduct = SELECTED_INVENTORY_PRODUCT.생성(1L, member, KEYBOARD_1.생성(1L));
         String authorizationHeader = "Bearer Token";
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn("1");
@@ -232,7 +232,7 @@ class InventoryProductControllerTest extends PresentationTest {
                 .andDo(document("inventoryProducts-get-own"));
 
         assertAll(
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(jwtProvider).getPayload(authorizationHeader),
                 () -> verify(inventoryProductService).findByMemberId(memberId)
         );

--- a/backend/src/test/java/com/woowacourse/f12/presentation/member/MemberControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/member/MemberControllerTest.java
@@ -76,7 +76,7 @@ class MemberControllerTest extends PresentationTest {
     void 로그인된_상태에서_나의_회원정보를_조회_성공() throws Exception {
         // given
         String authorizationHeader = "Bearer Token";
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn("1");
@@ -95,7 +95,7 @@ class MemberControllerTest extends PresentationTest {
                 .andDo(print());
 
         assertAll(
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(jwtProvider).getPayload(authorizationHeader),
                 () -> verify(memberService).findLoggedInMember(1L)
         );
@@ -148,7 +148,7 @@ class MemberControllerTest extends PresentationTest {
         String authorizationHeader = "Bearer Token";
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn(loggedInId.toString());
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(memberService.find(targetId, loggedInId))
                 .willReturn(MemberResponse.of(CORINNE.생성(targetId), false));
@@ -165,7 +165,7 @@ class MemberControllerTest extends PresentationTest {
 
         assertAll(
                 () -> verify(jwtProvider).getPayload(authorizationHeader),
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(memberService).find(targetId, loggedInId)
         );
     }
@@ -175,7 +175,7 @@ class MemberControllerTest extends PresentationTest {
         // given
         MemberRequest memberRequest = new MemberRequest(JUNIOR_CONSTANT, ETC_CONSTANT);
         String authorizationHeader = "Bearer Token";
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn("1");
@@ -195,7 +195,7 @@ class MemberControllerTest extends PresentationTest {
                 .andDo(print());
 
         assertAll(
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(jwtProvider).getPayload(authorizationHeader),
                 () -> verify(memberService).updateMember(eq(1L), any(MemberRequest.class))
         );
@@ -209,7 +209,7 @@ class MemberControllerTest extends PresentationTest {
         memberRequest.put("jobType", "backend");
 
         String authorizationHeader = "Bearer Token";
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn("1");
@@ -228,7 +228,7 @@ class MemberControllerTest extends PresentationTest {
                 .andDo(print());
 
         assertAll(
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(jwtProvider).getPayload(authorizationHeader),
                 () -> verify(memberService).updateMember(eq(1L), any(MemberRequest.class))
         );
@@ -242,7 +242,7 @@ class MemberControllerTest extends PresentationTest {
         memberRequest.put("jobType", "invalid");
 
         String authorizationHeader = "Bearer Token";
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn("1");
@@ -261,7 +261,7 @@ class MemberControllerTest extends PresentationTest {
                 .andDo(print());
 
         assertAll(
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(jwtProvider).getPayload(authorizationHeader),
                 () -> verify(memberService, times(0)).updateMember(eq(1L), any(MemberRequest.class))
         );
@@ -272,7 +272,7 @@ class MemberControllerTest extends PresentationTest {
         // given
         MemberRequest memberRequest = new MemberRequest(null, null);
         String authorizationHeader = "Bearer Token";
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn("1");
@@ -291,7 +291,7 @@ class MemberControllerTest extends PresentationTest {
                 .andDo(print());
 
         assertAll(
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(jwtProvider).getPayload(authorizationHeader),
                 () -> verify(memberService, times(0)).updateMember(eq(1L), any(MemberRequest.class))
         );
@@ -342,7 +342,7 @@ class MemberControllerTest extends PresentationTest {
                 new SliceImpl<>(List.of(member), pageable, false), List.of(following));
         String authorizationHeader = "Bearer Token";
 
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn(loggedInId.toString());
@@ -361,7 +361,7 @@ class MemberControllerTest extends PresentationTest {
                 .andDo(print());
 
         assertAll(
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(jwtProvider).getPayload(authorizationHeader),
                 () -> verify(memberService).findBySearchConditions(eq(loggedInId), refEq(memberSearchRequest),
                         refEq(pageable))
@@ -417,7 +417,7 @@ class MemberControllerTest extends PresentationTest {
         Long followingId = 2L;
 
         String authorizationHeader = "Bearer Token";
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn(followerId.toString());
@@ -443,7 +443,7 @@ class MemberControllerTest extends PresentationTest {
         Long followingId = 1L;
 
         String authorizationHeader = "Bearer Token";
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn(followerId.toString());
@@ -471,7 +471,7 @@ class MemberControllerTest extends PresentationTest {
         Long followingId = 2L;
 
         String authorizationHeader = "Bearer Token";
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn(followerId.toString());
@@ -499,7 +499,7 @@ class MemberControllerTest extends PresentationTest {
         Long followingId = 2L;
 
         String authorizationHeader = "Bearer Token";
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn(followerId.toString());
@@ -527,7 +527,7 @@ class MemberControllerTest extends PresentationTest {
         Long followingId = 2L;
 
         String authorizationHeader = "Bearer Token";
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn(followerId.toString());
@@ -555,7 +555,7 @@ class MemberControllerTest extends PresentationTest {
         Long followingId = 2L;
 
         String authorizationHeader = "Bearer Token";
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn(followerId.toString());
@@ -583,7 +583,7 @@ class MemberControllerTest extends PresentationTest {
         Long followingId = 2L;
 
         String authorizationHeader = "Bearer Token";
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn(followerId.toString());
@@ -611,7 +611,7 @@ class MemberControllerTest extends PresentationTest {
         Long followingId = 2L;
 
         String authorizationHeader = "Bearer Token";
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn(followerId.toString());
@@ -644,7 +644,7 @@ class MemberControllerTest extends PresentationTest {
                         false);
 
         String authorizationHeader = "Bearer Token";
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn(loggedInId.toString());
@@ -663,7 +663,7 @@ class MemberControllerTest extends PresentationTest {
                 .andDo(print());
 
         assertAll(
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(jwtProvider).getPayload(authorizationHeader),
                 () -> verify(memberService).findFollowingsByConditions(eq(loggedInId), refEq(memberSearchRequest),
                         eq(pageable))

--- a/backend/src/test/java/com/woowacourse/f12/presentation/review/ReviewControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/review/ReviewControllerTest.java
@@ -86,7 +86,7 @@ class ReviewControllerTest extends PresentationTest {
         // given
         ReviewRequest reviewRequest = new ReviewRequest("content", 5);
         String authorizationHeader = "Bearer Token";
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn("1");
@@ -109,7 +109,7 @@ class ReviewControllerTest extends PresentationTest {
                 );
 
         assertAll(
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(jwtProvider).getPayload(authorizationHeader),
                 () -> verify(reviewService).saveReviewAndInventoryProduct(eq(PRODUCT_ID), eq(1L),
                         any(ReviewRequest.class))
@@ -121,7 +121,7 @@ class ReviewControllerTest extends PresentationTest {
         // given
         ReviewRequest reviewRequest = new ReviewRequest(null, null);
         String authorizationHeader = "Bearer Token";
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn("1");
@@ -141,7 +141,7 @@ class ReviewControllerTest extends PresentationTest {
                 .andDo(print());
 
         assertAll(
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(reviewService, times(0)).saveReviewAndInventoryProduct(eq(PRODUCT_ID), eq(1L),
                         any(ReviewRequest.class))
         );
@@ -154,7 +154,7 @@ class ReviewControllerTest extends PresentationTest {
         Map<String, Object> reviewRequest = new HashMap<>();
         reviewRequest.put("content", "내용");
         reviewRequest.put("rating", "문자");
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn("1");
@@ -174,7 +174,7 @@ class ReviewControllerTest extends PresentationTest {
                 .andDo(print());
 
         assertAll(
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(reviewService, times(0)).saveReviewAndInventoryProduct(eq(PRODUCT_ID), eq(1L),
                         any(ReviewRequest.class))
         );
@@ -185,7 +185,7 @@ class ReviewControllerTest extends PresentationTest {
         // given
         String authorizationHeader = "Bearer Token";
         ReviewRequest reviewRequest = new ReviewRequest("", 5);
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn("1");
@@ -205,7 +205,7 @@ class ReviewControllerTest extends PresentationTest {
                 .andDo(print());
 
         assertAll(
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(jwtProvider).getPayload(authorizationHeader),
                 () -> verify(reviewService).saveReviewAndInventoryProduct(eq(PRODUCT_ID), eq(1L),
                         any(ReviewRequest.class))
@@ -218,7 +218,7 @@ class ReviewControllerTest extends PresentationTest {
         String authorizationHeader = "Bearer Token";
         String content = "a".repeat(1001);
         ReviewRequest reviewRequest = new ReviewRequest(content, 5);
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn("1");
@@ -238,7 +238,7 @@ class ReviewControllerTest extends PresentationTest {
                 .andDo(print());
 
         assertAll(
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(jwtProvider).getPayload(authorizationHeader),
                 () -> verify(reviewService).saveReviewAndInventoryProduct(eq(PRODUCT_ID), eq(1L),
                         any(ReviewRequest.class))
@@ -250,7 +250,7 @@ class ReviewControllerTest extends PresentationTest {
         // given
         String authorizationHeader = "Bearer Token";
         ReviewRequest reviewRequest = new ReviewRequest("내용", 0);
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn("1");
@@ -270,7 +270,7 @@ class ReviewControllerTest extends PresentationTest {
                 .andDo(print());
 
         assertAll(
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(jwtProvider).getPayload(authorizationHeader),
                 () -> verify(reviewService).saveReviewAndInventoryProduct(eq(PRODUCT_ID), eq(1L),
                         any(ReviewRequest.class))
@@ -282,7 +282,7 @@ class ReviewControllerTest extends PresentationTest {
         // given
         String authorizationHeader = "Bearer Token";
         ReviewRequest reviewRequest = new ReviewRequest("내용", 5);
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn("1");
@@ -302,7 +302,7 @@ class ReviewControllerTest extends PresentationTest {
                 .andDo(print());
 
         assertAll(
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(jwtProvider).getPayload(authorizationHeader),
                 () -> verify(reviewService).saveReviewAndInventoryProduct(eq(0L), eq(1L), any(ReviewRequest.class))
         );
@@ -313,7 +313,7 @@ class ReviewControllerTest extends PresentationTest {
         // given
         String authorizationHeader = "Bearer Token";
         ReviewRequest reviewRequest = new ReviewRequest("내용", 5);
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn("1");
@@ -333,7 +333,7 @@ class ReviewControllerTest extends PresentationTest {
                 .andDo(print());
 
         assertAll(
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(jwtProvider).getPayload(authorizationHeader),
                 () -> verify(reviewService).saveReviewAndInventoryProduct(eq(1L), eq(1L), any(ReviewRequest.class))
         );
@@ -344,7 +344,7 @@ class ReviewControllerTest extends PresentationTest {
         // given
         String authorizationHeader = "Bearer Token";
         ReviewRequest reviewRequest = new ReviewRequest("내용", 5);
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn("1");
@@ -364,7 +364,7 @@ class ReviewControllerTest extends PresentationTest {
                 .andDo(print());
 
         assertAll(
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(jwtProvider).getPayload(authorizationHeader),
                 () -> verify(reviewService).saveReviewAndInventoryProduct(eq(1L), eq(1L), any(ReviewRequest.class))
         );
@@ -375,7 +375,7 @@ class ReviewControllerTest extends PresentationTest {
         // given
         String authorizationHeader = "Bearer Token";
         ReviewRequest reviewRequest = new ReviewRequest("내용", 5);
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn("1");
@@ -399,7 +399,7 @@ class ReviewControllerTest extends PresentationTest {
 
         // then
         assertAll(
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(jwtProvider).getPayload(authorizationHeader),
                 () -> verify(reviewService).saveReviewAndInventoryProduct(eq(1L), eq(1L), any(ReviewRequest.class))
         );
@@ -478,7 +478,7 @@ class ReviewControllerTest extends PresentationTest {
 
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn("1");
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(reviewService.findPageByProductId(anyLong(), eq(corinne.getId()), any(Pageable.class)))
                 .willReturn(reviewWithAuthorPageResponse);
@@ -498,7 +498,7 @@ class ReviewControllerTest extends PresentationTest {
 
         assertAll(
                 () -> verify(jwtProvider).getPayload(authorizationHeader),
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(reviewService).findPageByProductId(product.getId(), corinne.getId(),
                         PageRequest.of(0, 10, Sort.by("createdAt", "id").descending()))
         );
@@ -531,7 +531,7 @@ class ReviewControllerTest extends PresentationTest {
         Long reviewId = 1L;
         Long memberId = 1L;
         ReviewRequest updateRequest = new ReviewRequest("수정된 내용", 4);
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn(memberId.toString());
@@ -552,7 +552,7 @@ class ReviewControllerTest extends PresentationTest {
                 );
 
         assertAll(
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(jwtProvider).getPayload(authorizationHeader),
                 () -> verify(reviewService).update(eq(reviewId), eq(memberId), any(ReviewRequest.class))
         );
@@ -565,7 +565,7 @@ class ReviewControllerTest extends PresentationTest {
         Long reviewId = 1L;
         Long memberId = 1L;
         ReviewRequest updateRequest = new ReviewRequest("수정된 내용", 4);
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn(memberId.toString());
@@ -585,7 +585,7 @@ class ReviewControllerTest extends PresentationTest {
                 .andDo(print());
 
         assertAll(
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(jwtProvider).getPayload(authorizationHeader),
                 () -> verify(reviewService).update(eq(reviewId), eq(memberId), any(ReviewRequest.class))
         );
@@ -598,7 +598,7 @@ class ReviewControllerTest extends PresentationTest {
         Long reviewId = 1L;
         Long memberId = 1L;
         ReviewRequest updateRequest = new ReviewRequest("수정된 내용", 4);
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn(memberId.toString());
@@ -618,7 +618,7 @@ class ReviewControllerTest extends PresentationTest {
                 .andDo(print());
 
         assertAll(
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(jwtProvider).getPayload(authorizationHeader),
                 () -> verify(reviewService).update(eq(reviewId), eq(memberId), any(ReviewRequest.class))
         );
@@ -631,7 +631,7 @@ class ReviewControllerTest extends PresentationTest {
         Long reviewId = 1L;
         Long memberId = 1L;
         ReviewRequest updateRequest = new ReviewRequest("수정된 내용", 4);
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn(memberId.toString());
@@ -651,7 +651,7 @@ class ReviewControllerTest extends PresentationTest {
                 .andDo(print());
 
         assertAll(
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(jwtProvider).getPayload(authorizationHeader),
                 () -> verify(reviewService).update(eq(reviewId), eq(memberId), any(ReviewRequest.class))
         );
@@ -663,7 +663,7 @@ class ReviewControllerTest extends PresentationTest {
         String authorizationHeader = "Bearer Token";
         Long reviewId = 1L;
         Long memberId = 1L;
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn(memberId.toString());
@@ -682,7 +682,7 @@ class ReviewControllerTest extends PresentationTest {
                 );
 
         assertAll(
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(jwtProvider).getPayload(authorizationHeader),
                 () -> verify(reviewService).delete(reviewId, memberId)
         );
@@ -694,7 +694,7 @@ class ReviewControllerTest extends PresentationTest {
         String authorizationHeader = "Bearer Token";
         Long reviewId = 1L;
         Long memberId = 1L;
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn(memberId.toString());
@@ -712,7 +712,7 @@ class ReviewControllerTest extends PresentationTest {
                 .andDo(print());
 
         assertAll(
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(jwtProvider).getPayload(authorizationHeader),
                 () -> verify(reviewService).delete(reviewId, memberId)
         );
@@ -724,7 +724,7 @@ class ReviewControllerTest extends PresentationTest {
         String authorizationHeader = "Bearer Token";
         Long reviewId = 1L;
         Long memberId = 1L;
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn(memberId.toString());
@@ -742,7 +742,7 @@ class ReviewControllerTest extends PresentationTest {
                 .andDo(print());
 
         assertAll(
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(jwtProvider).getPayload(authorizationHeader),
                 () -> verify(reviewService).delete(reviewId, memberId)
         );
@@ -754,7 +754,7 @@ class ReviewControllerTest extends PresentationTest {
         String authorizationHeader = "Bearer Token";
         Long reviewId = 1L;
         Long memberId = 1L;
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn(memberId.toString());
@@ -772,7 +772,7 @@ class ReviewControllerTest extends PresentationTest {
                 .andDo(print());
 
         assertAll(
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(jwtProvider).getPayload(authorizationHeader),
                 () -> verify(reviewService).delete(reviewId, memberId)
         );
@@ -808,7 +808,7 @@ class ReviewControllerTest extends PresentationTest {
         Long memberId = 1L;
         PageRequest pageable = PageRequest.of(0, 10, Sort.by("createdAt").descending());
         String authorizationHeader = "Bearer Token";
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn("1");

--- a/frontend/src/components/Profile/ProfileCard/ProfileCard.style.tsx
+++ b/frontend/src/components/Profile/ProfileCard/ProfileCard.style.tsx
@@ -94,6 +94,7 @@ export const RightButton = styled.button`
   font-size: 1.5rem;
 `;
 
+export const OuterLinkWrapper = styled.a``;
 export const LinkWrapper = styled(Link)``;
 
 export const ProfileViewButton = styled.button`

--- a/frontend/src/components/Profile/ProfileCard/ProfileCard.tsx
+++ b/frontend/src/components/Profile/ProfileCard/ProfileCard.tsx
@@ -129,13 +129,13 @@ function ProfileCard({
         <S.UserInfoWrapper>
           <S.UserNameWrapper>
             <S.UserName>{gitHubId}</S.UserName>
-            <S.LinkWrapper
-              to={`${GITHUB_URL}${gitHubId}`}
+            <S.OuterLinkWrapper
+              href={`${GITHUB_URL}${gitHubId}`}
               target="_blank"
               rel="noopener noreferrer"
             >
               <GithubIcon />
-            </S.LinkWrapper>
+            </S.OuterLinkWrapper>
           </S.UserNameWrapper>
           <S.FollowerCountWrapper>{followerCount}명이 팔로우함</S.FollowerCountWrapper>
           <S.UserCareer>


### PR DESCRIPTION
# issue: #691 

# 작업 내용
- JWT의 subject에는 "AccessToken" 이라는 값을 넣어 토큰의 주제를 표시
- subject 대신 claim에 payload를 저장
- payload를 꺼낼 때 subject가 "AccessToken" 인지 검증
- payload를 claims에서 꺼냄