### PR TITLE
[BE] DB 형상관리 툴을 적용한다

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -33,6 +33,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-log4j2'
     implementation 'org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:3.3'
 
+    implementation 'org.flywaydb:flyway-core:8.2.2'
+    
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'mysql:mysql-connector-java'
 

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -16,6 +16,9 @@ spring:
     properties:
       hibernate:
         format_sql: true
+  flyway:
+    enabled: true
+    baseline-on-migrate: true
 
 server:
   port: 8080

--- a/backend/src/main/resources/db/migration/V1__init.sql
+++ b/backend/src/main/resources/db/migration/V1__init.sql
@@ -1,0 +1,72 @@
+DROP TABLE IF EXISTS `following`;
+CREATE TABLE `following`
+(
+    `id`           bigint NOT NULL AUTO_INCREMENT,
+    `created_at`   datetime(6) NOT NULL,
+    `follower_id`  bigint NOT NULL,
+    `following_id` bigint NOT NULL,
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `following_following_id_follower_id_unique` (`following_id`,`follower_id`)
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+DROP TABLE IF EXISTS `inventory_product`;
+CREATE TABLE `inventory_product`
+(
+    `id`         bigint NOT NULL AUTO_INCREMENT,
+    `selected`   bit(1) DEFAULT 0,
+    `member_id`  bigint NOT NULL DEFAULT NULL,
+    `product_id` bigint NOT NULL DEFAULT NULL,
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `inventory_member_product_unique` (`member_id`,`product_id`)
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+DROP TABLE IF EXISTS `member`;
+CREATE TABLE `member`
+(
+    `id`             bigint        NOT NULL AUTO_INCREMENT,
+    `career_level`   varchar(255) DEFAULT NULL,
+    `follower_count` int           NOT NULL DEFAULT 0,
+    `github_id`      varchar(255)  NOT NULL,
+    `image_url`      varchar(15000) NOT NULL,
+    `job_type`       varchar(255) DEFAULT NULL,
+    `name`           varchar(255) DEFAULT NULL,
+    `registered`     bit(1)        NOT NULL DEFAULT 0,
+    `role`           varchar(255)  NOT NULL DEFAULT 'USER',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `github_id_unique` (`github_id`)
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+DROP TABLE IF EXISTS `product`;
+CREATE TABLE `product`
+(
+    `id`           bigint         NOT NULL AUTO_INCREMENT,
+    `category`     varchar(255)     NOT NULL,
+    `image_url`    varchar(15000) NOT NULL,
+    `name`         varchar(255)   NOT NULL,
+    `avg_rating`   double         NOT NULL DEFAULT 0,
+    `review_count` int            NOT NULL DEFAULT 0,
+    `total_rating` int            NOT NULL DEFAULT 0,
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `NAME_UNIQUE` (`name`)
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+DROP TABLE IF EXISTS `review`;
+CREATE TABLE `review`
+(
+    `id`         bigint        NOT NULL AUTO_INCREMENT,
+    `content`    varchar(1000) NOT NULL,
+    `created_at` datetime(6) NOT NULL,
+    `rating`     int           NOT NULL,
+    `member_id`  bigint        NOT NULL,
+    `product_id` bigint        NOT NULL,
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `review_product_id_member_id_unique` (`product_id`,`member_id`)
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+DROP TABLE IF EXISTS `refresh_token`;
+create table `refresh_token`
+(
+    `token_value` varchar(50) primary key,
+    `expired_at`  timestamp not null,
+    `member_id`   bigint    not null
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;

--- a/backend/src/test/java/com/woowacourse/f12/acceptance/AcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/acceptance/AcceptanceTest.java
@@ -4,6 +4,7 @@ import static io.restassured.RestAssured.UNDEFINED_PORT;
 
 import com.woowacourse.f12.acceptance.support.DatabaseCleanup;
 import io.restassured.RestAssured;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -22,11 +23,15 @@ class AcceptanceTest {
     private DatabaseCleanup databaseCleanup;
 
     @BeforeEach
-    void setUp() throws Exception {
+    void setUp() {
         if (RestAssured.port == UNDEFINED_PORT) {
             RestAssured.port = port;
             databaseCleanup.afterPropertiesSet();
         }
+    }
+
+    @AfterEach
+    void cleanUp() {
         databaseCleanup.execute();
     }
 }

--- a/backend/src/test/java/com/woowacourse/f12/application/auth/token/RefreshTokenRepositoryImplTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/application/auth/token/RefreshTokenRepositoryImplTest.java
@@ -15,14 +15,15 @@ import java.time.LocalDateTime;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.autoconfigure.jdbc.JdbcTest;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
-import org.springframework.test.context.jdbc.Sql;
 
 @JdbcTest
-@Sql("classpath:refreshTokenDDL.sql")
+@AutoConfigureTestDatabase(replace = Replace.NONE)
 class RefreshTokenRepositoryImplTest {
 
     private final String tokenValue = "tokenValue";

--- a/backend/src/test/java/com/woowacourse/f12/domain/RepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/domain/RepositoryTest.java
@@ -5,11 +5,14 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
+@AutoConfigureTestDatabase(replace = Replace.NONE)
 @DataJpaTest(showSql = false)
 @Import(JpaConfig.class)
 public @interface RepositoryTest {

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -1,10 +1,16 @@
 spring:
   jpa:
-    hibernate:
-      ddl-auto: create
     properties:
       hibernate:
         format_sql: true
+        dialect: org.hibernate.dialect.MySQL8Dialect
+  datasource:
+    url: jdbc:h2:mem:testdb;MODE=MySQL;
+    username: sa
+    password:
+  flyway:
+    enabled: true
+    baseline-on-migrate: true
 
 server:
   port: 8888


### PR DESCRIPTION
# issue: #775 
# 작업 내용
- flyway로 DB 형상관리 툴을 적용한다
- 기존에 있는 데이터베이스를 활용해서 init.sql을 작성했다.
- Test 코드를 ddl-auto: create를 이용하는 것이 아니라, resource에 있는 init.sql을 활용하여 실제 db와 Spring boot test 환경 db의 싱크를 맞추었다.
