### PR TITLE
[BugFix/BE] Github Oauth의 응답값이 DTO 필드에 존재하지 않는 경우 매핑 될 수 있도록 수정

### DIFF
--- a/backend/src/main/java/com/woowacourse/f12/application/auth/GitHubOauthClient.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/auth/GitHubOauthClient.java
@@ -78,8 +78,10 @@ public class GitHubOauthClient {
 
     private HttpRequest buildAccessTokenRequest(final String requestBody) {
         return HttpRequest.newBuilder(toURI(accessTokenUrl))
+                .header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
                 .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-                .POST(HttpRequest.BodyPublishers.ofString(requestBody)).build();
+                .POST(HttpRequest.BodyPublishers.ofString(requestBody))
+                .build();
     }
 
     private URI toURI(final String accessTokenUrl) {
@@ -132,7 +134,11 @@ public class GitHubOauthClient {
     }
 
     private HttpRequest buildProfileRequest(final String accessToken) {
-        return HttpRequest.newBuilder(toURI(profileUrl)).GET().header(HttpHeaders.AUTHORIZATION, "token " + accessToken)
+        return HttpRequest
+                .newBuilder(toURI(profileUrl))
+                .header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+                .header(HttpHeaders.AUTHORIZATION, "token " + accessToken)
+                .GET()
                 .build();
     }
 

--- a/backend/src/main/java/com/woowacourse/f12/application/auth/GitHubOauthClient.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/auth/GitHubOauthClient.java
@@ -7,6 +7,7 @@ import com.woowacourse.f12.dto.response.auth.GitHubProfileResponse;
 import com.woowacourse.f12.dto.response.auth.GitHubTokenResponse;
 import com.woowacourse.f12.exception.badrequest.InvalidGitHubLoginException;
 import com.woowacourse.f12.exception.internalserver.GitHubServerException;
+import com.woowacourse.f12.exception.internalserver.OauthJsonParsingException;
 import com.woowacourse.f12.exception.internalserver.OauthProcessingException;
 import java.io.IOException;
 import java.net.URI;
@@ -67,7 +68,7 @@ public class GitHubOauthClient {
         try {
             return objectMapper.writeValueAsString(gitHubTokenRequest);
         } catch (JsonProcessingException e) {
-            throw new OauthProcessingException();
+            throw new OauthJsonParsingException();
         }
     }
 
@@ -112,7 +113,7 @@ public class GitHubOauthClient {
         try {
             return objectMapper.readValue(response.body(), clazz);
         } catch (JsonProcessingException e) {
-            throw new OauthProcessingException();
+            throw new OauthJsonParsingException();
         }
     }
 

--- a/backend/src/main/java/com/woowacourse/f12/dto/response/auth/GitHubProfileResponse.java
+++ b/backend/src/main/java/com/woowacourse/f12/dto/response/auth/GitHubProfileResponse.java
@@ -1,10 +1,12 @@
 package com.woowacourse.f12.dto.response.auth;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.woowacourse.f12.domain.member.Member;
 import lombok.Getter;
 
 @Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class GitHubProfileResponse {
 
     @JsonProperty("login")

--- a/backend/src/main/java/com/woowacourse/f12/dto/response/auth/GitHubTokenResponse.java
+++ b/backend/src/main/java/com/woowacourse/f12/dto/response/auth/GitHubTokenResponse.java
@@ -1,9 +1,11 @@
 package com.woowacourse.f12.dto.response.auth;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 
 @Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class GitHubTokenResponse {
 
     @JsonProperty("access_token")

--- a/backend/src/main/java/com/woowacourse/f12/exception/internalserver/OauthJsonParsingException.java
+++ b/backend/src/main/java/com/woowacourse/f12/exception/internalserver/OauthJsonParsingException.java
@@ -1,0 +1,9 @@
+package com.woowacourse.f12.exception.internalserver;
+
+import com.woowacourse.f12.exception.ErrorCode;
+
+public class OauthJsonParsingException extends InternalServerException {
+    public OauthJsonParsingException() {
+        super(ErrorCode.INTERNAL_SERVER_ERROR, "Oauth 진행 중 데이터 파싱에 실패했습니다.");
+    }
+}


### PR DESCRIPTION
# issue: closes #704

# 작업 내용
- `@JsonIgnoreProperties(ignoreUnknown = true)`를 응답 DTO에 추가
- JSON 파싱 당시에 생긴 예외를 따로 분리해주기 위해서 커스텀 예외 추가 (하지만 내부 서버 예외 이므로 에러코드를 추가하지 않음)