### PR TITLE
[FE] 프로필 페이지, 팔로잉, 프로필 검색 반응형 디자인을 적용

### DIFF
--- a/frontend/src/components/DeskSetup/DeskSetup.style.tsx
+++ b/frontend/src/components/DeskSetup/DeskSetup.style.tsx
@@ -1,10 +1,8 @@
 import styled, { css } from 'styled-components';
 
 export const Container = styled.div`
-  width: 100%;
   display: grid;
   grid-template-columns: repeat(4, 1fr);
-
   overflow-x: scroll;
   -ms-overflow-style: none;
   scrollbar-width: none;
@@ -14,18 +12,19 @@ export const Container = styled.div`
 
   ${({ theme: { device } }) => css`
     @media screen and ${device.mobile} {
-      padding-left: 1rem;
-      padding-right: 1rem;
+      width: 90%;
       justify-items: start;
-      grid-column-gap: 1rem;
+      grid-column-gap: 0.8rem;
     }
     @media screen and ${device.tablet} {
+      width: 100%;
       padding-left: 0.3rem;
       padding-right: 0.3rem;
       justify-items: start;
       grid-column-gap: 1rem;
     }
     @media screen and ${device.desktop} {
+      width: 100%;
       justify-items: center;
       grid-column-gap: 0rem;
     }

--- a/frontend/src/components/DeskSetup/DeskSetup.style.tsx
+++ b/frontend/src/components/DeskSetup/DeskSetup.style.tsx
@@ -1,16 +1,35 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 export const Container = styled.div`
-  display: flex;
-  height: 100%;
-  align-items: center;
-  justify-content: center;
-`;
-export const CardWrapper = styled.div`
   width: 100%;
-  display: flex;
-  justify-content: center;
-  gap: 4rem;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+
+  overflow-x: scroll;
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
+
+  ${({ theme: { device } }) => css`
+    @media screen and ${device.mobile} {
+      padding-left: 1rem;
+      padding-right: 1rem;
+      justify-items: start;
+      grid-column-gap: 1rem;
+    }
+    @media screen and ${device.tablet} {
+      padding-left: 0.3rem;
+      padding-right: 0.3rem;
+      justify-items: start;
+      grid-column-gap: 1rem;
+    }
+    @media screen and ${device.desktop} {
+      justify-items: center;
+      grid-column-gap: 0rem;
+    }
+  `}
 `;
 
 export const NoContents = styled.div`

--- a/frontend/src/components/DeskSetup/DeskSetup.tsx
+++ b/frontend/src/components/DeskSetup/DeskSetup.tsx
@@ -24,21 +24,19 @@ function DeskSetup({ inventoryList }: Props) {
   return (
     <>
       <S.Container>
-        <S.CardWrapper>
-          {deskSetupItems.length > 0 ? (
-            deskSetupItems.map((item: InventoryProduct, index) => (
-              <DeskSetupCard
-                key={index}
-                item={item}
-                size={'l'}
-                borderType={'default'}
-                index={index}
-              />
-            ))
-          ) : (
-            <S.NoContents>데스크 셋업에 추가한 제품이 없어요</S.NoContents>
-          )}
-        </S.CardWrapper>
+        {deskSetupItems.length > 0 ? (
+          deskSetupItems.map((item: InventoryProduct, index) => (
+            <DeskSetupCard
+              key={index}
+              item={item}
+              size={'l'}
+              borderType={'default'}
+              index={index}
+            />
+          ))
+        ) : (
+          <S.NoContents>데스크 셋업에 추가한 제품이 없어요</S.NoContents>
+        )}
       </S.Container>
     </>
   );

--- a/frontend/src/components/Profile/InventoryProductList/InventoryProductList.style.tsx
+++ b/frontend/src/components/Profile/InventoryProductList/InventoryProductList.style.tsx
@@ -35,6 +35,18 @@ export const EditDeskSetupButton = styled.button`
   border-radius: 0.4rem;
   box-shadow: 4px 4px 10px ${({ theme }) => theme.colors.secondary};
   width: max-content;
+
+  ${({ theme: { device } }) => css`
+    @media screen and ${device.mobile} {
+      font-size: 0.8rem;
+    }
+    @media screen and ${device.tablet} {
+      font-size: 1rem;
+    }
+    @media screen and ${device.desktop} {
+      font-size: 1.2rem;
+    }
+  `}
 `;
 
 export const FlexWrapper = styled.div`

--- a/frontend/src/components/Profile/InventoryProductList/InventoryProductList.style.tsx
+++ b/frontend/src/components/Profile/InventoryProductList/InventoryProductList.style.tsx
@@ -20,7 +20,7 @@ export const Container = styled.div`
       grid-column-gap: 1rem;
     }
     @media screen and ${device.desktop} {
-      grid-column-gap: 1rem;
+      grid-column-gap: 0rem;
     }
   `}
 `;

--- a/frontend/src/components/Profile/InventoryProductList/InventoryProductList.style.tsx
+++ b/frontend/src/components/Profile/InventoryProductList/InventoryProductList.style.tsx
@@ -1,9 +1,28 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 export const Container = styled.div`
   display: grid;
   grid-template-columns: repeat(6, 1fr);
-  grid-gap: 1rem;
+  grid-row-gap: 1rem;
+
+  overflow-x: scroll;
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
+
+  ${({ theme: { device } }) => css`
+    @media screen and ${device.mobile} {
+      grid-column-gap: 0.8rem;
+    }
+    @media screen and ${device.tablet} {
+      grid-column-gap: 1rem;
+    }
+    @media screen and ${device.desktop} {
+      grid-column-gap: 1rem;
+    }
+  `}
 `;
 
 export const CategoryTitle = styled.h2`

--- a/frontend/src/components/Profile/ProfileCard/ProfileCard.style.tsx
+++ b/frontend/src/components/Profile/ProfileCard/ProfileCard.style.tsx
@@ -1,11 +1,23 @@
 import { Link } from 'react-router-dom';
 import styled, { css } from 'styled-components';
 
-export const Container = styled.div<{ index: number }>`
+export const Container = styled.div<{ index: number; displayWidth: number }>`
   display: flex;
   background-color: white;
   padding: 1rem;
-  width: 380px;
+
+  ${({ theme: { device }, displayWidth }) => css`
+    @media screen and (max-width: ${displayWidth}px) {
+      width: 330px;
+    }
+    @media screen and ${device.tablet} {
+      width: 380px;
+    }
+    @media screen and ${device.desktop} {
+      width: 380px;
+    }
+  `}
+
   border-radius: 0.4rem;
   box-shadow: 4px 4px 10px ${({ theme }) => theme.colors.secondary};
   ${({ index }) => css`
@@ -39,13 +51,33 @@ export const RightSection = styled.div`
 
 export const ProfileImageWrapper = styled.div`
   position: absolute;
-  left: -6rem;
-  top: 1.6rem;
-  width: 9.5rem;
-  height: 9.5rem;
+
+  ${({ theme: { device } }) => css`
+    @media screen and ${device.mobile} {
+      left: -0.6rem;
+      top: 0.4rem;
+      width: 3.5rem;
+      height: 3.5rem;
+      box-shadow: 2px 2px 4px ${({ theme }) => theme.colors.secondary};
+    }
+    @media screen and ${device.tablet} {
+      left: -6rem;
+      top: 2rem;
+      width: 8.5rem;
+      height: 8.5rem;
+      box-shadow: 5px 5px 10px ${({ theme }) => theme.colors.secondary};
+    }
+    @media screen and ${device.desktop} {
+      left: -6rem;
+      top: 1.6rem;
+      width: 9.5rem;
+      height: 9.5rem;
+      box-shadow: 5px 5px 10px ${({ theme }) => theme.colors.secondary};
+    }
+  `}
+
   border-radius: 50%;
   overflow: hidden;
-  box-shadow: 5px 5px 10px ${({ theme }) => theme.colors.secondary};
 `;
 
 export const ProfileImage = styled.img`

--- a/frontend/src/components/Profile/ProfileCard/ProfileCard.style.tsx
+++ b/frontend/src/components/Profile/ProfileCard/ProfileCard.style.tsx
@@ -1,13 +1,13 @@
 import { Link } from 'react-router-dom';
 import styled, { css } from 'styled-components';
 
-export const Container = styled.div<{ index: number; displayWidth: number }>`
+export const Container = styled.div<{ index: number }>`
   display: flex;
   background-color: white;
   padding: 1rem;
 
-  ${({ theme: { device }, displayWidth }) => css`
-    @media screen and (max-width: ${displayWidth}px) {
+  ${({ theme: { device } }) => css`
+    @media screen and ${device.mobile} {
       width: 330px;
     }
     @media screen and ${device.tablet} {

--- a/frontend/src/components/Profile/ProfileCard/ProfileCard.tsx
+++ b/frontend/src/components/Profile/ProfileCard/ProfileCard.tsx
@@ -120,8 +120,6 @@ function ProfileCard({
     }
   );
 
-  console.log(displayWidth);
-
   return (
     <S.Container index={index} displayWidth={displayWidth}>
       <S.LeftSection>

--- a/frontend/src/components/Profile/ProfileCard/ProfileCard.tsx
+++ b/frontend/src/components/Profile/ProfileCard/ProfileCard.tsx
@@ -6,6 +6,7 @@ import Chip from '@/components/common/Chip/Chip';
 import * as S from '@/components/Profile/ProfileCard/ProfileCard.style';
 
 import useAuth from '@/hooks/useAuth';
+import useDevice from '@/hooks/useDevice';
 import useFollowing from '@/hooks/useFollowing';
 
 import TITLE from '@/constants/header';
@@ -56,6 +57,7 @@ function ProfileCard({
   const [followed, setFollowed] = useState(following);
   const [followerCount, setFollowerCount] = useState(initialFollowerCount);
   const { isLoggedIn } = useAuth();
+  const { displayWidth } = useDevice();
 
   const { followUser, unfollowUser } = useFollowing(id);
 
@@ -118,8 +120,10 @@ function ProfileCard({
     }
   );
 
+  console.log(displayWidth);
+
   return (
-    <S.Container index={index}>
+    <S.Container index={index} displayWidth={displayWidth}>
       <S.LeftSection>
         <S.ProfileImageWrapper>
           <S.ProfileImage src={`${imageUrl}${GITHUB_IMAGE_SIZE_SEARCH_PARAM.large}`} />

--- a/frontend/src/components/Profile/ProfileCard/ProfileCard.tsx
+++ b/frontend/src/components/Profile/ProfileCard/ProfileCard.tsx
@@ -6,7 +6,6 @@ import Chip from '@/components/common/Chip/Chip';
 import * as S from '@/components/Profile/ProfileCard/ProfileCard.style';
 
 import useAuth from '@/hooks/useAuth';
-import useDevice from '@/hooks/useDevice';
 import useFollowing from '@/hooks/useFollowing';
 
 import TITLE from '@/constants/header';
@@ -57,7 +56,6 @@ function ProfileCard({
   const [followed, setFollowed] = useState(following);
   const [followerCount, setFollowerCount] = useState(initialFollowerCount);
   const { isLoggedIn } = useAuth();
-  const { displayWidth } = useDevice();
 
   const { followUser, unfollowUser } = useFollowing(id);
 
@@ -121,7 +119,7 @@ function ProfileCard({
   );
 
   return (
-    <S.Container index={index} displayWidth={displayWidth}>
+    <S.Container index={index}>
       <S.LeftSection>
         <S.ProfileImageWrapper>
           <S.ProfileImage src={`${imageUrl}${GITHUB_IMAGE_SIZE_SEARCH_PARAM.large}`} />

--- a/frontend/src/components/Profile/ProfileSearchResult/ProfileSearchResult.style.tsx
+++ b/frontend/src/components/Profile/ProfileSearchResult/ProfileSearchResult.style.tsx
@@ -1,12 +1,27 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 export const Container = styled.div`
   max-width: 80%;
-
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 3rem 12rem;
-  justify-items: center;
+
+  ${({ theme: { device } }) => css`
+    @media screen and ${device.mobile} {
+      justify-content: center;
+      grid-template-columns: repeat(1, 1fr);
+      gap: 2rem;
+    }
+    @media screen and ${device.tablet} {
+      justify-items: center;
+      grid-template-columns: repeat(1, 1fr);
+      gap: 2rem 7rem;
+    }
+    @media screen and ${device.desktop} {
+      justify-items: center;
+      grid-template-columns: repeat(2, 1fr);
+      gap: 2rem 10rem;
+    }
+  `}
+
   margin: 0 auto;
 `;
 

--- a/frontend/src/components/Profile/UserInfo/UserInfo.style.tsx
+++ b/frontend/src/components/Profile/UserInfo/UserInfo.style.tsx
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 export const Container = styled.div`
   display: flex;
@@ -54,4 +54,16 @@ export const FollowButton = styled.button<{ followed: boolean }>`
 
   background-color: ${({ theme, followed }) =>
     followed ? theme.colors.secondary : theme.colors.primary};
+
+  ${({ theme: { device } }) => css`
+    @media screen and ${device.mobile} {
+      font-size: 0.8rem;
+    }
+    @media screen and ${device.tablet} {
+      font-size: 1rem;
+    }
+    @media screen and ${device.desktop} {
+      font-size: 1.2rem;
+    }
+  `}
 `;

--- a/frontend/src/components/Profile/UserInfo/UserInfo.style.tsx
+++ b/frontend/src/components/Profile/UserInfo/UserInfo.style.tsx
@@ -54,6 +54,7 @@ export const FollowButton = styled.button<{ followed: boolean }>`
 
   background-color: ${({ theme, followed }) =>
     followed ? theme.colors.secondary : theme.colors.primary};
+  margin-top: 1rem;
 
   ${({ theme: { device } }) => css`
     @media screen and ${device.mobile} {

--- a/frontend/src/components/common/Modal/Modal.style.tsx
+++ b/frontend/src/components/common/Modal/Modal.style.tsx
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 export const Container = styled.section<{ scrollOffset: number }>`
   position: absolute;
@@ -32,12 +32,21 @@ export const Backdrop = styled.div<{ animationTrigger: boolean }>`
 `;
 
 export const Content = styled.section<{ animationTrigger: boolean }>`
-  width: 30rem;
+  ${({ theme: { device } }) => css`
+    @media screen and ${device.mobile} {
+      width: 20rem;
+    }
+    @media screen and ${device.tablet} {
+      width: 28rem;
+    }
+    @media screen and ${device.desktop} {
+      width: 36rem;
+    }
+  `}
+
   min-height: 10rem;
   padding: 1.5rem;
-
   position: relative;
-
   z-index: 15;
 
   display: flex;

--- a/frontend/src/components/common/SearchBar/SearchBar.style.tsx
+++ b/frontend/src/components/common/SearchBar/SearchBar.style.tsx
@@ -1,7 +1,17 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 export const Container = styled.div`
-  width: 60%;
+  ${({ theme: { device } }) => css`
+    @media screen and ${device.mobile} {
+      width: 80%;
+    }
+    @media screen and ${device.tablet} {
+      width: 70%;
+    }
+    @media screen and ${device.desktop} {
+      width: 70%;
+    }
+  `}
   display: flex;
   align-items: center;
 `;
@@ -30,5 +40,3 @@ export const Button = styled.button`
   border: none;
   outline: none;
 `;
-
-export const Form = styled.form``;

--- a/frontend/src/mocks/data.ts
+++ b/frontend/src/mocks/data.ts
@@ -630,6 +630,45 @@ export const InventoryProducts: { items: InventoryProduct[] } = {
         category: 'software',
       },
     },
+    {
+      id: 10,
+      selected: false,
+      product: {
+        id: 10,
+        name: '키보드3',
+        imageUrl:
+          'http://img.danawa.com/prod_img/500000/578/350/img/16350578_1.jpg?shrink=500:500&_v=20220209090426',
+        reviewCount: 0,
+        rating: 0.0,
+        category: 'keyboard',
+      },
+    },
+    {
+      id: 11,
+      selected: false,
+      product: {
+        id: 11,
+        name: '키보드4',
+        imageUrl:
+          'http://img.danawa.com/prod_img/500000/578/350/img/16350578_1.jpg?shrink=500:500&_v=20220209090426',
+        reviewCount: 0,
+        rating: 0.0,
+        category: 'keyboard',
+      },
+    },
+    {
+      id: 12,
+      selected: false,
+      product: {
+        id: 12,
+        name: '키보드5',
+        imageUrl:
+          'http://img.danawa.com/prod_img/500000/578/350/img/16350578_1.jpg?shrink=500:500&_v=20220209090426',
+        reviewCount: 0,
+        rating: 0.0,
+        category: 'keyboard',
+      },
+    },
   ],
 };
 

--- a/frontend/src/pages/Profile/Profile.style.tsx
+++ b/frontend/src/pages/Profile/Profile.style.tsx
@@ -4,7 +4,6 @@ export const Container = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 3rem;
 `;
 
 export const ProfileSection = styled.section`
@@ -13,7 +12,7 @@ export const ProfileSection = styled.section`
   justify-content: center;
   align-items: center;
   width: 100%;
-  gap: 1rem;
+  margin-bottom: 2rem;
 `;
 
 export const InventorySection = styled.section`
@@ -53,6 +52,7 @@ export const DeskSetupSection = styled.section`
   width: 100%;
   height: 22rem;
   background-color: ${({ theme }) => theme.colors.secondary};
+  margin-bottom: 2rem;
 `;
 
 export const TabButtonWrapper = styled.div`
@@ -69,6 +69,7 @@ export const TabButton = styled.button<{ selected: boolean }>`
   background-color: ${({ selected, theme }) =>
     selected ? theme.colors.primary : theme.colors.secondary};
   transition: 0.5s;
+  margin-bottom: 0.5rem;
 
   &:hover {
     background-color: ${({ theme }) => theme.colors.primary};

--- a/frontend/src/pages/Profile/Profile.style.tsx
+++ b/frontend/src/pages/Profile/Profile.style.tsx
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 export const Container = styled.div`
   display: flex;
@@ -65,7 +65,6 @@ export const TabButtonWrapper = styled.div`
 export const TabButton = styled.button<{ selected: boolean }>`
   width: max-content;
   padding: 0.4rem 0.6rem;
-  font-size: 1.2rem;
   border-radius: 0.4rem;
   background-color: ${({ selected, theme }) =>
     selected ? theme.colors.primary : theme.colors.secondary};
@@ -75,4 +74,16 @@ export const TabButton = styled.button<{ selected: boolean }>`
     background-color: ${({ theme }) => theme.colors.primary};
     transition: 0.5s;
   }
+
+  ${({ theme: { device } }) => css`
+    @media screen and ${device.mobile} {
+      font-size: 0.8rem;
+    }
+    @media screen and ${device.tablet} {
+      font-size: 1rem;
+    }
+    @media screen and ${device.desktop} {
+      font-size: 1.2rem;
+    }
+  `}
 `;

--- a/frontend/src/pages/Profile/Profile.style.tsx
+++ b/frontend/src/pages/Profile/Profile.style.tsx
@@ -47,8 +47,11 @@ export const EditDeskSetupButton = styled.button`
 `;
 
 export const DeskSetupSection = styled.section`
+  display: flex;
+  align-items: center;
+  justify-content: center;
   width: 100%;
-  height: 25rem;
+  height: 22rem;
   background-color: ${({ theme }) => theme.colors.secondary};
 `;
 

--- a/frontend/src/pages/ProfileSearch/ProfileSearch.style.tsx
+++ b/frontend/src/pages/ProfileSearch/ProfileSearch.style.tsx
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 export const Container = styled.div`
   display: flex;
@@ -18,5 +18,22 @@ export const SearchWrapper = styled.div`
 
 export const SearchFilterWrapper = styled.div`
   display: flex;
-  gap: 1em;
+
+  ${({ theme: { device } }) => css`
+    @media screen and ${device.mobile} {
+      flex-direction: column;
+      gap: 0.4rem;
+      margin-bottom: 1rem;
+    }
+    @media screen and ${device.tablet} {
+      flex-direction: column;
+      gap: 0.4rem;
+      margin-bottom: 1rem;
+    }
+    @media screen and ${device.desktop} {
+      flex-direction: row;
+      gap: 1rem;
+      margin-bottom: 0.4rem;
+    }
+  `}
 `;

--- a/frontend/src/pages/common/PageLayout/PageLayout.style.tsx
+++ b/frontend/src/pages/common/PageLayout/PageLayout.style.tsx
@@ -10,14 +10,13 @@ export const Main = styled.main`
 
   ${({ theme: { device } }) => css`
     @media screen and ${device.mobile} {
-      margin: 50px auto 72px;
+      margin: 10px auto 72px;
     }
-
     @media screen and ${device.tablet} {
-      margin: 50px auto 72px;
+      margin: 20px auto 72px;
     }
     @media screen and ${device.desktop} {
-      margin: 50px auto;
+      margin: 30px auto;
     }
   `}
 `;

--- a/frontend/src/pages/common/PageLayout/PageLayout.style.tsx
+++ b/frontend/src/pages/common/PageLayout/PageLayout.style.tsx
@@ -9,9 +9,15 @@ export const Main = styled.main`
   padding: 1.2rem;
 
   ${({ theme: { device } }) => css`
+    @media screen and ${device.mobile} {
+      margin: 50px auto 72px;
+    }
+
+    @media screen and ${device.tablet} {
+      margin: 50px auto 72px;
+    }
     @media screen and ${device.desktop} {
       margin: 50px auto;
-      gap: 3rem;
     }
   `}
 `;


### PR DESCRIPTION
# issue: #652 

# 작업 내용

- 프로필 페이지 반응형 적용
- 팔로잉 검색(프로필 검색) 페이지 반응형 적용

+) 구현하기로 했었던 플로팅 버튼은 작은 화면에서 리뷰 카드나 상품 카드 요소를 가리는 문제가 있어 오히려 사용성이 저하될 수도 있겠다는 생각이 들었습니다. 모바일에서는 메뉴바들이 하단으로 내려가 있고, 원하는 메뉴에 쉽게 진입할 수 있으므로 플로팅 버튼을 통해 상단으로 이동하는 경우도 적지 않을까 하는 생각도 들었습니다.

일부 요소를 가리더라도 플로팅 버튼을 통해 위로 올라갈 수 있게 vs 플로팅 버튼을 구현하지 않고 요소를 가리지 않게 
간단한 부분이라 구현은 금방할 수 있겠지만 사용성 측면에서 프론트엔드 + 백엔드와 함께 추가적인 논의가 필요할 것 같아요!
