### PR TITLE
[BE] 리뷰 작성 시 제품 통계 정보의 정합성을 맞추도록 수정

### DIFF
--- a/backend/src/main/java/com/woowacourse/f12/domain/product/ProductRepository.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/product/ProductRepository.java
@@ -2,8 +2,34 @@ package com.woowacourse.f12.domain.product;
 
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ProductRepository extends JpaRepository<Product, Long>, ProductRepositoryCustom {
 
     List<Product> findByReviewCountGreaterThanEqualAndRatingGreaterThanEqual(int reviewCount, double rating);
+
+    @Modifying(clearAutomatically = true)
+    @Query(value = "update Product p "
+            + "set p.rating = (p.totalRating + :reviewRating) / cast((p.reviewCount + 1) as double), "
+            + "p.reviewCount = p.reviewCount + 1, "
+            + "p.totalRating = p.totalRating + :reviewRating "
+            + "where p.id = :productId")
+    void updateProductStatisticsForReviewInsert(Long productId, int reviewRating);
+
+    @Modifying(clearAutomatically = true)
+    @Query(value = "update Product p "
+            + "set p.rating = case p.reviewCount when 1 then 0 "
+            + "else ((p.totalRating - :reviewRating) / cast((p.reviewCount - 1) as double)) end , "
+            + "p.reviewCount = p.reviewCount - 1, "
+            + "p.totalRating = p.totalRating - :reviewRating "
+            + "where p.id = :productId")
+    void updateProductStatisticsForReviewDelete(Long productId, int reviewRating);
+
+    @Modifying(clearAutomatically = true)
+    @Query(value = "update Product p "
+            + "set p.rating = (p.totalRating + :ratingGap) / cast(p.reviewCount as double), "
+            + "p.totalRating = p.totalRating + :ratingGap "
+            + "where p.id = :productId")
+    void updateProductStatisticsForReviewUpdate(Long productId, int ratingGap);
 }

--- a/backend/src/main/java/com/woowacourse/f12/domain/review/Review.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/review/Review.java
@@ -88,25 +88,13 @@ public class Review {
         }
     }
 
-    public void reflectToProductWhenWritten() {
-        product.increaseReviewCount();
-        product.increaseRating(rating);
-    }
-
-    public void reflectToProductBeforeDelete() {
-        product.decreaseReviewCount();
-        product.decreaseRating(rating);
-    }
-
     public boolean isWrittenBy(final Member member) {
         return this.member.equals(member);
     }
 
     public void update(final Review updateReview) {
-        product.decreaseRating(rating);
         content = updateReview.getContent();
         rating = updateReview.getRating();
-        product.increaseRating(rating);
     }
 
     @Override

--- a/backend/src/test/java/com/woowacourse/f12/application/review/ReviewServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/application/review/ReviewServiceTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.refEq;
 import static org.mockito.BDDMockito.any;
@@ -100,9 +101,10 @@ class ReviewServiceTest {
         // then
         assertAll(
                 () -> assertThat(reviewId).isEqualTo(1L),
-//                () -> assertThat(product.getReviewCount()).isOne(),
                 () -> verify(productRepository).findById(productId),
                 () -> verify(memberRepository).findById(memberId),
+                () -> verify(productRepository).updateProductStatisticsForReviewInsert(productId,
+                        reviewRequest.getRating()),
                 () -> verify(reviewRepository).save(any(Review.class)),
                 () -> verify(inventoryProductRepository).existsByMemberAndProduct(member, product),
                 () -> verify(inventoryProductRepository).save(inventoryProduct)
@@ -207,7 +209,6 @@ class ReviewServiceTest {
         Member member = CORINNE.생성(1L);
         Pageable pageable = PageRequest.of(0, 1, Sort.by(Order.desc("createdAt")));
         Review review = REVIEW_RATING_5.작성(1L, product, member);
-        review.reflectToProductWhenWritten();
         Slice<Review> slice = new SliceImpl<>(List.of(review), pageable, true);
 
         given(productRepository.existsById(productId))
@@ -237,7 +238,6 @@ class ReviewServiceTest {
         Member member = CORINNE.생성(1L);
         Pageable pageable = PageRequest.of(0, 1, Sort.by(Order.desc("createdAt")));
         Review review = REVIEW_RATING_5.작성(1L, product, member);
-        review.reflectToProductWhenWritten();
         Slice<Review> slice = new SliceImpl<>(List.of(review), pageable, true);
 
         given(productRepository.existsById(productId))
@@ -269,7 +269,6 @@ class ReviewServiceTest {
         Member member = CORINNE.생성(1L);
         Pageable pageable = PageRequest.of(0, 1, Sort.by(Order.desc("createdAt")));
         Review review = REVIEW_RATING_5.작성(1L, product, member);
-        review.reflectToProductWhenWritten();
         Slice<Review> slice = new SliceImpl<>(List.of(review), pageable, true);
 
         given(productRepository.existsById(productId))
@@ -313,9 +312,7 @@ class ReviewServiceTest {
         Pageable pageable = PageRequest.of(0, 2, Sort.by(Order.desc("createdAt")));
         Member member = CORINNE.생성(1L);
         Review review1 = REVIEW_RATING_5.작성(3L, KEYBOARD_1.생성(), member);
-        review1.reflectToProductWhenWritten();
         Review review2 = REVIEW_RATING_5.작성(2L, KEYBOARD_2.생성(), member);
-        review2.reflectToProductWhenWritten();
         Slice<Review> slice = new SliceImpl<>(List.of(review1, review2), pageable, true);
 
         given(reviewRepository.findPageBy(pageable))
@@ -342,9 +339,8 @@ class ReviewServiceTest {
         Long reviewId = 1L;
         Long memberId = 1L;
         Member member = CORINNE.생성(memberId);
-        Product product = KEYBOARD_1.생성();
+        Product product = KEYBOARD_1.생성(1L);
         Review review = REVIEW_RATING_5.작성(reviewId, product, member);
-        review.reflectToProductWhenWritten();
         ReviewRequest updateRequest = new ReviewRequest("수정할 내용", 4);
 
         given(memberRepository.findById(memberId))
@@ -360,9 +356,9 @@ class ReviewServiceTest {
                 () -> assertThat(review).usingRecursiveComparison()
                         .comparingOnlyFields("content", "rating")
                         .isEqualTo(updateRequest.toReview(product, member)),
-                () -> assertThat(product.getRating()).isEqualTo(4.0),
                 () -> verify(memberRepository).findById(memberId),
-                () -> verify(reviewRepository).findById(reviewId)
+                () -> verify(reviewRepository).findById(reviewId),
+                () -> verify(productRepository).updateProductStatisticsForReviewUpdate(product.getId(), -1)
         );
     }
 
@@ -428,7 +424,8 @@ class ReviewServiceTest {
                 () -> assertThatThrownBy(() -> reviewService.update(reviewId, notAuthorId, updateRequest))
                         .isExactlyInstanceOf(NotAuthorException.class),
                 () -> verify(memberRepository).findById(notAuthorId),
-                () -> verify(reviewRepository).findById(reviewId)
+                () -> verify(reviewRepository).findById(reviewId),
+                () -> verify(productRepository, times(0)).updateProductStatisticsForReviewUpdate(anyLong(), anyInt())
         );
     }
 
@@ -441,7 +438,6 @@ class ReviewServiceTest {
         Member member = CORINNE.생성(memberId);
         Product product = KEYBOARD_1.생성(productId);
         Review review = REVIEW_RATING_5.작성(reviewId, product, member);
-        review.reflectToProductWhenWritten();
         InventoryProduct inventoryProduct = SELECTED_INVENTORY_PRODUCT.생성(1L, member, product);
 
         given(memberRepository.findById(memberId))
@@ -458,12 +454,12 @@ class ReviewServiceTest {
         // when, then
         assertAll(
                 () -> assertDoesNotThrow(() -> reviewService.delete(reviewId, memberId)),
-                () -> assertThat(product.getReviewCount()).isZero(),
                 () -> verify(memberRepository).findById(memberId),
                 () -> verify(reviewRepository).findById(reviewId),
-                () -> verify(reviewRepository).delete(review),
                 () -> verify(inventoryProductRepository).findWithProductByMemberAndProduct(member, product),
-                () -> verify(inventoryProductRepository).delete(inventoryProduct)
+                () -> verify(inventoryProductRepository).delete(inventoryProduct),
+                () -> verify(reviewRepository).delete(review),
+                () -> verify(productRepository).updateProductStatisticsForReviewDelete(productId, review.getRating())
         );
     }
 
@@ -544,8 +540,6 @@ class ReviewServiceTest {
                 .willReturn(Optional.of(member));
         given(reviewRepository.findById(reviewId))
                 .willReturn(Optional.of(review));
-        willDoNothing().given(reviewRepository)
-                .delete(any(Review.class));
         given(inventoryProductRepository.findWithProductByMemberAndProduct(member, product))
                 .willReturn(Optional.empty());
 
@@ -555,9 +549,9 @@ class ReviewServiceTest {
                         .isExactlyInstanceOf(InventoryProductNotFoundException.class),
                 () -> verify(memberRepository).findById(memberId),
                 () -> verify(reviewRepository).findById(reviewId),
-                () -> verify(reviewRepository).delete(any(Review.class)),
                 () -> verify(inventoryProductRepository).findWithProductByMemberAndProduct(member, product),
-                () -> verify(inventoryProductRepository, times(0)).delete(any(InventoryProduct.class))
+                () -> verify(inventoryProductRepository, times(0)).delete(any(InventoryProduct.class)),
+                () -> verify(reviewRepository, times(0)).delete(any(Review.class))
         );
     }
 

--- a/backend/src/test/java/com/woowacourse/f12/domain/product/ProductRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/domain/product/ProductRepositoryTest.java
@@ -212,6 +212,87 @@ class ProductRepositoryTest {
                 .containsOnly(keyboard1);
     }
 
+    @Test
+    void 리뷰_작성에_맞게_제품_정합성을_맞춘다() {
+        // given
+        Long productId = 제품_저장(KEYBOARD_1.생성()).getId();
+
+        // when
+        productRepository.updateProductStatisticsForReviewInsert(productId, 1);
+        productRepository.updateProductStatisticsForReviewInsert(productId, 2);
+
+        // then
+        Product actual = productRepository.findById(productId)
+                .orElseThrow();
+
+        assertAll(
+                () -> assertThat(actual.getReviewCount()).isEqualTo(2),
+                () -> assertThat(actual.getRating()).isEqualTo(1.5),
+                () -> assertThat(actual.getTotalRating()).isEqualTo(3)
+        );
+    }
+
+    @Test
+    void 리뷰_삭제에_맞게_제품_정합성을_맞춘다() {
+        // given
+        Long productId = 제품_저장(KEYBOARD_1.생성()).getId();
+        productRepository.updateProductStatisticsForReviewInsert(productId, 1);
+        productRepository.updateProductStatisticsForReviewInsert(productId, 2);
+
+        // when
+        productRepository.updateProductStatisticsForReviewDelete(productId, 1);
+
+        // then
+        Product actual = productRepository.findById(productId)
+                .orElseThrow();
+
+        assertAll(
+                () -> assertThat(actual.getReviewCount()).isOne(),
+                () -> assertThat(actual.getRating()).isEqualTo(2.0),
+                () -> assertThat(actual.getTotalRating()).isEqualTo(2)
+        );
+    }
+
+    @Test
+    void 리뷰_삭제로_리뷰_개수가_0개일_때_제품_정합성을_맞춘다() {
+        // given
+        Long productId = 제품_저장(KEYBOARD_1.생성()).getId();
+        productRepository.updateProductStatisticsForReviewInsert(productId, 1);
+
+        // when
+        productRepository.updateProductStatisticsForReviewDelete(productId, 1);
+
+        // then
+        Product actual = productRepository.findById(productId)
+                .orElseThrow();
+
+        assertAll(
+                () -> assertThat(actual.getReviewCount()).isZero(),
+                () -> assertThat(actual.getRating()).isEqualTo(0.0),
+                () -> assertThat(actual.getTotalRating()).isEqualTo(0)
+        );
+    }
+
+    @Test
+    void 리뷰_수정에_맞게_제품_정합성을_맞춘다() {
+        // given
+        Long productId = 제품_저장(KEYBOARD_1.생성()).getId();
+        productRepository.updateProductStatisticsForReviewInsert(productId, 5);
+
+        // when
+        productRepository.updateProductStatisticsForReviewUpdate(productId, -2);
+
+        // then
+        Product actual = productRepository.findById(productId)
+                .orElseThrow();
+
+        assertAll(
+                () -> assertThat(actual.getReviewCount()).isOne(),
+                () -> assertThat(actual.getRating()).isEqualTo(3.0),
+                () -> assertThat(actual.getTotalRating()).isEqualTo(3)
+        );
+    }
+
     private Product 제품_저장(Product product) {
         return productRepository.save(product);
     }

--- a/backend/src/test/java/com/woowacourse/f12/domain/product/ProductRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/domain/product/ProductRepositoryTest.java
@@ -48,7 +48,7 @@ class ProductRepositoryTest {
         Member member2 = memberRepository.save(MINCHO.생성());
         Review review1 = REVIEW_RATING_4.작성(product, member1);
         Review review2 = REVIEW_RATING_5.작성(product, member2);
-
+        
         리뷰_저장(review1);
         리뷰_저장(review2);
 
@@ -298,7 +298,7 @@ class ProductRepositoryTest {
     }
 
     private Review 리뷰_저장(Review review) {
-        review.reflectToProductWhenWritten();
+        productRepository.updateProductStatisticsForReviewInsert(review.getProduct().getId(), review.getRating());
         return reviewRepository.save(review);
     }
 }

--- a/backend/src/test/java/com/woowacourse/f12/domain/review/ReviewRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/domain/review/ReviewRepositoryTest.java
@@ -330,7 +330,6 @@ class ReviewRepositoryTest {
     }
 
     private Review 리뷰_저장(Review review) {
-        review.reflectToProductWhenWritten();
         return reviewRepository.save(review);
     }
 }

--- a/backend/src/test/java/com/woowacourse/f12/domain/review/ReviewTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/domain/review/ReviewTest.java
@@ -126,7 +126,6 @@ class ReviewTest {
                 .rating(5)
                 .product(product)
                 .build();
-        review.reflectToProductWhenWritten();
 
         Review updateReview = Review.builder()
                 .id(2L)
@@ -143,57 +142,7 @@ class ReviewTest {
                 () -> assertThat(review.getId()).isEqualTo(1L),
                 () -> assertThat(review).usingRecursiveComparison()
                         .ignoringFields("id", "product")
-                        .isEqualTo(updateReview),
-                () -> assertThat(review.getProduct().getReviewCount()).isOne(),
-                () -> assertThat(review.getProduct().getTotalRating()).isEqualTo(4),
-                () -> assertThat(review.getProduct().getRating()).isEqualTo(4.0)
-        );
-    }
-
-    @Test
-    void 리뷰_작성_시_리뷰_대상_제품의_리뷰_개수와_평점을_증가시킨다() {
-        // given
-        Product product = Product.builder()
-                .build();
-
-        Review review = Review.builder()
-                .content("내용")
-                .rating(5)
-                .product(product)
-                .build();
-
-        // when
-        review.reflectToProductWhenWritten();
-
-        // then
-        assertAll(
-                () -> assertThat(product.getReviewCount()).isOne(),
-                () -> assertThat(product.getTotalRating()).isEqualTo(5),
-                () -> assertThat(product.getRating()).isEqualTo(5.0)
-        );
-    }
-
-    @Test
-    void 리뷰_삭제_전에_리뷰_대상_제품의_리뷰_개수와_평점을_감소시킨다() {
-        // given
-        Product product = Product.builder()
-                .build();
-
-        Review review = Review.builder()
-                .content("내용")
-                .rating(5)
-                .product(product)
-                .build();
-        review.reflectToProductWhenWritten();
-
-        // when
-        review.reflectToProductBeforeDelete();
-
-        // then
-        assertAll(
-                () -> assertThat(product.getReviewCount()).isZero(),
-                () -> assertThat(product.getTotalRating()).isEqualTo(0),
-                () -> assertThat(product.getRating()).isEqualTo(0)
+                        .isEqualTo(updateReview)
         );
     }
 }


### PR DESCRIPTION
# issue: #756 

# 작업 내용
- 제품 통계 정보(리뷰 개수, 리뷰 총 점수, 리뷰 평균 점수)가 리뷰 작성, 수정, 삭제의 동시성 문제로 제대로 업데이트 되지 않는 문제가 발생
  - 더티 체킹을 유지한 상태로 문제를 해결하려면 명시적으로 락을 걸어야 하지만 애플리케이션 단의 락은 위험
  - 애플리케이션 단의 명시적 락이 아닌, 데이터베이스의 암시적 락을 활용하기 위해 JPQL을 직접 사용하도록 변경
- 리뷰 작성, 수정, 삭제 각각에 대해 통계를 반영하는 JPQL 작성
  - 기존에 이미 테이블에 있는 정보를 사용하여 업데이트 하도록 작성
  - 최대한 DBMS에 종속적이지 않도록 작성
    - JPQL로 작성하고, DBMS마다 다른 계산 방식을 해결하기 위해 나눗셈시 미리 double로 타입 캐스팅
- JpaRepository의 명시적 flush 기능 사용
  - `@Modifying(clearAutomatically = true)` 옵션을 사용하기 때문에 영속성 컨텍스트가 초기화 됨
  - 이 때 JPQL은 product 테이블에 대해서만 나가므로, review나 inventoryProduct에 대한 수정, 삭제 쿼리는 flush되지 않음
  - clearAutomatically = true에 의해 영속성 컨텍스트가 초기화되어 쿼리가 실행되지 않음
  - JpaRepository의 flush를 직접 호출하여 영속성 컨텍스트 초기화 이전에 모든 쓰기 지연 저장소의 쿼리가 flush 되도록 지정