### PR TITLE
[Feature/BE] 프로덕션 인증 기능과 어드민 인증 기능 분리

### DIFF
--- a/backend/src/main/java/com/woowacourse/f12/application/auth/GitHubOauthClient.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/auth/GitHubOauthClient.java
@@ -19,13 +19,10 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.time.Duration;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.stereotype.Component;
 
-@Component
 public class GitHubOauthClient {
 
     private final String clientId;
@@ -40,10 +37,8 @@ public class GitHubOauthClient {
             .connectTimeout(Duration.ofSeconds(10))
             .build();
 
-    public GitHubOauthClient(@Value("${github.client.id}") final String clientId,
-                             @Value("${github.client.secret}") final String secret,
-                             @Value("${github.url.accessToken}") final String accessTokenUrl,
-                             @Value("${github.url.user}") final String profileUrl) {
+    public GitHubOauthClient(final String clientId, final String secret, final String accessTokenUrl,
+                             final String profileUrl) {
         this.clientId = clientId;
         this.secret = secret;
         this.accessTokenUrl = accessTokenUrl;

--- a/backend/src/main/java/com/woowacourse/f12/config/OauthClientConfig.java
+++ b/backend/src/main/java/com/woowacourse/f12/config/OauthClientConfig.java
@@ -1,0 +1,29 @@
+package com.woowacourse.f12.config;
+
+import com.woowacourse.f12.application.auth.GitHubOauthClient;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OauthClientConfig {
+
+    @Bean
+    @Qualifier("production")
+    public GitHubOauthClient productionGitHubOauthClient(@Value("${github.client.id}") final String clientId,
+                                                         @Value("${github.client.secret}") final String secret,
+                                                         @Value("${github.url.accessToken}") final String accessTokenUrl,
+                                                         @Value("${github.url.user}") final String profileUrl) {
+        return new GitHubOauthClient(clientId, secret, accessTokenUrl, profileUrl);
+    }
+
+    @Bean
+    @Qualifier("admin")
+    public GitHubOauthClient adminGitHubOauthClient(@Value("${github.client.admin-id}") final String clientId,
+                                                    @Value("${github.client.admin-secret}") final String secret,
+                                                    @Value("${github.url.accessToken}") final String accessTokenUrl,
+                                                    @Value("${github.url.user}") final String profileUrl) {
+        return new GitHubOauthClient(clientId, secret, accessTokenUrl, profileUrl);
+    }
+}

--- a/backend/src/test/java/com/woowacourse/f12/application/auth/GitHubOauthClientTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/application/auth/GitHubOauthClientTest.java
@@ -10,6 +10,7 @@ import com.woowacourse.f12.exception.badrequest.InvalidGitHubLoginException;
 import com.woowacourse.f12.support.fixture.MemberFixture;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 
@@ -17,6 +18,7 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 class GitHubOauthClientTest {
 
     @Autowired
+    @Qualifier("production")
     private GitHubOauthClient gitHubOauthClient;
 
     @Test

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -13,6 +13,8 @@ github:
   client:
     id: clientId
     secret: secret
+    admin-id: adminId
+    admin-secret: adminSecret
   url:
     accessToken: http://localhost:8888/login/oauth/access_token
     user: http://localhost:8888/user


### PR DESCRIPTION
# issue: closes #718 

# 작업 내용
- GitHubOauthClient를 두 개로 분리
  - 프로덕션 인증을 처리하고 redirect하는 빈과 어드민 인증을 처리하고 redirect하는 빈을 분리
  - 각각의 빈은 `@Qualifier`를 통해 구분