### PR TITLE
[BugFix/BE] 제품 수정, 삭제 API DTO 카테고리 enum을 DTO용 Constant로 수정

### DIFF
--- a/backend/src/main/java/com/woowacourse/f12/dto/request/product/ProductCreateRequest.java
+++ b/backend/src/main/java/com/woowacourse/f12/dto/request/product/ProductCreateRequest.java
@@ -1,7 +1,7 @@
 package com.woowacourse.f12.dto.request.product;
 
-import com.woowacourse.f12.domain.product.Category;
 import com.woowacourse.f12.domain.product.Product;
+import com.woowacourse.f12.presentation.product.CategoryConstant;
 import javax.validation.constraints.NotNull;
 import lombok.Getter;
 
@@ -15,12 +15,12 @@ public class ProductCreateRequest {
     private String imageUrl;
 
     @NotNull(message = "카테고리가 없습니다.")
-    private Category category;
+    private CategoryConstant category;
 
     private ProductCreateRequest() {
     }
 
-    public ProductCreateRequest(final String name, final String imageUrl, final Category category) {
+    public ProductCreateRequest(final String name, final String imageUrl, final CategoryConstant category) {
         this.name = name;
         this.imageUrl = imageUrl;
         this.category = category;
@@ -28,7 +28,7 @@ public class ProductCreateRequest {
 
     public Product toProduct() {
         return Product.builder()
-                .category(category)
+                .category(category.toCategory())
                 .name(name)
                 .imageUrl(imageUrl)
                 .build();

--- a/backend/src/main/java/com/woowacourse/f12/dto/request/product/ProductUpdateRequest.java
+++ b/backend/src/main/java/com/woowacourse/f12/dto/request/product/ProductUpdateRequest.java
@@ -1,7 +1,7 @@
 package com.woowacourse.f12.dto.request.product;
 
-import com.woowacourse.f12.domain.product.Category;
 import com.woowacourse.f12.domain.product.Product;
+import com.woowacourse.f12.presentation.product.CategoryConstant;
 import javax.validation.constraints.NotNull;
 import lombok.Getter;
 
@@ -15,12 +15,12 @@ public class ProductUpdateRequest {
     private String imageUrl;
 
     @NotNull(message = "카테고리가 없습니다.")
-    private Category category;
+    private CategoryConstant category;
 
     private ProductUpdateRequest() {
     }
 
-    public ProductUpdateRequest(final String name, final String imageUrl, final Category category) {
+    public ProductUpdateRequest(final String name, final String imageUrl, final CategoryConstant category) {
         this.name = name;
         this.imageUrl = imageUrl;
         this.category = category;
@@ -28,7 +28,7 @@ public class ProductUpdateRequest {
 
     public Product toProduct() {
         return Product.builder()
-                .category(category)
+                .category(category.toCategory())
                 .name(name)
                 .imageUrl(imageUrl)
                 .build();

--- a/backend/src/test/java/com/woowacourse/f12/acceptance/ProductAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/acceptance/ProductAcceptanceTest.java
@@ -13,6 +13,7 @@ import static com.woowacourse.f12.presentation.member.JobTypeConstant.ETC_CONSTA
 import static com.woowacourse.f12.presentation.member.JobTypeConstant.FRONTEND_CONSTANT;
 import static com.woowacourse.f12.presentation.member.JobTypeConstant.MOBILE_CONSTANT;
 import static com.woowacourse.f12.presentation.product.CategoryConstant.KEYBOARD_CONSTANT;
+import static com.woowacourse.f12.presentation.product.CategoryConstant.MONITOR_CONSTANT;
 import static com.woowacourse.f12.support.fixture.AcceptanceFixture.민초;
 import static com.woowacourse.f12.support.fixture.AcceptanceFixture.코린;
 import static com.woowacourse.f12.support.fixture.AcceptanceFixture.클레이;
@@ -28,7 +29,6 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.woowacourse.f12.domain.member.Member;
 import com.woowacourse.f12.domain.member.MemberRepository;
-import com.woowacourse.f12.domain.product.Category;
 import com.woowacourse.f12.domain.product.Product;
 import com.woowacourse.f12.domain.product.ProductRepository;
 import com.woowacourse.f12.dto.request.member.MemberRequest;
@@ -301,7 +301,7 @@ class ProductAcceptanceTest extends AcceptanceTest {
 
         // when
         ProductCreateRequest productCreateRequest = new ProductCreateRequest("keyboard", "keyboard.url",
-                Category.KEYBOARD);
+                KEYBOARD_CONSTANT);
         ExtractableResponse<Response> response = 로그인된_상태로_POST_요청을_보낸다("/api/v1/products", loginToken,
                 productCreateRequest);
 
@@ -323,7 +323,7 @@ class ProductAcceptanceTest extends AcceptanceTest {
 
         // when
         ProductUpdateRequest productUpdateRequest = new ProductUpdateRequest("updatedName", "updatedURL",
-                Category.MONITOR);
+                MONITOR_CONSTANT);
         ExtractableResponse<Response> response = 로그인된_상태로_PATCH_요청을_보낸다("/api/v1/products/" + savedProduct.getId(),
                 loginToken, productUpdateRequest);
 

--- a/backend/src/test/java/com/woowacourse/f12/application/product/ProductServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/application/product/ProductServiceTest.java
@@ -5,7 +5,6 @@ import static com.woowacourse.f12.domain.member.CareerLevel.MID_LEVEL;
 import static com.woowacourse.f12.domain.member.JobType.BACKEND;
 import static com.woowacourse.f12.domain.member.JobType.ETC;
 import static com.woowacourse.f12.domain.product.Category.KEYBOARD;
-import static com.woowacourse.f12.domain.product.Category.MOUSE;
 import static com.woowacourse.f12.presentation.member.CareerLevelConstant.JUNIOR_CONSTANT;
 import static com.woowacourse.f12.presentation.member.CareerLevelConstant.MID_LEVEL_CONSTANT;
 import static com.woowacourse.f12.presentation.member.CareerLevelConstant.NONE_CONSTANT;
@@ -15,6 +14,7 @@ import static com.woowacourse.f12.presentation.member.JobTypeConstant.ETC_CONSTA
 import static com.woowacourse.f12.presentation.member.JobTypeConstant.FRONTEND_CONSTANT;
 import static com.woowacourse.f12.presentation.member.JobTypeConstant.MOBILE_CONSTANT;
 import static com.woowacourse.f12.presentation.product.CategoryConstant.KEYBOARD_CONSTANT;
+import static com.woowacourse.f12.presentation.product.CategoryConstant.MOUSE_CONSTANT;
 import static com.woowacourse.f12.support.fixture.ProductFixture.KEYBOARD_1;
 import static com.woowacourse.f12.support.fixture.ProductFixture.MOUSE_1;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -70,7 +70,7 @@ class ProductServiceTest {
     void 제품_추가_요청으로_제품을_저장한다() {
         // given
         Product savedProduct = KEYBOARD_1.생성(1L);
-        ProductCreateRequest productCreateRequest = new ProductCreateRequest("키보드1", "이미지 주소", KEYBOARD);
+        ProductCreateRequest productCreateRequest = new ProductCreateRequest("키보드1", "이미지 주소", KEYBOARD_CONSTANT);
 
         given(productRepository.save(any(Product.class)))
                 .willReturn(savedProduct);
@@ -192,7 +192,7 @@ class ProductServiceTest {
     void 제품_정보를_수정한다() {
         // given
         Product target = KEYBOARD_1.생성(1L);
-        ProductUpdateRequest productUpdateRequest = new ProductUpdateRequest("마우스1", "이미지 주소", MOUSE);
+        ProductUpdateRequest productUpdateRequest = new ProductUpdateRequest("마우스1", "이미지 주소", MOUSE_CONSTANT);
 
         given(productRepository.findById(1L))
                 .willReturn(Optional.of(target));
@@ -211,7 +211,7 @@ class ProductServiceTest {
     @Test
     void 없는_제품을_수정하려고_하면_예외를_반환한다() {
         // given
-        ProductUpdateRequest productUpdateRequest = new ProductUpdateRequest("마우스1", "이미지 주소", MOUSE);
+        ProductUpdateRequest productUpdateRequest = new ProductUpdateRequest("마우스1", "이미지 주소", MOUSE_CONSTANT);
 
         given(productRepository.findById(1L))
                 .willReturn(Optional.empty());

--- a/backend/src/test/java/com/woowacourse/f12/presentation/auth/AuthInterceptorTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/auth/AuthInterceptorTest.java
@@ -1,5 +1,6 @@
 package com.woowacourse.f12.presentation.auth;
 
+import static com.woowacourse.f12.presentation.product.CategoryConstant.KEYBOARD_CONSTANT;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -25,7 +26,6 @@ import com.woowacourse.f12.domain.member.Role;
 import com.woowacourse.f12.dto.request.product.ProductCreateRequest;
 import com.woowacourse.f12.dto.request.review.ReviewRequest;
 import com.woowacourse.f12.presentation.PresentationTest;
-import com.woowacourse.f12.presentation.product.CategoryConstant;
 import com.woowacourse.f12.presentation.product.ProductController;
 import com.woowacourse.f12.presentation.review.ReviewController;
 import org.junit.jupiter.api.Test;
@@ -139,7 +139,7 @@ class AuthInterceptorTest extends PresentationTest {
                 .willReturn(new MemberPayload(1L, Role.USER));
 
         final ProductCreateRequest productCreateRequest = new ProductCreateRequest("keyboard", "keyboardUrl",
-                CategoryConstant.KEYBOARD_CONSTANT);
+                KEYBOARD_CONSTANT);
 
         // when
         mockMvc.perform(

--- a/backend/src/test/java/com/woowacourse/f12/presentation/auth/AuthInterceptorTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/auth/AuthInterceptorTest.java
@@ -22,10 +22,10 @@ import com.woowacourse.f12.application.auth.token.MemberPayload;
 import com.woowacourse.f12.application.product.ProductService;
 import com.woowacourse.f12.application.review.ReviewService;
 import com.woowacourse.f12.domain.member.Role;
-import com.woowacourse.f12.domain.product.Category;
 import com.woowacourse.f12.dto.request.product.ProductCreateRequest;
 import com.woowacourse.f12.dto.request.review.ReviewRequest;
 import com.woowacourse.f12.presentation.PresentationTest;
+import com.woowacourse.f12.presentation.product.CategoryConstant;
 import com.woowacourse.f12.presentation.product.ProductController;
 import com.woowacourse.f12.presentation.review.ReviewController;
 import org.junit.jupiter.api.Test;
@@ -139,7 +139,7 @@ class AuthInterceptorTest extends PresentationTest {
                 .willReturn(new MemberPayload(1L, Role.USER));
 
         final ProductCreateRequest productCreateRequest = new ProductCreateRequest("keyboard", "keyboardUrl",
-                Category.KEYBOARD);
+                CategoryConstant.KEYBOARD_CONSTANT);
 
         // when
         mockMvc.perform(

--- a/backend/src/test/java/com/woowacourse/f12/presentation/product/ProductControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/product/ProductControllerTest.java
@@ -9,6 +9,7 @@ import static com.woowacourse.f12.domain.member.JobType.ETC;
 import static com.woowacourse.f12.domain.member.JobType.FRONTEND;
 import static com.woowacourse.f12.domain.member.JobType.MOBILE;
 import static com.woowacourse.f12.presentation.product.CategoryConstant.KEYBOARD_CONSTANT;
+import static com.woowacourse.f12.presentation.product.CategoryConstant.MONITOR_CONSTANT;
 import static com.woowacourse.f12.support.fixture.ProductFixture.KEYBOARD_1;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
@@ -35,7 +36,6 @@ import com.woowacourse.f12.application.product.ProductService;
 import com.woowacourse.f12.domain.member.CareerLevel;
 import com.woowacourse.f12.domain.member.JobType;
 import com.woowacourse.f12.domain.member.Role;
-import com.woowacourse.f12.domain.product.Category;
 import com.woowacourse.f12.dto.request.product.ProductCreateRequest;
 import com.woowacourse.f12.dto.request.product.ProductSearchRequest;
 import com.woowacourse.f12.dto.request.product.ProductUpdateRequest;
@@ -236,7 +236,7 @@ class ProductControllerTest extends PresentationTest {
         given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         ProductCreateRequest productCreateRequest = new ProductCreateRequest("keyboard", "keyborad.url",
-                Category.KEYBOARD);
+                KEYBOARD_CONSTANT);
 
         // when
         ResultActions resultActions = mockMvc.perform(
@@ -264,7 +264,7 @@ class ProductControllerTest extends PresentationTest {
         given(jwtProvider.isValidToken(authorizationHeader))
                 .willReturn(true);
         ProductUpdateRequest productUpdateRequest = new ProductUpdateRequest("updatedName", "updatedURL",
-                Category.MONITOR);
+                MONITOR_CONSTANT);
 
         // when
         ResultActions resultActions = mockMvc.perform(patch("/api/v1/products/" + 1)


### PR DESCRIPTION
# issue: #711 

# 작업 내용
- 제품 수정 요청 및 제품 삭제 요청 DTO에 사용되는 Category enum을 CategoryConstant enum으로 교체.