### PR TITLE
[BugFix/BE] 액세스 토큰 발급 시 read only 커넥션 500 에러 수정

### DIFF
--- a/backend/src/main/java/com/woowacourse/f12/application/auth/AuthService.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/auth/AuthService.java
@@ -83,6 +83,7 @@ public class AuthService {
         return member;
     }
 
+    @Transactional
     public IssuedTokensResponse issueAccessToken(final String refreshTokenValue) {
         final RefreshToken refreshToken = refreshTokenRepository.findToken(refreshTokenValue)
                 .orElseThrow(RefreshTokenNotFoundException::new);


### PR DESCRIPTION
# issue: closes #758

# 작업 내용
- 액세스 토큰 발급 로직 메서드에 `@Transaction`메서드를 추가한다.
