### PR TITLE
[Feature/be] 인증 인가 수정

### DIFF
--- a/backend/src/main/java/com/woowacourse/f12/application/auth/AuthService.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/auth/AuthService.java
@@ -1,10 +1,16 @@
 package com.woowacourse.f12.application.auth;
 
+import com.woowacourse.f12.application.auth.token.JwtProvider;
+import com.woowacourse.f12.application.auth.token.RefreshToken;
+import com.woowacourse.f12.application.auth.token.RefreshTokenProvider;
+import com.woowacourse.f12.application.auth.token.RefreshTokenRepository;
 import com.woowacourse.f12.domain.member.Member;
 import com.woowacourse.f12.domain.member.MemberRepository;
+import com.woowacourse.f12.domain.member.Role;
 import com.woowacourse.f12.dto.response.auth.GitHubProfileResponse;
 import com.woowacourse.f12.dto.response.auth.IssuedTokensResponse;
 import com.woowacourse.f12.dto.result.LoginResult;
+import com.woowacourse.f12.exception.notfound.MemberNotFoundException;
 import com.woowacourse.f12.exception.unauthorized.RefreshTokenExpiredException;
 import com.woowacourse.f12.exception.unauthorized.RefreshTokenInvalidException;
 import org.springframework.stereotype.Service;
@@ -35,7 +41,7 @@ public class AuthService {
         final GitHubProfileResponse gitHubProfileResponse = getGitHubProfileResponse(code);
         final Member member = addOrUpdateMember(gitHubProfileResponse);
         final Long memberId = member.getId();
-        final String applicationAccessToken = jwtProvider.createAccessToken(memberId);
+        final String applicationAccessToken = jwtProvider.createAccessToken(memberId, member.getRole());
         final RefreshToken refreshToken = refreshTokenProvider.createToken(memberId);
         refreshTokenRepository.save(refreshToken);
         return new LoginResult(refreshToken.getRefreshToken(), applicationAccessToken, member);
@@ -59,7 +65,10 @@ public class AuthService {
                 .orElseThrow(RefreshTokenInvalidException::new);
         checkExpired(refreshTokenValue, refreshToken);
         final Long memberId = refreshToken.getMemberId();
-        final String newAccessToken = jwtProvider.createAccessToken(memberId);
+        final Role memberRole = memberRepository.findById(memberId)
+                .orElseThrow(MemberNotFoundException::new)
+                .getRole();
+        final String newAccessToken = jwtProvider.createAccessToken(memberId, memberRole);
         final RefreshToken newRefreshToken = refreshTokenProvider.createToken(memberId);
         refreshTokenRepository.save(newRefreshToken);
         refreshTokenRepository.delete(refreshTokenValue);

--- a/backend/src/main/java/com/woowacourse/f12/application/auth/token/InmemoryRefreshTokenRepository.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/auth/token/InmemoryRefreshTokenRepository.java
@@ -1,4 +1,4 @@
-package com.woowacourse.f12.application.auth;
+package com.woowacourse.f12.application.auth.token;
 
 import java.util.Map;
 import java.util.Optional;

--- a/backend/src/main/java/com/woowacourse/f12/application/auth/token/MemberPayload.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/auth/token/MemberPayload.java
@@ -1,0 +1,38 @@
+package com.woowacourse.f12.application.auth.token;
+
+import com.woowacourse.f12.domain.member.Role;
+import java.util.Objects;
+import lombok.Getter;
+
+@Getter
+public class MemberPayload {
+
+    private final Long id;
+    private final Role role;
+
+    public MemberPayload(final Long id, final Role role) {
+        this.id = id;
+        this.role = role;
+    }
+
+    public boolean isAdmin() {
+        return role == Role.ADMIN;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final MemberPayload that = (MemberPayload) o;
+        return Objects.equals(id, that.id) && role == that.role;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, role);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/application/auth/token/RefreshToken.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/auth/token/RefreshToken.java
@@ -1,4 +1,4 @@
-package com.woowacourse.f12.application.auth;
+package com.woowacourse.f12.application.auth.token;
 
 import java.time.LocalDateTime;
 import java.util.Objects;

--- a/backend/src/main/java/com/woowacourse/f12/application/auth/token/RefreshTokenProvider.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/auth/token/RefreshTokenProvider.java
@@ -1,4 +1,4 @@
-package com.woowacourse.f12.application.auth;
+package com.woowacourse.f12.application.auth.token;
 
 import java.time.LocalDateTime;
 import java.util.concurrent.TimeUnit;

--- a/backend/src/main/java/com/woowacourse/f12/application/auth/token/RefreshTokenRepository.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/auth/token/RefreshTokenRepository.java
@@ -1,4 +1,4 @@
-package com.woowacourse.f12.application.auth;
+package com.woowacourse.f12.application.auth.token;
 
 import java.util.Optional;
 

--- a/backend/src/main/java/com/woowacourse/f12/domain/member/Member.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/member/Member.java
@@ -58,7 +58,7 @@ public class Member {
     private InventoryProducts inventoryProducts = new InventoryProducts();
 
     @Builder.Default
-    @Enumerated
+    @Enumerated(EnumType.STRING)
     @Column(name = "role", nullable = false)
     private Role role = Role.USER;
 

--- a/backend/src/main/java/com/woowacourse/f12/domain/member/Member.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/member/Member.java
@@ -3,13 +3,21 @@ package com.woowacourse.f12.domain.member;
 import com.woowacourse.f12.domain.inventoryproduct.InventoryProduct;
 import com.woowacourse.f12.domain.inventoryproduct.InventoryProducts;
 import com.woowacourse.f12.exception.badrequest.InvalidFollowerCountException;
+import java.util.List;
+import java.util.Objects;
+import javax.persistence.Column;
+import javax.persistence.Embedded;
+import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
-import javax.persistence.*;
-import java.util.List;
-import java.util.Objects;
 
 @Entity
 @Table(name = "member")
@@ -49,11 +57,17 @@ public class Member {
     @Embedded
     private InventoryProducts inventoryProducts = new InventoryProducts();
 
+    @Builder.Default
+    @Enumerated
+    @Column(name = "role", nullable = false)
+    private Role role = Role.USER;
+
     protected Member() {
     }
 
-    private Member(final Long id, final String gitHubId, final String name, final String imageUrl, final boolean registered, final CareerLevel careerLevel,
-                   final JobType jobType, final int followerCount, final InventoryProducts inventoryProducts) {
+    private Member(final Long id, final String gitHubId, final String name, final String imageUrl,
+                   final boolean registered, final CareerLevel careerLevel, final JobType jobType,
+                   final int followerCount, final InventoryProducts inventoryProducts, final Role role) {
         this.id = id;
         this.gitHubId = gitHubId;
         this.name = name;
@@ -61,8 +75,9 @@ public class Member {
         this.registered = registered;
         this.careerLevel = careerLevel;
         this.jobType = jobType;
-        this.inventoryProducts = inventoryProducts;
         this.followerCount = followerCount;
+        this.inventoryProducts = inventoryProducts;
+        this.role = role;
     }
 
     public void update(final Member updateMember) {

--- a/backend/src/main/java/com/woowacourse/f12/domain/member/Role.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/member/Role.java
@@ -1,0 +1,6 @@
+package com.woowacourse.f12.domain.member;
+
+public enum Role {
+
+    USER, ADMIN
+}

--- a/backend/src/main/java/com/woowacourse/f12/dto/response/auth/IssuedTokensResponse.java
+++ b/backend/src/main/java/com/woowacourse/f12/dto/response/auth/IssuedTokensResponse.java
@@ -1,6 +1,6 @@
 package com.woowacourse.f12.dto.response.auth;
 
-import com.woowacourse.f12.application.auth.RefreshToken;
+import com.woowacourse.f12.application.auth.token.RefreshToken;
 import lombok.Getter;
 
 @Getter

--- a/backend/src/main/java/com/woowacourse/f12/presentation/auth/AuthArgumentResolver.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/auth/AuthArgumentResolver.java
@@ -1,7 +1,6 @@
 package com.woowacourse.f12.presentation.auth;
 
-import com.woowacourse.f12.application.auth.JwtProvider;
-import com.woowacourse.f12.exception.unauthorized.TokenInvalidFormatException;
+import com.woowacourse.f12.application.auth.token.JwtProvider;
 import java.util.Objects;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.HttpHeaders;
@@ -32,11 +31,6 @@ public class AuthArgumentResolver implements HandlerMethodArgumentResolver {
         if (Objects.isNull(authorizationHeader)) {
             return null;
         }
-        final String payload = jwtProvider.getPayload(authorizationHeader);
-        try {
-            return Long.parseLong(payload);
-        } catch (NumberFormatException e) {
-            throw new TokenInvalidFormatException();
-        }
+        return jwtProvider.getPayload(authorizationHeader);
     }
 }

--- a/backend/src/main/java/com/woowacourse/f12/presentation/auth/AuthInterceptor.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/auth/AuthInterceptor.java
@@ -48,7 +48,7 @@ public class AuthInterceptor implements HandlerInterceptor {
 
     private void validateAuthorization(final HttpServletRequest request) {
         final String authorizationHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
-        if (!jwtProvider.validateToken(authorizationHeader)) {
+        if (!jwtProvider.isValidToken(authorizationHeader)) {
             throw new TokenExpiredException();
         }
     }

--- a/backend/src/main/java/com/woowacourse/f12/presentation/auth/AuthInterceptor.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/auth/AuthInterceptor.java
@@ -1,6 +1,6 @@
 package com.woowacourse.f12.presentation.auth;
 
-import com.woowacourse.f12.application.auth.JwtProvider;
+import com.woowacourse.f12.application.auth.token.JwtProvider;
 import com.woowacourse.f12.exception.unauthorized.TokenExpiredException;
 import com.woowacourse.f12.exception.unauthorized.TokenNotExistsException;
 import javax.servlet.http.HttpServletRequest;

--- a/backend/src/main/java/com/woowacourse/f12/presentation/inventoryproduct/InventoryProductController.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/inventoryproduct/InventoryProductController.java
@@ -1,5 +1,6 @@
 package com.woowacourse.f12.presentation.inventoryproduct;
 
+import com.woowacourse.f12.application.auth.token.MemberPayload;
 import com.woowacourse.f12.application.inventoryproduct.InventoryProductService;
 import com.woowacourse.f12.dto.request.inventoryproduct.ProfileProductRequest;
 import com.woowacourse.f12.dto.response.inventoryproduct.InventoryProductsResponse;
@@ -28,15 +29,17 @@ public class InventoryProductController {
     @Login
     public ResponseEntity<Void> updateProfileProducts(
             @RequestBody @Valid final ProfileProductRequest profileProductRequest,
-            @VerifiedMember final Long memberId) {
-        inventoryProductService.updateProfileProducts(memberId, profileProductRequest);
+            @VerifiedMember final MemberPayload memberPayload) {
+        inventoryProductService.updateProfileProducts(memberPayload.getId(), profileProductRequest);
         return ResponseEntity.ok().build();
     }
 
     @GetMapping("/members/inventoryProducts")
     @Login
-    public ResponseEntity<InventoryProductsResponse> showMyInventoryProducts(@VerifiedMember final Long memberId) {
-        final InventoryProductsResponse inventoryProductsResponse = inventoryProductService.findByMemberId(memberId);
+    public ResponseEntity<InventoryProductsResponse> showMyInventoryProducts(
+            @VerifiedMember final MemberPayload memberPayload) {
+        final InventoryProductsResponse inventoryProductsResponse = inventoryProductService.findByMemberId(
+                memberPayload.getId());
         return ResponseEntity.ok(inventoryProductsResponse);
     }
 

--- a/backend/src/main/java/com/woowacourse/f12/presentation/member/MemberController.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/member/MemberController.java
@@ -1,5 +1,6 @@
 package com.woowacourse.f12.presentation.member;
 
+import com.woowacourse.f12.application.auth.token.MemberPayload;
 import com.woowacourse.f12.application.member.MemberService;
 import com.woowacourse.f12.dto.request.member.MemberRequest;
 import com.woowacourse.f12.dto.request.member.MemberSearchRequest;
@@ -34,60 +35,72 @@ public class MemberController {
 
     @GetMapping("/me")
     @Login
-    public ResponseEntity<LoggedInMemberResponse> showLoggedIn(@VerifiedMember final Long memberId) {
-        final LoggedInMemberResponse loggedInMemberResponse = memberService.findLoggedInMember(memberId);
+    public ResponseEntity<LoggedInMemberResponse> showLoggedIn(@VerifiedMember final MemberPayload memberPayload) {
+        final LoggedInMemberResponse loggedInMemberResponse = memberService.findLoggedInMember(memberPayload.getId());
         return ResponseEntity.ok(loggedInMemberResponse);
     }
 
     @GetMapping("/{memberId}")
     @Login(required = false)
     public ResponseEntity<MemberResponse> show(@PathVariable final Long memberId,
-                                               @VerifiedMember @Nullable final Long loggedInMemberId) {
-        final MemberResponse memberResponse = memberService.find(memberId, loggedInMemberId);
+                                               @VerifiedMember @Nullable final MemberPayload loggedInMemberPayload) {
+        Long id = getLoggedInMemberId(loggedInMemberPayload);
+        final MemberResponse memberResponse = memberService.find(memberId, id);
         return ResponseEntity.ok(memberResponse);
     }
 
     @PatchMapping("/me")
     @Login
-    public ResponseEntity<Void> updateMe(@VerifiedMember final Long memberId,
+    public ResponseEntity<Void> updateMe(@VerifiedMember final MemberPayload memberPayload,
                                          @Valid @RequestBody final MemberRequest memberRequest) {
-        memberService.updateMember(memberId, memberRequest);
+        memberService.updateMember(memberPayload.getId(), memberRequest);
         return ResponseEntity.ok().build();
     }
 
     @GetMapping
     @Login(required = false)
-    public ResponseEntity<MemberPageResponse> searchMembers(@VerifiedMember @Nullable final Long loggedInId,
-                                                            @ModelAttribute final MemberSearchRequest memberSearchRequest,
-                                                            final Pageable pageable) {
-        final MemberPageResponse memberPageResponse = memberService.findBySearchConditions(loggedInId,
+    public ResponseEntity<MemberPageResponse> searchMembers(
+            @VerifiedMember @Nullable final MemberPayload loggedInMemberPayload,
+            @ModelAttribute final MemberSearchRequest memberSearchRequest,
+            final Pageable pageable) {
+        Long loggedInMemberId = getLoggedInMemberId(loggedInMemberPayload);
+        final MemberPageResponse memberPageResponse = memberService.findBySearchConditions(loggedInMemberId,
                 memberSearchRequest, pageable);
         return ResponseEntity.ok(memberPageResponse);
     }
 
     @PostMapping("/{memberId}/following")
     @Login
-    public ResponseEntity<Void> follow(@VerifiedMember final Long followerId,
+    public ResponseEntity<Void> follow(@VerifiedMember final MemberPayload followerPayload,
                                        @PathVariable("memberId") final Long followingId) {
-        memberService.follow(followerId, followingId);
+        memberService.follow(followerPayload.getId(), followingId);
         return ResponseEntity.noContent()
                 .build();
     }
 
     @DeleteMapping("/{memberId}/following")
     @Login
-    public ResponseEntity<Void> unfollow(@VerifiedMember final Long followerId,
+    public ResponseEntity<Void> unfollow(@VerifiedMember final MemberPayload followerPayload,
                                          @PathVariable("memberId") final Long followingId) {
-        memberService.unfollow(followerId, followingId);
+        memberService.unfollow(followerPayload.getId(), followingId);
         return ResponseEntity.noContent()
                 .build();
     }
 
     @GetMapping("/me/followings")
     @Login
-    public ResponseEntity<MemberPageResponse> searchFollowings(@VerifiedMember final Long loggedInId,
-                                                               @ModelAttribute final MemberSearchRequest memberSearchRequest,
-                                                               final Pageable pageable) {
-        return ResponseEntity.ok(memberService.findFollowingsByConditions(loggedInId, memberSearchRequest, pageable));
+    public ResponseEntity<MemberPageResponse> searchFollowings(
+            @VerifiedMember final MemberPayload loggedInMemberPayload,
+            @ModelAttribute final MemberSearchRequest memberSearchRequest,
+            final Pageable pageable) {
+        return ResponseEntity.ok(
+                memberService.findFollowingsByConditions(loggedInMemberPayload.getId(), memberSearchRequest, pageable));
+    }
+
+    private Long getLoggedInMemberId(@Nullable final MemberPayload loggedInMemberPayload) {
+        if (loggedInMemberPayload == null) {
+            return null;
+        }
+        return loggedInMemberPayload.getId();
     }
 }

--- a/backend/src/main/java/com/woowacourse/f12/presentation/member/MemberController.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/member/MemberController.java
@@ -9,6 +9,7 @@ import com.woowacourse.f12.dto.response.member.MemberPageResponse;
 import com.woowacourse.f12.dto.response.member.MemberResponse;
 import com.woowacourse.f12.presentation.auth.Login;
 import com.woowacourse.f12.presentation.auth.VerifiedMember;
+import com.woowacourse.f12.support.MemberPayloadSupport;
 import javax.validation.Valid;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
@@ -44,8 +45,8 @@ public class MemberController {
     @Login(required = false)
     public ResponseEntity<MemberResponse> show(@PathVariable final Long memberId,
                                                @VerifiedMember @Nullable final MemberPayload loggedInMemberPayload) {
-        Long id = getLoggedInMemberId(loggedInMemberPayload);
-        final MemberResponse memberResponse = memberService.find(memberId, id);
+        Long loggedInMemberId = MemberPayloadSupport.getLoggedInMemberId(loggedInMemberPayload);
+        final MemberResponse memberResponse = memberService.find(memberId, loggedInMemberId);
         return ResponseEntity.ok(memberResponse);
     }
 
@@ -63,7 +64,7 @@ public class MemberController {
             @VerifiedMember @Nullable final MemberPayload loggedInMemberPayload,
             @ModelAttribute final MemberSearchRequest memberSearchRequest,
             final Pageable pageable) {
-        Long loggedInMemberId = getLoggedInMemberId(loggedInMemberPayload);
+        Long loggedInMemberId = MemberPayloadSupport.getLoggedInMemberId(loggedInMemberPayload);
         final MemberPageResponse memberPageResponse = memberService.findBySearchConditions(loggedInMemberId,
                 memberSearchRequest, pageable);
         return ResponseEntity.ok(memberPageResponse);
@@ -95,12 +96,5 @@ public class MemberController {
             final Pageable pageable) {
         return ResponseEntity.ok(
                 memberService.findFollowingsByConditions(loggedInMemberPayload.getId(), memberSearchRequest, pageable));
-    }
-
-    private Long getLoggedInMemberId(@Nullable final MemberPayload loggedInMemberPayload) {
-        if (loggedInMemberPayload == null) {
-            return null;
-        }
-        return loggedInMemberPayload.getId();
     }
 }

--- a/backend/src/main/java/com/woowacourse/f12/presentation/review/ReviewController.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/review/ReviewController.java
@@ -1,5 +1,6 @@
 package com.woowacourse.f12.presentation.review;
 
+import com.woowacourse.f12.application.auth.token.MemberPayload;
 import com.woowacourse.f12.application.review.ReviewService;
 import com.woowacourse.f12.dto.request.review.ReviewRequest;
 import com.woowacourse.f12.dto.response.review.ReviewWithAuthorAndProductPageResponse;
@@ -35,9 +36,9 @@ public class ReviewController {
     @PostMapping("/products/{productId}/reviews")
     @Login
     public ResponseEntity<Void> create(@PathVariable final Long productId,
-                                       @VerifiedMember final Long memberId,
+                                       @VerifiedMember final MemberPayload memberPayload,
                                        @Valid @RequestBody final ReviewRequest reviewRequest) {
-        final Long id = reviewService.saveReviewAndInventoryProduct(productId, memberId, reviewRequest);
+        final Long id = reviewService.saveReviewAndInventoryProduct(productId, memberPayload.getId(), reviewRequest);
         return ResponseEntity.created(URI.create("/api/v1/reviews/" + id))
                 .build();
     }
@@ -45,10 +46,11 @@ public class ReviewController {
     @GetMapping("/products/{productId}/reviews")
     @Login(required = false)
     public ResponseEntity<ReviewWithAuthorPageResponse> showPageByProductId(@PathVariable final Long productId,
-                                                                            @VerifiedMember @Nullable Long memberId,
+                                                                            @VerifiedMember @Nullable MemberPayload memberPayload,
                                                                             final Pageable pageable) {
-        final ReviewWithAuthorPageResponse reviewPageResponse = reviewService.findPageByProductId(productId, memberId,
-                pageable);
+        final Long loggedInMemberId = getLoggedInMemberId(memberPayload);
+        final ReviewWithAuthorPageResponse reviewPageResponse = reviewService.findPageByProductId(productId,
+                loggedInMemberId, pageable);
         return ResponseEntity.ok(reviewPageResponse);
     }
 
@@ -62,17 +64,18 @@ public class ReviewController {
     @PutMapping("/reviews/{reviewId}")
     @Login
     public ResponseEntity<Void> update(@PathVariable final Long reviewId,
-                                       @VerifiedMember final Long memberId,
+                                       @VerifiedMember final MemberPayload memberPayload,
                                        @Valid @RequestBody final ReviewRequest updateRequest) {
-        reviewService.update(reviewId, memberId, updateRequest);
+        reviewService.update(reviewId, memberPayload.getId(), updateRequest);
         return ResponseEntity.noContent()
                 .build();
     }
 
     @DeleteMapping("/reviews/{reviewId}")
     @Login
-    public ResponseEntity<Void> delete(@PathVariable final Long reviewId, @VerifiedMember final Long memberId) {
-        reviewService.delete(reviewId, memberId);
+    public ResponseEntity<Void> delete(@PathVariable final Long reviewId,
+                                       @VerifiedMember final MemberPayload memberPayload) {
+        reviewService.delete(reviewId, memberPayload.getId());
         return ResponseEntity.noContent()
                 .build();
     }
@@ -87,10 +90,11 @@ public class ReviewController {
 
     @GetMapping("/members/me/reviews")
     @Login
-    public ResponseEntity<ReviewWithProductPageResponse> showMyReviewPage(@VerifiedMember final Long memberId,
-                                                                          final Pageable pageable) {
-        final ReviewWithProductPageResponse reviewWithProductPageResponse = reviewService.findPageByMemberId(memberId,
-                pageable);
+    public ResponseEntity<ReviewWithProductPageResponse> showMyReviewPage(
+            @VerifiedMember final MemberPayload memberPayload,
+            final Pageable pageable) {
+        final ReviewWithProductPageResponse reviewWithProductPageResponse = reviewService.findPageByMemberId(
+                memberPayload.getId(), pageable);
         return ResponseEntity.ok(reviewWithProductPageResponse);
     }
 
@@ -98,5 +102,12 @@ public class ReviewController {
     public ResponseEntity<ReviewWithProductResponse> showReview(@PathVariable final Long inventoryProductId) {
         final ReviewWithProductResponse reviewResponse = reviewService.findByInventoryProductId(inventoryProductId);
         return ResponseEntity.ok(reviewResponse);
+    }
+
+    private Long getLoggedInMemberId(@Nullable final MemberPayload loggedInMemberPayload) {
+        if (loggedInMemberPayload == null) {
+            return null;
+        }
+        return loggedInMemberPayload.getId();
     }
 }

--- a/backend/src/main/java/com/woowacourse/f12/presentation/review/ReviewController.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/review/ReviewController.java
@@ -9,6 +9,7 @@ import com.woowacourse.f12.dto.response.review.ReviewWithProductPageResponse;
 import com.woowacourse.f12.dto.response.review.ReviewWithProductResponse;
 import com.woowacourse.f12.presentation.auth.Login;
 import com.woowacourse.f12.presentation.auth.VerifiedMember;
+import com.woowacourse.f12.support.MemberPayloadSupport;
 import java.net.URI;
 import javax.validation.Valid;
 import org.springframework.data.domain.Pageable;
@@ -48,7 +49,7 @@ public class ReviewController {
     public ResponseEntity<ReviewWithAuthorPageResponse> showPageByProductId(@PathVariable final Long productId,
                                                                             @VerifiedMember @Nullable MemberPayload memberPayload,
                                                                             final Pageable pageable) {
-        final Long loggedInMemberId = getLoggedInMemberId(memberPayload);
+        final Long loggedInMemberId = MemberPayloadSupport.getLoggedInMemberId(memberPayload);
         final ReviewWithAuthorPageResponse reviewPageResponse = reviewService.findPageByProductId(productId,
                 loggedInMemberId, pageable);
         return ResponseEntity.ok(reviewPageResponse);
@@ -102,12 +103,5 @@ public class ReviewController {
     public ResponseEntity<ReviewWithProductResponse> showReview(@PathVariable final Long inventoryProductId) {
         final ReviewWithProductResponse reviewResponse = reviewService.findByInventoryProductId(inventoryProductId);
         return ResponseEntity.ok(reviewResponse);
-    }
-
-    private Long getLoggedInMemberId(@Nullable final MemberPayload loggedInMemberPayload) {
-        if (loggedInMemberPayload == null) {
-            return null;
-        }
-        return loggedInMemberPayload.getId();
     }
 }

--- a/backend/src/main/java/com/woowacourse/f12/support/MemberPayloadSupport.java
+++ b/backend/src/main/java/com/woowacourse/f12/support/MemberPayloadSupport.java
@@ -1,0 +1,17 @@
+package com.woowacourse.f12.support;
+
+import com.woowacourse.f12.application.auth.token.MemberPayload;
+import javax.annotation.Nullable;
+
+public class MemberPayloadSupport {
+
+    private MemberPayloadSupport() {
+    }
+
+    public static Long getLoggedInMemberId(@Nullable final MemberPayload loggedInMemberPayload) {
+        if (loggedInMemberPayload == null) {
+            return null;
+        }
+        return loggedInMemberPayload.getId();
+    }
+}

--- a/backend/src/test/java/com/woowacourse/f12/application/auth/AuthServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/application/auth/AuthServiceTest.java
@@ -11,8 +11,13 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.verify;
 
+import com.woowacourse.f12.application.auth.token.JwtProvider;
+import com.woowacourse.f12.application.auth.token.RefreshToken;
+import com.woowacourse.f12.application.auth.token.RefreshTokenProvider;
+import com.woowacourse.f12.application.auth.token.RefreshTokenRepository;
 import com.woowacourse.f12.domain.member.Member;
 import com.woowacourse.f12.domain.member.MemberRepository;
+import com.woowacourse.f12.domain.member.Role;
 import com.woowacourse.f12.dto.response.auth.GitHubProfileResponse;
 import com.woowacourse.f12.dto.response.auth.IssuedTokensResponse;
 import com.woowacourse.f12.dto.result.LoginResult;
@@ -68,7 +73,7 @@ class AuthServiceTest {
                 .willReturn(Optional.empty());
         given(memberRepository.save(gitHubProfile.toMember()))
                 .willReturn(member);
-        given(jwtProvider.createAccessToken(member.getId()))
+        given(jwtProvider.createAccessToken(member.getId(), member.getRole()))
                 .willReturn(expectedAccessToken);
         given(refreshTokenProvider.createToken(memberId))
                 .willReturn(new RefreshToken(refreshTokenValue, memberId, expiredAt));
@@ -86,7 +91,7 @@ class AuthServiceTest {
                 () -> verify(gitHubOauthClient).getProfile(accessToken),
                 () -> verify(memberRepository).findByGitHubId(gitHubProfile.getGitHubId()),
                 () -> verify(memberRepository).save(gitHubProfile.toMember()),
-                () -> verify(jwtProvider).createAccessToken(memberId),
+                () -> verify(jwtProvider).createAccessToken(memberId, member.getRole()),
                 () -> verify(refreshTokenProvider).createToken(memberId)
         );
     }
@@ -107,7 +112,7 @@ class AuthServiceTest {
                 .willReturn(gitHubProfile);
         given(memberRepository.findByGitHubId(gitHubProfile.getGitHubId()))
                 .willReturn(Optional.of(member));
-        given(jwtProvider.createAccessToken(member.getId()))
+        given(jwtProvider.createAccessToken(member.getId(), member.getRole()))
                 .willReturn(applicationToken);
         given(refreshTokenProvider.createToken(memberId))
                 .willReturn(new RefreshToken(refreshTokenValue, memberId, expiredAt));
@@ -123,7 +128,7 @@ class AuthServiceTest {
                 () -> verify(gitHubOauthClient).getAccessToken(code),
                 () -> verify(gitHubOauthClient).getProfile(accessToken),
                 () -> verify(memberRepository).findByGitHubId(gitHubProfile.getGitHubId()),
-                () -> verify(jwtProvider).createAccessToken(memberId),
+                () -> verify(jwtProvider).createAccessToken(memberId, member.getRole()),
                 () -> verify(refreshTokenProvider).createToken(memberId)
         );
     }
@@ -143,8 +148,10 @@ class AuthServiceTest {
                 .willReturn(newRefreshToken);
         given(refreshTokenRepository.save(eq(newRefreshToken)))
                 .willReturn(newRefreshToken);
-        given(jwtProvider.createAccessToken(1L))
+        given(jwtProvider.createAccessToken(1L, Role.USER))
                 .willReturn(newAccessTokenValue);
+        given(memberRepository.findById(1L))
+                .willReturn(Optional.of(Member.builder().id(1L).build()));
         willDoNothing().given(refreshTokenRepository).delete(refreshTokenValue);
 
         // when
@@ -157,7 +164,7 @@ class AuthServiceTest {
                 () -> verify(refreshTokenRepository).findToken(refreshTokenValue),
                 () -> verify(refreshTokenProvider).createToken(memberId),
                 () -> verify(refreshTokenRepository).save(eq(newRefreshToken)),
-                () -> verify(jwtProvider).createAccessToken(1L),
+                () -> verify(jwtProvider).createAccessToken(1L, Role.USER),
                 () -> verify(refreshTokenRepository).delete(refreshTokenValue)
         );
     }

--- a/backend/src/test/java/com/woowacourse/f12/application/auth/JwtProviderTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/application/auth/JwtProviderTest.java
@@ -30,7 +30,7 @@ class JwtProviderTest {
         String authorizationHeader = "Bearer " + token;
 
         // when, then
-        assertThat(jwtProvider.validateToken(authorizationHeader)).isTrue();
+        assertThat(jwtProvider.isValidToken(authorizationHeader)).isTrue();
     }
 
     @Test
@@ -43,7 +43,7 @@ class JwtProviderTest {
         String authorizationHeader = "Bearer " + token;
 
         // when, then
-        assertThat(jwtProvider.validateToken(authorizationHeader)).isFalse();
+        assertThat(jwtProvider.isValidToken(authorizationHeader)).isFalse();
     }
 
     @Test
@@ -52,7 +52,7 @@ class JwtProviderTest {
         String authorizationHeader = "Bearer invalidToken";
 
         // when, then
-        assertThat(jwtProvider.validateToken(authorizationHeader)).isFalse();
+        assertThat(jwtProvider.isValidToken(authorizationHeader)).isFalse();
     }
 
     @Test
@@ -65,7 +65,7 @@ class JwtProviderTest {
         String authorizationHeader = "Bearer " + token;
 
         // when, then
-        assertThat(jwtProvider.validateToken(authorizationHeader)).isFalse();
+        assertThat(jwtProvider.isValidToken(authorizationHeader)).isFalse();
     }
 
     @Test

--- a/backend/src/test/java/com/woowacourse/f12/application/auth/token/FakeJwtProvider.java
+++ b/backend/src/test/java/com/woowacourse/f12/application/auth/token/FakeJwtProvider.java
@@ -1,0 +1,39 @@
+package com.woowacourse.f12.application.auth.token;
+
+import com.woowacourse.f12.domain.member.Role;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Date;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Value;
+
+public class FakeJwtProvider {
+
+    private static final String ACCESS_TOKEN_SUBJECT = "AccessToken";
+
+    private final Key secretKey;
+    private final long validityInMilliseconds;
+
+    public FakeJwtProvider(@Value("${security.jwt.secret-key}") final String secretKey,
+                           @Value("${security.jwt.expire-length}") final long validityInMilliseconds) {
+        this.secretKey = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
+        this.validityInMilliseconds = validityInMilliseconds;
+    }
+
+    public String createAccessToken(final String id, final Role role) {
+        final Date now = new Date();
+        final Date validity = new Date(now.getTime() + validityInMilliseconds);
+        final Map<String, Object> claims = Map.of("id", id, "role", role);
+
+        return Jwts.builder()
+                .setSubject(ACCESS_TOKEN_SUBJECT)
+                .setIssuedAt(now)
+                .setExpiration(validity)
+                .addClaims(claims)
+                .signWith(secretKey, SignatureAlgorithm.HS256)
+                .compact();
+    }
+}

--- a/backend/src/test/java/com/woowacourse/f12/application/auth/token/FakeJwtProvider.java
+++ b/backend/src/test/java/com/woowacourse/f12/application/auth/token/FakeJwtProvider.java
@@ -7,7 +7,6 @@ import io.jsonwebtoken.security.Keys;
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.util.Date;
-import java.util.Map;
 import org.springframework.beans.factory.annotation.Value;
 
 public class FakeJwtProvider {
@@ -23,16 +22,43 @@ public class FakeJwtProvider {
         this.validityInMilliseconds = validityInMilliseconds;
     }
 
-    public String createAccessToken(final String id, final Role role) {
+    public String createAccessToken(final Long id) {
         final Date now = new Date();
         final Date validity = new Date(now.getTime() + validityInMilliseconds);
-        final Map<String, Object> claims = Map.of("id", id, "role", role);
 
         return Jwts.builder()
                 .setSubject(ACCESS_TOKEN_SUBJECT)
                 .setIssuedAt(now)
                 .setExpiration(validity)
-                .addClaims(claims)
+                .claim("id", id)
+                .signWith(secretKey, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public String createAccessToken(final String id, final Role role) {
+        final Date now = new Date();
+        final Date validity = new Date(now.getTime() + validityInMilliseconds);
+
+        return Jwts.builder()
+                .setSubject(ACCESS_TOKEN_SUBJECT)
+                .setIssuedAt(now)
+                .setExpiration(validity)
+                .claim("id", id)
+                .claim("role", role)
+                .signWith(secretKey, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public String createAccessToken(final Long id, final String role) {
+        final Date now = new Date();
+        final Date validity = new Date(now.getTime() + validityInMilliseconds);
+
+        return Jwts.builder()
+                .setSubject(ACCESS_TOKEN_SUBJECT)
+                .setIssuedAt(now)
+                .setExpiration(validity)
+                .claim("id", id)
+                .claim("role", role)
                 .signWith(secretKey, SignatureAlgorithm.HS256)
                 .compact();
     }

--- a/backend/src/test/java/com/woowacourse/f12/application/auth/token/InmemoryRefreshTokenRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/application/auth/token/InmemoryRefreshTokenRepositoryTest.java
@@ -1,4 +1,4 @@
-package com.woowacourse.f12.application.auth;
+package com.woowacourse.f12.application.auth.token;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/backend/src/test/java/com/woowacourse/f12/application/auth/token/JwtProviderTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/application/auth/token/JwtProviderTest.java
@@ -88,9 +88,31 @@ class JwtProviderTest {
     }
 
     @Test
-    void 토큰의_payload_복호화_시_Long_id가_아니면_예외를_발생한다() {
+    void 토큰의_payload_복호화_시_Long_id가_아니면_예외를_반환한다() {
         // given
         String token = fakeJwtProvider.createAccessToken("string", Role.USER);
+        String authorizationHeader = "Bearer " + token;
+
+        // when, then
+        assertThatThrownBy(() -> jwtProvider.getPayload(authorizationHeader))
+                .isExactlyInstanceOf(TokenInvalidFormatException.class);
+    }
+
+    @Test
+    void 토큰의_payload_복호화_시_필요한_정보가_없으면_예외를_반환한다() {
+        // given
+        String token = fakeJwtProvider.createAccessToken(1L);
+        String authorizationHeader = "Bearer " + token;
+
+        // when, then
+        assertThatThrownBy(() -> jwtProvider.getPayload(authorizationHeader))
+                .isExactlyInstanceOf(TokenInvalidFormatException.class);
+    }
+
+    @Test
+    void 토큰의_payload_복호화_시_role값이_올바르지_않으면_예외를_반환한다() {
+        // given
+        String token = fakeJwtProvider.createAccessToken(1L, "invalid");
         String authorizationHeader = "Bearer " + token;
 
         // when, then

--- a/backend/src/test/java/com/woowacourse/f12/application/auth/token/RefreshTokenProviderTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/application/auth/token/RefreshTokenProviderTest.java
@@ -1,4 +1,4 @@
-package com.woowacourse.f12.application.auth;
+package com.woowacourse.f12.application.auth.token;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;

--- a/backend/src/test/java/com/woowacourse/f12/application/auth/token/RefreshTokenTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/application/auth/token/RefreshTokenTest.java
@@ -1,4 +1,4 @@
-package com.woowacourse.f12.application.auth;
+package com.woowacourse.f12.application.auth.token;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/backend/src/test/java/com/woowacourse/f12/presentation/PresentationTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/PresentationTest.java
@@ -1,6 +1,6 @@
 package com.woowacourse.f12.presentation;
 
-import com.woowacourse.f12.application.auth.JwtProvider;
+import com.woowacourse.f12.application.auth.token.JwtProvider;
 import com.woowacourse.f12.config.LoggingConfig;
 import com.woowacourse.f12.logging.ApiQueryCounter;
 import com.woowacourse.f12.presentation.auth.RefreshTokenCookieProvider;

--- a/backend/src/test/java/com/woowacourse/f12/presentation/auth/AuthInterceptorTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/auth/AuthInterceptorTest.java
@@ -52,7 +52,7 @@ class AuthInterceptorTest extends PresentationTest {
         // given
         ReviewRequest reviewRequest = new ReviewRequest("content", 5);
         String authorizationHeader = "Bearer Token";
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(false);
         given(reviewService.saveReviewAndInventoryProduct(anyLong(), anyLong(), any(ReviewRequest.class)))
                 .willReturn(1L);
@@ -69,7 +69,7 @@ class AuthInterceptorTest extends PresentationTest {
 
         // then
         assertAll(
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(reviewService, times(0)).saveReviewAndInventoryProduct(eq(1L), eq(1L),
                         any(ReviewRequest.class))
         );
@@ -79,7 +79,7 @@ class AuthInterceptorTest extends PresentationTest {
     void 인증_인가가_필수가_아닌_경우에_만료된_액세스_토큰으로_요청보내면_예외발생() throws Exception {
         // given
         String authorizationHeader = "Bearer InvalidToken";
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(false);
         given(reviewService.findPageByProductId(anyLong(), anyLong(), any()))
                 .willReturn(null);
@@ -94,7 +94,7 @@ class AuthInterceptorTest extends PresentationTest {
 
         // then
         assertAll(
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(reviewService, times(0)).findPageByProductId(any(), any(), any())
         );
     }
@@ -102,7 +102,7 @@ class AuthInterceptorTest extends PresentationTest {
     @Test
     void 인증_인가가_필수인_경우에_토큰이_없는_경우_예외_발생() throws Exception {
         // given
-        given(jwtProvider.validateToken(any()))
+        given(jwtProvider.isValidToken(any()))
                 .willReturn(false);
         willDoNothing().given(reviewService).delete(anyLong(), anyLong());
 
@@ -114,7 +114,7 @@ class AuthInterceptorTest extends PresentationTest {
 
         // then
         assertAll(
-                () -> verify(jwtProvider, times(0)).validateToken(any()),
+                () -> verify(jwtProvider, times(0)).isValidToken(any()),
                 () -> verify(reviewService, times(0)).delete(any(), any())
         );
     }

--- a/backend/src/test/java/com/woowacourse/f12/presentation/auth/AuthInterceptorTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/auth/AuthInterceptorTest.java
@@ -16,7 +16,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.woowacourse.f12.application.auth.JwtProvider;
+import com.woowacourse.f12.application.auth.token.JwtProvider;
 import com.woowacourse.f12.application.review.ReviewService;
 import com.woowacourse.f12.dto.request.review.ReviewRequest;
 import com.woowacourse.f12.presentation.PresentationTest;

--- a/backend/src/test/java/com/woowacourse/f12/presentation/inventoryproduct/InventoryProductControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/inventoryproduct/InventoryProductControllerTest.java
@@ -18,10 +18,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.woowacourse.f12.application.auth.JwtProvider;
+import com.woowacourse.f12.application.auth.token.JwtProvider;
+import com.woowacourse.f12.application.auth.token.MemberPayload;
 import com.woowacourse.f12.application.inventoryproduct.InventoryProductService;
 import com.woowacourse.f12.domain.inventoryproduct.InventoryProduct;
 import com.woowacourse.f12.domain.member.Member;
+import com.woowacourse.f12.domain.member.Role;
 import com.woowacourse.f12.dto.request.inventoryproduct.ProfileProductRequest;
 import com.woowacourse.f12.dto.response.inventoryproduct.InventoryProductsResponse;
 import com.woowacourse.f12.exception.badrequest.DuplicatedProfileProductCategoryException;
@@ -59,7 +61,7 @@ class InventoryProductControllerTest extends PresentationTest {
         given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
-                .willReturn("1");
+                .willReturn(new MemberPayload(1L, Role.USER));
         ProfileProductRequest profileProductRequest = new ProfileProductRequest(List.of(1L));
         willDoNothing().given(inventoryProductService).updateProfileProducts(1L, profileProductRequest);
 
@@ -92,7 +94,7 @@ class InventoryProductControllerTest extends PresentationTest {
         given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
-                .willReturn("1");
+                .willReturn(new MemberPayload(1L, Role.USER));
         ProfileProductRequest profileProductRequest = new ProfileProductRequest(List.of(1L));
         willThrow(new InventoryProductNotFoundException()).given(inventoryProductService)
                 .updateProfileProducts(anyLong(), any(ProfileProductRequest.class));
@@ -151,7 +153,7 @@ class InventoryProductControllerTest extends PresentationTest {
         given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
-                .willReturn("1");
+                .willReturn(new MemberPayload(1L, Role.USER));
         ProfileProductRequest profileProductRequest = new ProfileProductRequest(List.of(1L, 2L));
         willThrow(new DuplicatedProfileProductCategoryException())
                 .given(inventoryProductService).updateProfileProducts(anyLong(), any(ProfileProductRequest.class));
@@ -182,7 +184,7 @@ class InventoryProductControllerTest extends PresentationTest {
         given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
-                .willReturn("1");
+                .willReturn(new MemberPayload(1L, Role.USER));
         ProfileProductRequest profileProductRequest = new ProfileProductRequest(List.of(1L, 2L));
         willThrow(new InvalidProfileProductCategoryException())
                 .given(inventoryProductService).updateProfileProducts(anyLong(), any(ProfileProductRequest.class));
@@ -216,7 +218,7 @@ class InventoryProductControllerTest extends PresentationTest {
         given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
-                .willReturn("1");
+                .willReturn(new MemberPayload(1L, Role.USER));
         given(inventoryProductService.findByMemberId(memberId))
                 .willReturn(InventoryProductsResponse.from(List.of(inventoryProduct)));
 

--- a/backend/src/test/java/com/woowacourse/f12/presentation/inventoryproduct/InventoryProductControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/inventoryproduct/InventoryProductControllerTest.java
@@ -56,7 +56,7 @@ class InventoryProductControllerTest extends PresentationTest {
     void 대표_장비_등록_성공() throws Exception {
         // given
         String authorizationHeader = "Bearer Token";
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn("1");
@@ -79,7 +79,7 @@ class InventoryProductControllerTest extends PresentationTest {
                 );
 
         assertAll(
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(jwtProvider).getPayload(authorizationHeader),
                 () -> verify(inventoryProductService).updateProfileProducts(anyLong(), any(ProfileProductRequest.class))
         );
@@ -89,7 +89,7 @@ class InventoryProductControllerTest extends PresentationTest {
     void 대표_장비_등록_실패_인벤토리_상품_id가_없는_경우() throws Exception {
         // given
         String authorizationHeader = "Bearer Token";
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn("1");
@@ -110,7 +110,7 @@ class InventoryProductControllerTest extends PresentationTest {
                 .andDo(print());
 
         assertAll(
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(jwtProvider).getPayload(authorizationHeader),
                 () -> verify(inventoryProductService).updateProfileProducts(anyLong(), any(ProfileProductRequest.class))
         );
@@ -120,7 +120,7 @@ class InventoryProductControllerTest extends PresentationTest {
     void 대표_장비_등록_실패_요청된_장비가_모두_null인_경우() throws Exception {
         // given
         String authorizationHeader = "Bearer Token";
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         ProfileProductRequest profileProductRequest = new ProfileProductRequest(null);
 
@@ -137,7 +137,7 @@ class InventoryProductControllerTest extends PresentationTest {
                 .andDo(print());
 
         assertAll(
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(jwtProvider, times(0)).getPayload(authorizationHeader),
                 () -> verify(inventoryProductService, times(0)).updateProfileProducts(anyLong(),
                         any(ProfileProductRequest.class))
@@ -148,7 +148,7 @@ class InventoryProductControllerTest extends PresentationTest {
     void 대표_장비_등록_실패_요청된_장비가_중복된_카테고리인_경우() throws Exception {
         // given
         String authorizationHeader = "Bearer Token";
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn("1");
@@ -169,7 +169,7 @@ class InventoryProductControllerTest extends PresentationTest {
                 .andDo(print());
 
         assertAll(
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(jwtProvider).getPayload(authorizationHeader),
                 () -> verify(inventoryProductService).updateProfileProducts(anyLong(), any(ProfileProductRequest.class))
         );
@@ -179,7 +179,7 @@ class InventoryProductControllerTest extends PresentationTest {
     void 대표_장비_등록_실패_요청된_장비에_소프트웨어_카테고리가_포함된_경우() throws Exception {
         // given
         String authorizationHeader = "Bearer Token";
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn("1");
@@ -200,7 +200,7 @@ class InventoryProductControllerTest extends PresentationTest {
                 .andDo(print());
 
         assertAll(
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(jwtProvider).getPayload(authorizationHeader),
                 () -> verify(inventoryProductService).updateProfileProducts(anyLong(), any(ProfileProductRequest.class))
         );
@@ -213,7 +213,7 @@ class InventoryProductControllerTest extends PresentationTest {
         Member member = CORINNE.생성(memberId);
         InventoryProduct inventoryProduct = SELECTED_INVENTORY_PRODUCT.생성(1L, member, KEYBOARD_1.생성(1L));
         String authorizationHeader = "Bearer Token";
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn("1");
@@ -232,7 +232,7 @@ class InventoryProductControllerTest extends PresentationTest {
                 .andDo(document("inventoryProducts-get-own"));
 
         assertAll(
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(jwtProvider).getPayload(authorizationHeader),
                 () -> verify(inventoryProductService).findByMemberId(memberId)
         );

--- a/backend/src/test/java/com/woowacourse/f12/presentation/member/MemberControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/member/MemberControllerTest.java
@@ -26,11 +26,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.woowacourse.f12.application.auth.JwtProvider;
+import com.woowacourse.f12.application.auth.token.JwtProvider;
+import com.woowacourse.f12.application.auth.token.MemberPayload;
 import com.woowacourse.f12.application.member.MemberService;
 import com.woowacourse.f12.domain.inventoryproduct.InventoryProduct;
 import com.woowacourse.f12.domain.member.Following;
 import com.woowacourse.f12.domain.member.Member;
+import com.woowacourse.f12.domain.member.Role;
 import com.woowacourse.f12.dto.request.member.MemberRequest;
 import com.woowacourse.f12.dto.request.member.MemberSearchRequest;
 import com.woowacourse.f12.dto.response.member.LoggedInMemberResponse;
@@ -79,7 +81,7 @@ class MemberControllerTest extends PresentationTest {
         given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
-                .willReturn("1");
+                .willReturn(new MemberPayload(1L, Role.USER));
         given(memberService.findLoggedInMember(1L))
                 .willReturn(LoggedInMemberResponse.from(CORINNE.생성(1L)));
 
@@ -147,7 +149,7 @@ class MemberControllerTest extends PresentationTest {
         Long loggedInId = 2L;
         String authorizationHeader = "Bearer Token";
         given(jwtProvider.getPayload(authorizationHeader))
-                .willReturn(loggedInId.toString());
+                .willReturn(new MemberPayload(loggedInId, Role.USER));
         given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(memberService.find(targetId, loggedInId))
@@ -178,7 +180,7 @@ class MemberControllerTest extends PresentationTest {
         given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
-                .willReturn("1");
+                .willReturn(new MemberPayload(1L, Role.USER));
         willDoNothing().given(memberService).updateMember(1L, memberRequest);
 
         // when
@@ -212,7 +214,7 @@ class MemberControllerTest extends PresentationTest {
         given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
-                .willReturn("1");
+                .willReturn(new MemberPayload(1L, Role.USER));
         willDoNothing().given(memberService).updateMember(eq(1L), any(MemberRequest.class));
 
         // when
@@ -245,7 +247,7 @@ class MemberControllerTest extends PresentationTest {
         given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
-                .willReturn("1");
+                .willReturn(new MemberPayload(1L, Role.USER));
         willDoNothing().given(memberService).updateMember(eq(1L), any(MemberRequest.class));
 
         // when
@@ -275,7 +277,7 @@ class MemberControllerTest extends PresentationTest {
         given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
-                .willReturn("1");
+                .willReturn(new MemberPayload(1L, Role.USER));
         willDoNothing().given(memberService).updateMember(1L, memberRequest);
 
         // when
@@ -345,7 +347,7 @@ class MemberControllerTest extends PresentationTest {
         given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
-                .willReturn(loggedInId.toString());
+                .willReturn(new MemberPayload(loggedInId, Role.USER));
         given(memberService.findBySearchConditions(eq(loggedInId), any(MemberSearchRequest.class),
                 any(PageRequest.class)))
                 .willReturn(memberPageResponse);
@@ -420,7 +422,7 @@ class MemberControllerTest extends PresentationTest {
         given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
-                .willReturn(followerId.toString());
+                .willReturn(new MemberPayload(followerId, Role.USER));
 
         // when
         ResultActions resultActions = mockMvc.perform(
@@ -446,7 +448,7 @@ class MemberControllerTest extends PresentationTest {
         given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
-                .willReturn(followerId.toString());
+                .willReturn(new MemberPayload(followerId, Role.USER));
         willThrow(new SelfFollowException())
                 .given(memberService)
                 .follow(followerId, followingId);
@@ -474,7 +476,7 @@ class MemberControllerTest extends PresentationTest {
         given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
-                .willReturn(followerId.toString());
+                .willReturn(new MemberPayload(followerId, Role.USER));
         willThrow(new MemberNotFoundException())
                 .given(memberService)
                 .follow(followerId, followingId);
@@ -502,7 +504,7 @@ class MemberControllerTest extends PresentationTest {
         given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
-                .willReturn(followerId.toString());
+                .willReturn(new MemberPayload(followerId, Role.USER));
         willThrow(new AlreadyFollowingException())
                 .given(memberService)
                 .follow(followerId, followingId);
@@ -530,7 +532,7 @@ class MemberControllerTest extends PresentationTest {
         given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
-                .willReturn(followerId.toString());
+                .willReturn(new MemberPayload(followerId, Role.USER));
         willDoNothing().given(memberService)
                 .unfollow(followerId, followingId);
 
@@ -558,7 +560,7 @@ class MemberControllerTest extends PresentationTest {
         given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
-                .willReturn(followerId.toString());
+                .willReturn(new MemberPayload(followerId, Role.USER));
         willThrow(new MemberNotFoundException())
                 .given(memberService)
                 .unfollow(followerId, followingId);
@@ -586,7 +588,7 @@ class MemberControllerTest extends PresentationTest {
         given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
-                .willReturn(followerId.toString());
+                .willReturn(new MemberPayload(followerId, Role.USER));
         willThrow(new NotFollowingException())
                 .given(memberService)
                 .unfollow(followerId, followingId);
@@ -614,7 +616,7 @@ class MemberControllerTest extends PresentationTest {
         given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
-                .willReturn(followerId.toString());
+                .willReturn(new MemberPayload(followerId, Role.USER));
         willThrow(new InvalidFollowerCountException())
                 .given(memberService)
                 .unfollow(followerId, followingId);
@@ -647,7 +649,7 @@ class MemberControllerTest extends PresentationTest {
         given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
-                .willReturn(loggedInId.toString());
+                .willReturn(new MemberPayload(loggedInId, Role.USER));
         given(memberService.findFollowingsByConditions(eq(loggedInId), refEq(memberSearchRequest), eq(pageable)))
                 .willReturn(memberPageResponse);
 

--- a/backend/src/test/java/com/woowacourse/f12/presentation/member/MemberControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/member/MemberControllerTest.java
@@ -76,7 +76,7 @@ class MemberControllerTest extends PresentationTest {
     void 로그인된_상태에서_나의_회원정보를_조회_성공() throws Exception {
         // given
         String authorizationHeader = "Bearer Token";
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn("1");
@@ -95,7 +95,7 @@ class MemberControllerTest extends PresentationTest {
                 .andDo(print());
 
         assertAll(
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(jwtProvider).getPayload(authorizationHeader),
                 () -> verify(memberService).findLoggedInMember(1L)
         );
@@ -148,7 +148,7 @@ class MemberControllerTest extends PresentationTest {
         String authorizationHeader = "Bearer Token";
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn(loggedInId.toString());
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(memberService.find(targetId, loggedInId))
                 .willReturn(MemberResponse.of(CORINNE.생성(targetId), false));
@@ -165,7 +165,7 @@ class MemberControllerTest extends PresentationTest {
 
         assertAll(
                 () -> verify(jwtProvider).getPayload(authorizationHeader),
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(memberService).find(targetId, loggedInId)
         );
     }
@@ -175,7 +175,7 @@ class MemberControllerTest extends PresentationTest {
         // given
         MemberRequest memberRequest = new MemberRequest(JUNIOR_CONSTANT, ETC_CONSTANT);
         String authorizationHeader = "Bearer Token";
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn("1");
@@ -195,7 +195,7 @@ class MemberControllerTest extends PresentationTest {
                 .andDo(print());
 
         assertAll(
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(jwtProvider).getPayload(authorizationHeader),
                 () -> verify(memberService).updateMember(eq(1L), any(MemberRequest.class))
         );
@@ -209,7 +209,7 @@ class MemberControllerTest extends PresentationTest {
         memberRequest.put("jobType", "backend");
 
         String authorizationHeader = "Bearer Token";
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn("1");
@@ -228,7 +228,7 @@ class MemberControllerTest extends PresentationTest {
                 .andDo(print());
 
         assertAll(
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(jwtProvider).getPayload(authorizationHeader),
                 () -> verify(memberService).updateMember(eq(1L), any(MemberRequest.class))
         );
@@ -242,7 +242,7 @@ class MemberControllerTest extends PresentationTest {
         memberRequest.put("jobType", "invalid");
 
         String authorizationHeader = "Bearer Token";
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn("1");
@@ -261,7 +261,7 @@ class MemberControllerTest extends PresentationTest {
                 .andDo(print());
 
         assertAll(
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(jwtProvider).getPayload(authorizationHeader),
                 () -> verify(memberService, times(0)).updateMember(eq(1L), any(MemberRequest.class))
         );
@@ -272,7 +272,7 @@ class MemberControllerTest extends PresentationTest {
         // given
         MemberRequest memberRequest = new MemberRequest(null, null);
         String authorizationHeader = "Bearer Token";
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn("1");
@@ -291,7 +291,7 @@ class MemberControllerTest extends PresentationTest {
                 .andDo(print());
 
         assertAll(
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(jwtProvider).getPayload(authorizationHeader),
                 () -> verify(memberService, times(0)).updateMember(eq(1L), any(MemberRequest.class))
         );
@@ -342,7 +342,7 @@ class MemberControllerTest extends PresentationTest {
                 new SliceImpl<>(List.of(member), pageable, false), List.of(following));
         String authorizationHeader = "Bearer Token";
 
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn(loggedInId.toString());
@@ -361,7 +361,7 @@ class MemberControllerTest extends PresentationTest {
                 .andDo(print());
 
         assertAll(
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(jwtProvider).getPayload(authorizationHeader),
                 () -> verify(memberService).findBySearchConditions(eq(loggedInId), refEq(memberSearchRequest),
                         refEq(pageable))
@@ -417,7 +417,7 @@ class MemberControllerTest extends PresentationTest {
         Long followingId = 2L;
 
         String authorizationHeader = "Bearer Token";
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn(followerId.toString());
@@ -443,7 +443,7 @@ class MemberControllerTest extends PresentationTest {
         Long followingId = 1L;
 
         String authorizationHeader = "Bearer Token";
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn(followerId.toString());
@@ -471,7 +471,7 @@ class MemberControllerTest extends PresentationTest {
         Long followingId = 2L;
 
         String authorizationHeader = "Bearer Token";
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn(followerId.toString());
@@ -499,7 +499,7 @@ class MemberControllerTest extends PresentationTest {
         Long followingId = 2L;
 
         String authorizationHeader = "Bearer Token";
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn(followerId.toString());
@@ -527,7 +527,7 @@ class MemberControllerTest extends PresentationTest {
         Long followingId = 2L;
 
         String authorizationHeader = "Bearer Token";
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn(followerId.toString());
@@ -555,7 +555,7 @@ class MemberControllerTest extends PresentationTest {
         Long followingId = 2L;
 
         String authorizationHeader = "Bearer Token";
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn(followerId.toString());
@@ -583,7 +583,7 @@ class MemberControllerTest extends PresentationTest {
         Long followingId = 2L;
 
         String authorizationHeader = "Bearer Token";
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn(followerId.toString());
@@ -611,7 +611,7 @@ class MemberControllerTest extends PresentationTest {
         Long followingId = 2L;
 
         String authorizationHeader = "Bearer Token";
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn(followerId.toString());
@@ -644,7 +644,7 @@ class MemberControllerTest extends PresentationTest {
                         false);
 
         String authorizationHeader = "Bearer Token";
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn(loggedInId.toString());
@@ -663,7 +663,7 @@ class MemberControllerTest extends PresentationTest {
                 .andDo(print());
 
         assertAll(
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(jwtProvider).getPayload(authorizationHeader),
                 () -> verify(memberService).findFollowingsByConditions(eq(loggedInId), refEq(memberSearchRequest),
                         eq(pageable))

--- a/backend/src/test/java/com/woowacourse/f12/presentation/review/ReviewControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/review/ReviewControllerTest.java
@@ -86,7 +86,7 @@ class ReviewControllerTest extends PresentationTest {
         // given
         ReviewRequest reviewRequest = new ReviewRequest("content", 5);
         String authorizationHeader = "Bearer Token";
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn("1");
@@ -109,7 +109,7 @@ class ReviewControllerTest extends PresentationTest {
                 );
 
         assertAll(
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(jwtProvider).getPayload(authorizationHeader),
                 () -> verify(reviewService).saveReviewAndInventoryProduct(eq(PRODUCT_ID), eq(1L),
                         any(ReviewRequest.class))
@@ -121,7 +121,7 @@ class ReviewControllerTest extends PresentationTest {
         // given
         ReviewRequest reviewRequest = new ReviewRequest(null, null);
         String authorizationHeader = "Bearer Token";
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn("1");
@@ -141,7 +141,7 @@ class ReviewControllerTest extends PresentationTest {
                 .andDo(print());
 
         assertAll(
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(reviewService, times(0)).saveReviewAndInventoryProduct(eq(PRODUCT_ID), eq(1L),
                         any(ReviewRequest.class))
         );
@@ -154,7 +154,7 @@ class ReviewControllerTest extends PresentationTest {
         Map<String, Object> reviewRequest = new HashMap<>();
         reviewRequest.put("content", "내용");
         reviewRequest.put("rating", "문자");
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn("1");
@@ -174,7 +174,7 @@ class ReviewControllerTest extends PresentationTest {
                 .andDo(print());
 
         assertAll(
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(reviewService, times(0)).saveReviewAndInventoryProduct(eq(PRODUCT_ID), eq(1L),
                         any(ReviewRequest.class))
         );
@@ -185,7 +185,7 @@ class ReviewControllerTest extends PresentationTest {
         // given
         String authorizationHeader = "Bearer Token";
         ReviewRequest reviewRequest = new ReviewRequest("", 5);
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn("1");
@@ -205,7 +205,7 @@ class ReviewControllerTest extends PresentationTest {
                 .andDo(print());
 
         assertAll(
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(jwtProvider).getPayload(authorizationHeader),
                 () -> verify(reviewService).saveReviewAndInventoryProduct(eq(PRODUCT_ID), eq(1L),
                         any(ReviewRequest.class))
@@ -218,7 +218,7 @@ class ReviewControllerTest extends PresentationTest {
         String authorizationHeader = "Bearer Token";
         String content = "a".repeat(1001);
         ReviewRequest reviewRequest = new ReviewRequest(content, 5);
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn("1");
@@ -238,7 +238,7 @@ class ReviewControllerTest extends PresentationTest {
                 .andDo(print());
 
         assertAll(
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(jwtProvider).getPayload(authorizationHeader),
                 () -> verify(reviewService).saveReviewAndInventoryProduct(eq(PRODUCT_ID), eq(1L),
                         any(ReviewRequest.class))
@@ -250,7 +250,7 @@ class ReviewControllerTest extends PresentationTest {
         // given
         String authorizationHeader = "Bearer Token";
         ReviewRequest reviewRequest = new ReviewRequest("내용", 0);
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn("1");
@@ -270,7 +270,7 @@ class ReviewControllerTest extends PresentationTest {
                 .andDo(print());
 
         assertAll(
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(jwtProvider).getPayload(authorizationHeader),
                 () -> verify(reviewService).saveReviewAndInventoryProduct(eq(PRODUCT_ID), eq(1L),
                         any(ReviewRequest.class))
@@ -282,7 +282,7 @@ class ReviewControllerTest extends PresentationTest {
         // given
         String authorizationHeader = "Bearer Token";
         ReviewRequest reviewRequest = new ReviewRequest("내용", 5);
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn("1");
@@ -302,7 +302,7 @@ class ReviewControllerTest extends PresentationTest {
                 .andDo(print());
 
         assertAll(
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(jwtProvider).getPayload(authorizationHeader),
                 () -> verify(reviewService).saveReviewAndInventoryProduct(eq(0L), eq(1L), any(ReviewRequest.class))
         );
@@ -313,7 +313,7 @@ class ReviewControllerTest extends PresentationTest {
         // given
         String authorizationHeader = "Bearer Token";
         ReviewRequest reviewRequest = new ReviewRequest("내용", 5);
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn("1");
@@ -333,7 +333,7 @@ class ReviewControllerTest extends PresentationTest {
                 .andDo(print());
 
         assertAll(
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(jwtProvider).getPayload(authorizationHeader),
                 () -> verify(reviewService).saveReviewAndInventoryProduct(eq(1L), eq(1L), any(ReviewRequest.class))
         );
@@ -344,7 +344,7 @@ class ReviewControllerTest extends PresentationTest {
         // given
         String authorizationHeader = "Bearer Token";
         ReviewRequest reviewRequest = new ReviewRequest("내용", 5);
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn("1");
@@ -364,7 +364,7 @@ class ReviewControllerTest extends PresentationTest {
                 .andDo(print());
 
         assertAll(
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(jwtProvider).getPayload(authorizationHeader),
                 () -> verify(reviewService).saveReviewAndInventoryProduct(eq(1L), eq(1L), any(ReviewRequest.class))
         );
@@ -375,7 +375,7 @@ class ReviewControllerTest extends PresentationTest {
         // given
         String authorizationHeader = "Bearer Token";
         ReviewRequest reviewRequest = new ReviewRequest("내용", 5);
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn("1");
@@ -399,7 +399,7 @@ class ReviewControllerTest extends PresentationTest {
 
         // then
         assertAll(
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(jwtProvider).getPayload(authorizationHeader),
                 () -> verify(reviewService).saveReviewAndInventoryProduct(eq(1L), eq(1L), any(ReviewRequest.class))
         );
@@ -478,7 +478,7 @@ class ReviewControllerTest extends PresentationTest {
 
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn("1");
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(reviewService.findPageByProductId(anyLong(), eq(corinne.getId()), any(Pageable.class)))
                 .willReturn(reviewWithAuthorPageResponse);
@@ -498,7 +498,7 @@ class ReviewControllerTest extends PresentationTest {
 
         assertAll(
                 () -> verify(jwtProvider).getPayload(authorizationHeader),
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(reviewService).findPageByProductId(product.getId(), corinne.getId(),
                         PageRequest.of(0, 10, Sort.by("createdAt", "id").descending()))
         );
@@ -531,7 +531,7 @@ class ReviewControllerTest extends PresentationTest {
         Long reviewId = 1L;
         Long memberId = 1L;
         ReviewRequest updateRequest = new ReviewRequest("수정된 내용", 4);
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn(memberId.toString());
@@ -552,7 +552,7 @@ class ReviewControllerTest extends PresentationTest {
                 );
 
         assertAll(
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(jwtProvider).getPayload(authorizationHeader),
                 () -> verify(reviewService).update(eq(reviewId), eq(memberId), any(ReviewRequest.class))
         );
@@ -565,7 +565,7 @@ class ReviewControllerTest extends PresentationTest {
         Long reviewId = 1L;
         Long memberId = 1L;
         ReviewRequest updateRequest = new ReviewRequest("수정된 내용", 4);
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn(memberId.toString());
@@ -585,7 +585,7 @@ class ReviewControllerTest extends PresentationTest {
                 .andDo(print());
 
         assertAll(
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(jwtProvider).getPayload(authorizationHeader),
                 () -> verify(reviewService).update(eq(reviewId), eq(memberId), any(ReviewRequest.class))
         );
@@ -598,7 +598,7 @@ class ReviewControllerTest extends PresentationTest {
         Long reviewId = 1L;
         Long memberId = 1L;
         ReviewRequest updateRequest = new ReviewRequest("수정된 내용", 4);
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn(memberId.toString());
@@ -618,7 +618,7 @@ class ReviewControllerTest extends PresentationTest {
                 .andDo(print());
 
         assertAll(
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(jwtProvider).getPayload(authorizationHeader),
                 () -> verify(reviewService).update(eq(reviewId), eq(memberId), any(ReviewRequest.class))
         );
@@ -631,7 +631,7 @@ class ReviewControllerTest extends PresentationTest {
         Long reviewId = 1L;
         Long memberId = 1L;
         ReviewRequest updateRequest = new ReviewRequest("수정된 내용", 4);
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn(memberId.toString());
@@ -651,7 +651,7 @@ class ReviewControllerTest extends PresentationTest {
                 .andDo(print());
 
         assertAll(
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(jwtProvider).getPayload(authorizationHeader),
                 () -> verify(reviewService).update(eq(reviewId), eq(memberId), any(ReviewRequest.class))
         );
@@ -663,7 +663,7 @@ class ReviewControllerTest extends PresentationTest {
         String authorizationHeader = "Bearer Token";
         Long reviewId = 1L;
         Long memberId = 1L;
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn(memberId.toString());
@@ -682,7 +682,7 @@ class ReviewControllerTest extends PresentationTest {
                 );
 
         assertAll(
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(jwtProvider).getPayload(authorizationHeader),
                 () -> verify(reviewService).delete(reviewId, memberId)
         );
@@ -694,7 +694,7 @@ class ReviewControllerTest extends PresentationTest {
         String authorizationHeader = "Bearer Token";
         Long reviewId = 1L;
         Long memberId = 1L;
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn(memberId.toString());
@@ -712,7 +712,7 @@ class ReviewControllerTest extends PresentationTest {
                 .andDo(print());
 
         assertAll(
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(jwtProvider).getPayload(authorizationHeader),
                 () -> verify(reviewService).delete(reviewId, memberId)
         );
@@ -724,7 +724,7 @@ class ReviewControllerTest extends PresentationTest {
         String authorizationHeader = "Bearer Token";
         Long reviewId = 1L;
         Long memberId = 1L;
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn(memberId.toString());
@@ -742,7 +742,7 @@ class ReviewControllerTest extends PresentationTest {
                 .andDo(print());
 
         assertAll(
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(jwtProvider).getPayload(authorizationHeader),
                 () -> verify(reviewService).delete(reviewId, memberId)
         );
@@ -754,7 +754,7 @@ class ReviewControllerTest extends PresentationTest {
         String authorizationHeader = "Bearer Token";
         Long reviewId = 1L;
         Long memberId = 1L;
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn(memberId.toString());
@@ -772,7 +772,7 @@ class ReviewControllerTest extends PresentationTest {
                 .andDo(print());
 
         assertAll(
-                () -> verify(jwtProvider).validateToken(authorizationHeader),
+                () -> verify(jwtProvider).isValidToken(authorizationHeader),
                 () -> verify(jwtProvider).getPayload(authorizationHeader),
                 () -> verify(reviewService).delete(reviewId, memberId)
         );
@@ -808,7 +808,7 @@ class ReviewControllerTest extends PresentationTest {
         Long memberId = 1L;
         PageRequest pageable = PageRequest.of(0, 10, Sort.by("createdAt").descending());
         String authorizationHeader = "Bearer Token";
-        given(jwtProvider.validateToken(authorizationHeader))
+        given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
                 .willReturn("1");

--- a/backend/src/test/java/com/woowacourse/f12/presentation/review/ReviewControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/review/ReviewControllerTest.java
@@ -26,9 +26,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.woowacourse.f12.application.auth.JwtProvider;
+import com.woowacourse.f12.application.auth.token.JwtProvider;
+import com.woowacourse.f12.application.auth.token.MemberPayload;
 import com.woowacourse.f12.application.review.ReviewService;
 import com.woowacourse.f12.domain.member.Member;
+import com.woowacourse.f12.domain.member.Role;
 import com.woowacourse.f12.domain.product.Product;
 import com.woowacourse.f12.dto.request.review.ReviewRequest;
 import com.woowacourse.f12.dto.response.review.ReviewWithAuthorAndProductPageResponse;
@@ -89,7 +91,7 @@ class ReviewControllerTest extends PresentationTest {
         given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
-                .willReturn("1");
+                .willReturn(new MemberPayload(1L, Role.USER));
         given(reviewService.saveReviewAndInventoryProduct(anyLong(), anyLong(), any(ReviewRequest.class)))
                 .willReturn(1L);
 
@@ -124,7 +126,7 @@ class ReviewControllerTest extends PresentationTest {
         given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
-                .willReturn("1");
+                .willReturn(new MemberPayload(1L, Role.USER));
         given(reviewService.saveReviewAndInventoryProduct(anyLong(), anyLong(), any(ReviewRequest.class)))
                 .willThrow(new BlankContentException());
 
@@ -157,7 +159,7 @@ class ReviewControllerTest extends PresentationTest {
         given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
-                .willReturn("1");
+                .willReturn(new MemberPayload(1L, Role.USER));
         given(reviewService.saveReviewAndInventoryProduct(anyLong(), anyLong(), any(ReviewRequest.class)))
                 .willThrow(new BlankContentException());
 
@@ -188,7 +190,7 @@ class ReviewControllerTest extends PresentationTest {
         given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
-                .willReturn("1");
+                .willReturn(new MemberPayload(1L, Role.USER));
         given(reviewService.saveReviewAndInventoryProduct(anyLong(), anyLong(), any(ReviewRequest.class)))
                 .willThrow(new BlankContentException());
 
@@ -221,7 +223,7 @@ class ReviewControllerTest extends PresentationTest {
         given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
-                .willReturn("1");
+                .willReturn(new MemberPayload(1L, Role.USER));
         given(reviewService.saveReviewAndInventoryProduct(anyLong(), anyLong(), any(ReviewRequest.class)))
                 .willThrow(new InvalidContentLengthException(1000));
 
@@ -253,7 +255,7 @@ class ReviewControllerTest extends PresentationTest {
         given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
-                .willReturn("1");
+                .willReturn(new MemberPayload(1L, Role.USER));
         given(reviewService.saveReviewAndInventoryProduct(anyLong(), anyLong(), any(ReviewRequest.class)))
                 .willThrow(new InvalidRatingValueException());
 
@@ -285,7 +287,7 @@ class ReviewControllerTest extends PresentationTest {
         given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
-                .willReturn("1");
+                .willReturn(new MemberPayload(1L, Role.USER));
         given(reviewService.saveReviewAndInventoryProduct(anyLong(), anyLong(), any(ReviewRequest.class)))
                 .willThrow(new ProductNotFoundException());
 
@@ -316,7 +318,7 @@ class ReviewControllerTest extends PresentationTest {
         given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
-                .willReturn("1");
+                .willReturn(new MemberPayload(1L, Role.USER));
         given(reviewService.saveReviewAndInventoryProduct(anyLong(), anyLong(), any(ReviewRequest.class)))
                 .willThrow(new MemberNotFoundException());
 
@@ -347,7 +349,7 @@ class ReviewControllerTest extends PresentationTest {
         given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
-                .willReturn("1");
+                .willReturn(new MemberPayload(1L, Role.USER));
         given(reviewService.saveReviewAndInventoryProduct(anyLong(), anyLong(), any(ReviewRequest.class)))
                 .willThrow(new RegisterNotCompletedException());
 
@@ -378,7 +380,7 @@ class ReviewControllerTest extends PresentationTest {
         given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
-                .willReturn("1");
+                .willReturn(new MemberPayload(1L, Role.USER));
         given(reviewService.saveReviewAndInventoryProduct(anyLong(), anyLong(), any(ReviewRequest.class)))
                 .willThrow(new AlreadyWrittenReviewException());
 
@@ -477,7 +479,7 @@ class ReviewControllerTest extends PresentationTest {
                         pageable, false), corinne.getId());
 
         given(jwtProvider.getPayload(authorizationHeader))
-                .willReturn("1");
+                .willReturn(new MemberPayload(1L, Role.USER));
         given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(reviewService.findPageByProductId(anyLong(), eq(corinne.getId()), any(Pageable.class)))
@@ -534,7 +536,7 @@ class ReviewControllerTest extends PresentationTest {
         given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
-                .willReturn(memberId.toString());
+                .willReturn(new MemberPayload(memberId, Role.USER));
         willDoNothing().given(reviewService)
                 .update(eq(reviewId), eq(memberId), any(ReviewRequest.class));
 
@@ -568,7 +570,7 @@ class ReviewControllerTest extends PresentationTest {
         given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
-                .willReturn(memberId.toString());
+                .willReturn(new MemberPayload(memberId, Role.USER));
         willThrow(new MemberNotFoundException()).given(reviewService)
                 .update(eq(reviewId), eq(memberId), any(ReviewRequest.class));
 
@@ -601,7 +603,7 @@ class ReviewControllerTest extends PresentationTest {
         given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
-                .willReturn(memberId.toString());
+                .willReturn(new MemberPayload(memberId, Role.USER));
         willThrow(new ReviewNotFoundException()).given(reviewService)
                 .update(eq(reviewId), eq(memberId), any(ReviewRequest.class));
 
@@ -634,7 +636,7 @@ class ReviewControllerTest extends PresentationTest {
         given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
-                .willReturn(memberId.toString());
+                .willReturn(new MemberPayload(memberId, Role.USER));
         willThrow(new NotAuthorException()).given(reviewService)
                 .update(eq(reviewId), eq(memberId), any(ReviewRequest.class));
 
@@ -666,7 +668,7 @@ class ReviewControllerTest extends PresentationTest {
         given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
-                .willReturn(memberId.toString());
+                .willReturn(new MemberPayload(memberId, Role.USER));
         willDoNothing().given(reviewService)
                 .delete(reviewId, memberId);
 
@@ -697,7 +699,7 @@ class ReviewControllerTest extends PresentationTest {
         given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
-                .willReturn(memberId.toString());
+                .willReturn(new MemberPayload(memberId, Role.USER));
         willThrow(new MemberNotFoundException()).given(reviewService)
                 .delete(reviewId, memberId);
 
@@ -727,7 +729,7 @@ class ReviewControllerTest extends PresentationTest {
         given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
-                .willReturn(memberId.toString());
+                .willReturn(new MemberPayload(memberId, Role.USER));
         willThrow(new ReviewNotFoundException()).given(reviewService)
                 .delete(reviewId, memberId);
 
@@ -757,7 +759,7 @@ class ReviewControllerTest extends PresentationTest {
         given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
-                .willReturn(memberId.toString());
+                .willReturn(new MemberPayload(memberId, Role.USER));
         willThrow(new NotAuthorException()).given(reviewService)
                 .delete(reviewId, memberId);
 
@@ -811,7 +813,7 @@ class ReviewControllerTest extends PresentationTest {
         given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         given(jwtProvider.getPayload(authorizationHeader))
-                .willReturn("1");
+                .willReturn(new MemberPayload(1L, Role.USER));
         given(reviewService.findPageByMemberId(anyLong(), any(Pageable.class)))
                 .willReturn(ReviewWithProductPageResponse.from(
                         new SliceImpl<>(List.of(


### PR DESCRIPTION
# issue: closes #577 closes #698 

# 작업 내용

### JWT 생성 방식 변경
- JWT의 subject에는 "AccessToken" 이라는 값을 넣어 토큰의 주제를 표시
- subject 대신 claim에 payload를 저장
- payload를 꺼낼 때 subject가 "AccessToken" 인지 검증
- payload를 claims에서 꺼냄

### 회원에게 Role 부여
- Member에 Role 필드 추가
- @VerifiedMember의 대상 타입 Long -> MemberPayload 변경
  - MemberPayload는 id와 Role을 가지고 있음
- JWT가 Payload 객체로 변환할 때 자동으로 타입 변환해줌
  - 기존처럼 NumberFormatException을 잡는 것이 아니라 RequiredTypeException을 잡아서 TokenInvalidFormatException으로 바꿔줌