### PR TITLE
[FE] 제품 카드를 클릭했을 때 새로운 탭에서 링크가 열리도록 설정

### DIFF
--- a/frontend/src/components/Product/ProductListSection/ProductListSection.tsx
+++ b/frontend/src/components/Product/ProductListSection/ProductListSection.tsx
@@ -1,15 +1,24 @@
 import { Link } from 'react-router-dom';
 
+
+
 import InfiniteScroll from '@/components/common/InfiniteScroll/InfiniteScroll';
 import Masonry from '@/components/common/Masonry/Masonry';
 import NoDataPlaceholder from '@/components/common/NoDataPlaceholder/NoDataPlaceholder';
 
+
+
 import ProductCard from '@/components/Product/ProductCard/ProductCard';
 import * as S from '@/components/Product/ProductListSection/ProductListSection.style';
 
+
+
 import useDevice from '@/hooks/useDevice';
 
+
+
 import ROUTES from '@/constants/routes';
+
 
 type Props = Omit<DataFetchStatus, 'isReady'> & {
   title: string;
@@ -42,7 +51,12 @@ function ProductListSection({
     displayType === 'flex' ? DEVICE_TO_SIZE[device] : device === 'tablet' ? 'm' : 'l';
 
   const productList = data.map(({ id, imageUrl, name, rating, reviewCount }, index) => (
-    <Link to={`${ROUTES.PRODUCT}/${id}`} key={id}>
+    <Link
+      to={`${ROUTES.PRODUCT}/${id}`}
+      key={id}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
       <ProductCard
         imageUrl={imageUrl}
         name={name}


### PR DESCRIPTION
# issue: #714

# 작업 내용
제품 카드를 클릭했을 때 새로운 탭에서 링크가 열리도록 설정해서 목록의 스크롤이 유지될 수 있는 효과를 만든다.