### PR TITLE
[Feature/BE] Objects 의 null 체크 메서드를 제거 

### DIFF
--- a/backend/src/main/java/com/woowacourse/f12/application/member/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/member/MemberService.java
@@ -20,7 +20,6 @@ import com.woowacourse.f12.exception.notfound.MemberNotFoundException;
 import com.woowacourse.f12.presentation.member.CareerLevelConstant;
 import com.woowacourse.f12.presentation.member.JobTypeConstant;
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -60,7 +59,7 @@ public class MemberService {
     }
 
     private boolean isNotLoggedIn(final Long loggedInId) {
-        return Objects.isNull(loggedInId);
+        return loggedInId == null;
     }
 
     private boolean isFollowing(final Long followerId, final Long followingId) {
@@ -118,7 +117,7 @@ public class MemberService {
 
     private JobType parseJobType(final MemberSearchRequest memberSearchRequest) {
         final JobTypeConstant jobTypeConstant = memberSearchRequest.getJobType();
-        if (Objects.isNull(jobTypeConstant)) {
+        if (jobTypeConstant == null) {
             return null;
         }
         return jobTypeConstant.toJobType();
@@ -126,7 +125,7 @@ public class MemberService {
 
     private CareerLevel parseCareerLevel(final MemberSearchRequest memberSearchRequest) {
         final CareerLevelConstant careerLevelConstant = memberSearchRequest.getCareerLevel();
-        if (Objects.isNull(careerLevelConstant)) {
+        if (careerLevelConstant == null) {
             return null;
         }
         return careerLevelConstant.toCareerLevel();

--- a/backend/src/main/java/com/woowacourse/f12/application/product/ProductService.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/product/ProductService.java
@@ -20,7 +20,6 @@ import com.woowacourse.f12.exception.notfound.ProductNotFoundException;
 import com.woowacourse.f12.presentation.product.CategoryConstant;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -70,7 +69,7 @@ public class ProductService {
 
     private Category parseCategory(final ProductSearchRequest productSearchRequest) {
         final CategoryConstant categoryConstant = productSearchRequest.getCategory();
-        if (Objects.isNull(categoryConstant)) {
+        if (categoryConstant == null) {
             return null;
         }
         return categoryConstant.toCategory();

--- a/backend/src/main/java/com/woowacourse/f12/application/review/ReviewService.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/review/ReviewService.java
@@ -20,7 +20,6 @@ import com.woowacourse.f12.exception.notfound.InventoryProductNotFoundException;
 import com.woowacourse.f12.exception.notfound.MemberNotFoundException;
 import com.woowacourse.f12.exception.notfound.ProductNotFoundException;
 import com.woowacourse.f12.exception.notfound.ReviewNotFoundException;
-import java.util.Objects;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -91,7 +90,7 @@ public class ReviewService {
                                                             final Pageable pageable) {
         validateKeyboardExists(productId);
         final Slice<Review> page = reviewRepository.findPageByProductId(productId, pageable);
-        if (Objects.isNull(memberId)) {
+        if (memberId == null) {
             return ReviewWithAuthorPageResponse.from(page);
         }
         return ReviewWithAuthorPageResponse.of(page, memberId);

--- a/backend/src/main/java/com/woowacourse/f12/domain/member/Member.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/member/Member.java
@@ -91,25 +91,25 @@ public class Member {
     }
 
     private void updateName(final String name) {
-        if (Objects.nonNull(name)) {
+        if (name != null) {
             this.name = name;
         }
     }
 
     private void updateImageUrl(String imageUrl) {
-        if (Objects.nonNull(imageUrl)) {
+        if (imageUrl != null) {
             this.imageUrl = imageUrl;
         }
     }
 
     private void updateCareerLevel(final CareerLevel careerLevel) {
-        if (Objects.nonNull(careerLevel)) {
+        if (careerLevel != null) {
             this.careerLevel = careerLevel;
         }
     }
 
     private void updateJobType(final JobType jobType) {
-        if (Objects.nonNull(jobType)) {
+        if (jobType != null) {
             this.jobType = jobType;
         }
     }

--- a/backend/src/main/java/com/woowacourse/f12/logging/ApiQueryInspector.java
+++ b/backend/src/main/java/com/woowacourse/f12/logging/ApiQueryInspector.java
@@ -1,6 +1,5 @@
 package com.woowacourse.f12.logging;
 
-import java.util.Objects;
 import org.hibernate.resource.jdbc.spi.StatementInspector;
 import org.springframework.stereotype.Component;
 import org.springframework.web.context.request.RequestContextHolder;
@@ -23,6 +22,6 @@ public class ApiQueryInspector implements StatementInspector {
     }
 
     private boolean isInRequestScope() {
-        return Objects.nonNull(RequestContextHolder.getRequestAttributes());
+        return RequestContextHolder.getRequestAttributes() != null;
     }
 }

--- a/backend/src/main/java/com/woowacourse/f12/presentation/CustomPageableArgumentResolver.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/CustomPageableArgumentResolver.java
@@ -3,7 +3,6 @@ package com.woowacourse.f12.presentation;
 import com.woowacourse.f12.exception.badrequest.InvalidPageNumberFormatException;
 import com.woowacourse.f12.exception.badrequest.InvalidPageSizeException;
 import com.woowacourse.f12.exception.badrequest.InvalidPageSizeFormatException;
-import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.annotation.Nonnull;
@@ -69,7 +68,7 @@ public class CustomPageableArgumentResolver extends PageableHandlerMethodArgumen
     }
 
     private void validatePage(final String pageArgument) {
-        if (Objects.isNull(pageArgument)) {
+        if (pageArgument == null) {
             return;
         }
         final Matcher matcher = NUMBER_PATTERN.matcher(pageArgument);
@@ -79,7 +78,7 @@ public class CustomPageableArgumentResolver extends PageableHandlerMethodArgumen
     }
 
     private void validateSize(final String sizeArgument) {
-        if (Objects.isNull(sizeArgument)) {
+        if (sizeArgument == null) {
             return;
         }
         final Matcher matcher = NUMBER_PATTERN.matcher(sizeArgument);

--- a/backend/src/main/java/com/woowacourse/f12/presentation/auth/AuthArgumentResolver.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/auth/AuthArgumentResolver.java
@@ -1,7 +1,6 @@
 package com.woowacourse.f12.presentation.auth;
 
 import com.woowacourse.f12.application.auth.token.JwtProvider;
-import java.util.Objects;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
@@ -28,7 +27,7 @@ public class AuthArgumentResolver implements HandlerMethodArgumentResolver {
     public Object resolveArgument(final MethodParameter parameter, final ModelAndViewContainer mavContainer,
                                   final NativeWebRequest webRequest, final WebDataBinderFactory binderFactory) {
         final String authorizationHeader = webRequest.getHeader(HttpHeaders.AUTHORIZATION);
-        if (Objects.isNull(authorizationHeader)) {
+        if (authorizationHeader == null) {
             return null;
         }
         return jwtProvider.getPayload(authorizationHeader);

--- a/backend/src/main/java/com/woowacourse/f12/support/AuthTokenExtractor.java
+++ b/backend/src/main/java/com/woowacourse/f12/support/AuthTokenExtractor.java
@@ -2,14 +2,13 @@ package com.woowacourse.f12.support;
 
 import com.woowacourse.f12.exception.unauthorized.TokenInvalidFormatException;
 import com.woowacourse.f12.exception.unauthorized.TokenNotExistsException;
-import java.util.Objects;
 import org.springframework.stereotype.Component;
 
 @Component
 public class AuthTokenExtractor {
 
     public String extractToken(final String authorizationHeader, final String tokenType) {
-        if (Objects.isNull(authorizationHeader)) {
+        if (authorizationHeader == null) {
             throw new TokenNotExistsException();
         }
         final String[] splitHeaders = authorizationHeader.split(" ");

--- a/backend/src/main/java/com/woowacourse/f12/support/RepositorySupport.java
+++ b/backend/src/main/java/com/woowacourse/f12/support/RepositorySupport.java
@@ -21,7 +21,7 @@ public class RepositorySupport {
     }
 
     public static BooleanExpression toContainsExpression(final StringPath stringPath, final String keyword) {
-        if (StringUtils.hasText(keyword)) {
+        if (!StringUtils.hasText(keyword)) {
             return null;
         }
         return stringPath.contains(keyword);

--- a/backend/src/main/java/com/woowacourse/f12/support/RepositorySupport.java
+++ b/backend/src/main/java/com/woowacourse/f12/support/RepositorySupport.java
@@ -2,15 +2,17 @@ package com.woowacourse.f12.support;
 
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
-import com.querydsl.core.types.dsl.*;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.EntityPathBase;
+import com.querydsl.core.types.dsl.PathBuilder;
+import com.querydsl.core.types.dsl.SimpleExpression;
+import com.querydsl.core.types.dsl.StringPath;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.domain.Sort;
-
-import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
 
 public class RepositorySupport {
 
@@ -18,14 +20,14 @@ public class RepositorySupport {
     }
 
     public static BooleanExpression toContainsExpression(final StringPath stringPath, final String keyword) {
-        if (Objects.isNull(keyword) || keyword.isBlank()) {
+        if (keyword == null || keyword.isBlank()) {
             return null;
         }
         return stringPath.contains(keyword);
     }
 
     public static <T> BooleanExpression toEqExpression(final SimpleExpression<T> simpleExpression, final T compared) {
-        if (Objects.isNull(compared)) {
+        if (compared == null) {
             return null;
         }
         return simpleExpression.eq(compared);

--- a/backend/src/main/java/com/woowacourse/f12/support/RepositorySupport.java
+++ b/backend/src/main/java/com/woowacourse/f12/support/RepositorySupport.java
@@ -13,6 +13,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.domain.Sort;
+import org.springframework.util.StringUtils;
 
 public class RepositorySupport {
 
@@ -20,7 +21,7 @@ public class RepositorySupport {
     }
 
     public static BooleanExpression toContainsExpression(final StringPath stringPath, final String keyword) {
-        if (keyword == null || keyword.isBlank()) {
+        if (StringUtils.hasText(keyword)) {
             return null;
         }
         return stringPath.contains(keyword);

--- a/backend/src/test/java/com/woowacourse/f12/support/FakeGitHubApiController.java
+++ b/backend/src/test/java/com/woowacourse/f12/support/FakeGitHubApiController.java
@@ -14,7 +14,6 @@ import com.woowacourse.f12.dto.request.auth.GitHubTokenRequest;
 import com.woowacourse.f12.dto.response.auth.GitHubProfileResponse;
 import com.woowacourse.f12.dto.response.auth.GitHubTokenResponse;
 import java.util.Map;
-import java.util.Objects;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
@@ -61,7 +60,7 @@ public class FakeGitHubApiController {
     @GetMapping("/user")
     public ResponseEntity<GitHubProfileResponse> showFakeProfile(
             @RequestHeader(value = HttpHeaders.AUTHORIZATION) final String authorizationHeaderValue) {
-        if (Objects.isNull(authorizationHeaderValue)) {
+        if (authorizationHeaderValue == null) {
             return ResponseEntity.badRequest().build();
         }
         final String[] splitValue = authorizationHeaderValue.split(" ");


### PR DESCRIPTION
# issue: closes #708 

# 작업 내용
Objects 의 null 체크 메서드를 제거한다.
Objects 의 null 체크 메서드는 람다식에서 메서드 참조를 위해 만들어졌다. 일반적인 경우에는 ==, !=null 을 사용하도록 한다.