### PR TITLE
[FE] 상품 상세 조회 + 리뷰 작성 플로우의 웹 접근성을 개선

### DIFF
--- a/frontend/cypress/e2e/spec.cy.ts
+++ b/frontend/cypress/e2e/spec.cy.ts
@@ -16,7 +16,7 @@ describe('비회원 사용자 기본 플로우', () => {
       cy.wait('@productsRequest');
 
       cy.findByRole('region', { name: /제품/ })
-        .findAllByRole('article')
+        .findAllByRole('link')
         .should('be.visible');
     });
 
@@ -24,7 +24,7 @@ describe('비회원 사용자 기본 플로우', () => {
       cy.wait('@reviewsRequest');
 
       cy.findByRole('region', { name: /후기/ })
-        .findAllByRole('article')
+        .findAllByRole('link')
         .should('be.visible');
     });
 
@@ -33,9 +33,11 @@ describe('비회원 사용자 기본 플로우', () => {
         cy.findByRole('region', { name: /후기/ }).isCardImageLoadDone();
       });
 
-      cy.findByRole('region', {
-        name: '무한스크롤 목록 끝 지표',
-      }).scrollIntoView();
+      cy.findByRole('region', { name: /후기/ })
+        .findAllByRole('link')
+        .should('be.visible')
+        .last()
+        .scrollIntoView();
 
       cy.wait('@reviewsRequest').then((res) => {
         const page = new URL(res.request.url).searchParams.get('page');
@@ -52,7 +54,7 @@ describe('비회원 사용자 기본 플로우', () => {
       cy.wait('@productsRequest');
 
       cy.findByRole('region', { name: /키보드/ })
-        .findAllByRole('article')
+        .findAllByRole('link')
         .should('be.visible');
     });
 
@@ -63,7 +65,7 @@ describe('비회원 사용자 기본 플로우', () => {
       cy.wait('@productsRequest');
 
       cy.findByRole('region', { name: /마우스/ })
-        .findAllByRole('article')
+        .findAllByRole('link')
         .should('be.visible');
     });
 
@@ -74,7 +76,7 @@ describe('비회원 사용자 기본 플로우', () => {
       cy.wait('@productsRequest');
 
       cy.findByRole('region', { name: /모니터/ })
-        .findAllByRole('article')
+        .findAllByRole('link')
         .should('be.visible');
     });
 
@@ -85,7 +87,7 @@ describe('비회원 사용자 기본 플로우', () => {
       cy.wait('@productsRequest');
 
       cy.findByRole('region', { name: /거치대/ })
-        .findAllByRole('article')
+        .findAllByRole('link')
         .should('be.visible');
     });
 
@@ -95,7 +97,7 @@ describe('비회원 사용자 기본 플로우', () => {
 
       cy.wait('@productsRequest');
       cy.findByRole('region', { name: /소프트웨어/ })
-        .findAllByRole('article')
+        .findAllByRole('link')
         .should('be.visible');
     });
 
@@ -103,14 +105,14 @@ describe('비회원 사용자 기본 플로우', () => {
       cy.wait('@productsRequest');
 
       cy.findByRole('region', { name: '인기 있는 제품' })
-        .findAllByRole('article')
+        .findAllByRole('link')
         .first()
         // .findByRole('img')
         .click({ force: true });
 
       // 후기는 없는 제품이 있을 수도 있기 때문에 삭제하거나 빈 데이터 이미지 표시 필요
       // cy.findByRole('region', { name: '최근 후기' })
-      //   .findAllByRole('article')
+      //   .findAllByRole('link')
       //   .should('be.visible');
       cy.wait('@productRequest');
 

--- a/frontend/cypress/support/commands.ts
+++ b/frontend/cypress/support/commands.ts
@@ -5,7 +5,7 @@ Cypress.Commands.add(
   { prevSubject: true },
   (card: Cypress.Chainable<JQuery<HTMLElement>>) => {
     cy.wrap(card)
-      .findAllByRole('article')
+      .findAllByRole('link')
       .each((element) => {
         cy.wrap(element).get('img').should('be.visible');
       });
@@ -16,8 +16,6 @@ Cypress.Commands.add(
   'isNotLoading',
   { prevSubject: true },
   (container: Cypress.Chainable<JQuery<HTMLElement>>) => {
-    cy.wrap(container)
-      .findByRole('region', { name: 'loading' })
-      .should('not.exist');
+    cy.wrap(container).findByRole('region', { name: 'loading' }).should('not.exist');
   }
 );

--- a/frontend/src/assets/left_arrow.svg
+++ b/frontend/src/assets/left_arrow.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M14 5L9 10L14 15L13 17L6 10L13 3L14 5Z" fill="#3C3C3C"/>
+</svg>

--- a/frontend/src/assets/nextSign.svg
+++ b/frontend/src/assets/nextSign.svg
@@ -1,3 +1,0 @@
-<svg width="11" height="18" viewBox="0 0 11 18" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M2.00001 0L0.600006 1.5L8.00001 9L0.600006 16.5L2.00001 18L11 9L2.00001 0Z" fill="black"/>
-</svg>

--- a/frontend/src/assets/right_arrow.svg
+++ b/frontend/src/assets/right_arrow.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M6 15L11 10L6 5L7 3L14 10L7 17L6 15Z" fill="#3C3C3C"/>
+</svg>

--- a/frontend/src/components/Product/ProductCard/ProductCard.style.tsx
+++ b/frontend/src/components/Product/ProductCard/ProductCard.style.tsx
@@ -1,6 +1,6 @@
 import styled, { css } from 'styled-components';
 
-export const Container = styled.article<{ index: number; size: 's' | 'm' | 'l' }>`
+export const Container = styled.div<{ index: number; size: 's' | 'm' | 'l' }>`
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -15,9 +15,6 @@ export const Container = styled.article<{ index: number; size: 's' | 'm' | 'l' }
     img {
       transform: scale(1.03);
       transition: 0.2s;
-    }
-    h2 {
-      text-decoration: underline;
     }
   }
 
@@ -41,6 +38,7 @@ export const Container = styled.article<{ index: number; size: 's' | 'm' | 'l' }
 `;
 export const ImageWrapper = styled.div`
   width: 100%;
+  aspect-ratio: 1 / 1;
   overflow: hidden;
   border: 1px solid ${({ theme }) => theme.colors.secondary};
   background-color: #fff;
@@ -64,7 +62,12 @@ const nameFontSize = {
   l: '1rem',
 };
 
-export const Name = styled.h2<{ size: 's' | 'm' | 'l' }>`
+export const Name = styled.p<{ size: 's' | 'm' | 'l' }>`
   line-height: 1.3;
+  font-weight: 500;
   font-size: ${({ size }) => nameFontSize[size]};
+
+  ${Container}:hover & {
+    text-decoration: underline;
+  }
 `;

--- a/frontend/src/components/Product/ProductCard/ProductCard.tsx
+++ b/frontend/src/components/Product/ProductCard/ProductCard.tsx
@@ -18,9 +18,9 @@ function ProductCard({
   size = 'l',
 }: Props) {
   return (
-    <S.Container aria-label={name} index={index} size={size}>
+    <S.Container index={index} size={size}>
       <S.ImageWrapper>
-        <LazyImage src={imageUrl} />
+        <LazyImage src={imageUrl} alt={''} />
       </S.ImageWrapper>
       <S.Name size={size}>{name}</S.Name>
       <S.BottomWrapper>

--- a/frontend/src/components/Product/ProductDetail/ProductDetail.tsx
+++ b/frontend/src/components/Product/ProductDetail/ProductDetail.tsx
@@ -12,7 +12,7 @@ function ProductDetail({ product }: Props) {
 
   return (
     <S.Container>
-      <S.Image src={imageUrl} aria-label="제품 이미지" />
+      <S.Image src={imageUrl} aria-label={`${name} 이미지`} />
       <S.Wrapper>
         <S.Name>{name}</S.Name>
         <S.Details>

--- a/frontend/src/components/Product/ProductListSection/ProductListSection.style.tsx
+++ b/frontend/src/components/Product/ProductListSection/ProductListSection.style.tsx
@@ -27,6 +27,7 @@ export const FlexWrapper = styled.div`
     }
     @media screen and ${device.desktop} {
       min-height: 28rem;
+      justify-content: space-between;
       -ms-overflow-style: none;
       scrollbar-width: none;
       &::-webkit-scrollbar {
@@ -36,11 +37,23 @@ export const FlexWrapper = styled.div`
   `}
 `;
 
+export const Grid = styled.ul<{ columnCount: number }>`
+  display: grid;
+  grid-template-columns: repeat(${({ columnCount }) => columnCount}, 1fr);
+`;
+
 export const Title = styled.h1`
   font-size: 1.5rem;
 `;
 
 export const CustomLink = styled(Link)``;
+
+export const ProductLink = styled(Link)`
+  display: flex;
+  justify-content: center;
+  width: max-content;
+  margin: 0 auto;
+`;
 
 export const Wrapper = styled.div`
   margin: 1rem auto 0 auto;

--- a/frontend/src/components/Product/ProductListSection/ProductListSection.tsx
+++ b/frontend/src/components/Product/ProductListSection/ProductListSection.tsx
@@ -1,7 +1,4 @@
-import { Link } from 'react-router-dom';
-
 import InfiniteScroll from '@/components/common/InfiniteScroll/InfiniteScroll';
-import Masonry from '@/components/common/Masonry/Masonry';
 import NoDataPlaceholder from '@/components/common/NoDataPlaceholder/NoDataPlaceholder';
 
 import ProductCard from '@/components/Product/ProductCard/ProductCard';
@@ -42,16 +39,18 @@ function ProductListSection({
     displayType === 'flex' ? DEVICE_TO_SIZE[device] : device === 'tablet' ? 'm' : 'l';
 
   const productList = data.map(({ id, imageUrl, name, rating, reviewCount }, index) => (
-    <Link to={`${ROUTES.PRODUCT}/${id}`} key={id}>
-      <ProductCard
-        imageUrl={imageUrl}
-        name={name}
-        rating={rating}
-        reviewCount={reviewCount}
-        index={index % pageSize}
-        size={cardSize}
-      />
-    </Link>
+    <li key={id}>
+      <S.ProductLink to={`${ROUTES.PRODUCT}/${id}`}>
+        <ProductCard
+          imageUrl={imageUrl}
+          name={name}
+          rating={rating}
+          reviewCount={reviewCount}
+          index={index % pageSize}
+          size={cardSize}
+        />
+      </S.ProductLink>
+    </li>
   ));
 
   return (
@@ -69,11 +68,11 @@ function ProductListSection({
             isLoading={isLoading}
             isError={isError}
           >
-            <Masonry
+            <S.Grid
               columnCount={displayType === 'masonry' ? ROW_COUNT(displayWidth) : pageSize}
             >
               {productList}
-            </Masonry>
+            </S.Grid>
           </InfiniteScroll>
         )}
       </S.Wrapper>

--- a/frontend/src/components/Profile/ProfileCard/ProfileCard.tsx
+++ b/frontend/src/components/Profile/ProfileCard/ProfileCard.tsx
@@ -15,7 +15,8 @@ import ROUTES from '@/constants/routes';
 
 import Empty from '@/assets/empty.svg';
 import GithubIcon from '@/assets/github.svg';
-import NextSign from '@/assets/nextSign.svg';
+import LeftArrow from '@/assets/left_arrow.svg';
+import RightArrow from '@/assets/right_arrow.svg';
 
 const DISTANCE_DIFFERENCE = 116;
 
@@ -151,7 +152,7 @@ function ProfileCard({
         </S.UserInfoWrapper>
         <S.InventoryWrapper>
           <S.LeftButton onClick={handleLeftButtonClick}>
-            <NextSign transform="rotate(-180)" />
+            <LeftArrow />
           </S.LeftButton>
           <S.InventoryListWrapper>
             <S.InventoryList positionX={positionX}>
@@ -184,7 +185,7 @@ function ProfileCard({
             </S.InventoryList>
           </S.InventoryListWrapper>
           <S.RightButton onClick={handleRightButtonClick}>
-            <NextSign />
+            <RightArrow />
           </S.RightButton>
         </S.InventoryWrapper>
         <S.LinkWrapper to={`${ROUTES.PROFILE}/${id}`}>

--- a/frontend/src/components/Review/ReviewBottomSheet/ReviewBottomSheet.tsx
+++ b/frontend/src/components/Review/ReviewBottomSheet/ReviewBottomSheet.tsx
@@ -4,6 +4,7 @@ import * as S from '@/components/Review/ReviewBottomSheet/ReviewBottomSheet.styl
 import ReviewForm from '@/components/Review/ReviewForm/ReviewForm';
 
 type Props = Partial<Pick<Review, 'id' | 'rating' | 'content'>> & {
+  isSheetOpen: boolean;
   handleClose: () => void;
   handleSubmit?: (reviewInput: ReviewInput) => Promise<void>;
   handleEdit?: (reviewInput: ReviewInput, id: number) => Promise<void>;
@@ -13,6 +14,7 @@ type Props = Partial<Pick<Review, 'id' | 'rating' | 'content'>> & {
 };
 
 function ReviewBottomSheet({
+  isSheetOpen,
   handleClose,
   handleSubmit,
   handleEdit,
@@ -35,19 +37,21 @@ function ReviewBottomSheet({
       console.log(error);
     }
   };
+
   return (
     <BottomSheet
       handleClose={handleClose}
       handleUnmount={handleUnmount}
       animationTrigger={animationTrigger}
     >
-      <S.Button onClick={handleClose}>닫기</S.Button>
       <ReviewForm
+        isSheetOpen={isSheetOpen}
         handleSubmit={handleCloseWithSubmit}
         isEdit={isEdit ? true : false}
         rating={rating}
         content={content}
       />
+      <S.Button onClick={handleClose}>닫기</S.Button>
     </BottomSheet>
   );
 }

--- a/frontend/src/components/Review/ReviewBottomSheet/ReviewBottomSheet.tsx
+++ b/frontend/src/components/Review/ReviewBottomSheet/ReviewBottomSheet.tsx
@@ -4,17 +4,16 @@ import * as S from '@/components/Review/ReviewBottomSheet/ReviewBottomSheet.styl
 import ReviewForm from '@/components/Review/ReviewForm/ReviewForm';
 
 type Props = Partial<Pick<Review, 'id' | 'rating' | 'content'>> & {
-  isSheetOpen: boolean;
   handleClose: () => void;
   handleSubmit?: (reviewInput: ReviewInput) => Promise<void>;
   handleEdit?: (reviewInput: ReviewInput, id: number) => Promise<void>;
   isEdit: boolean;
   handleUnmount?: () => void;
+  handleFocus?: () => void;
   animationTrigger?: boolean;
 };
 
 function ReviewBottomSheet({
-  isSheetOpen,
   handleClose,
   handleSubmit,
   handleEdit,
@@ -23,6 +22,7 @@ function ReviewBottomSheet({
   rating,
   content,
   handleUnmount,
+  handleFocus,
   animationTrigger,
 }: Props) {
   const handleCloseWithSubmit = async (reviewInput: ReviewInput) => {
@@ -33,6 +33,7 @@ function ReviewBottomSheet({
         await handleSubmit(reviewInput);
       }
       handleClose();
+      handleFocus();
     } catch (error) {
       console.log(error);
     }
@@ -45,7 +46,6 @@ function ReviewBottomSheet({
       animationTrigger={animationTrigger}
     >
       <ReviewForm
-        isSheetOpen={isSheetOpen}
         handleSubmit={handleCloseWithSubmit}
         isEdit={isEdit ? true : false}
         rating={rating}

--- a/frontend/src/components/Review/ReviewCard/ReviewCard.style.tsx
+++ b/frontend/src/components/Review/ReviewCard/ReviewCard.style.tsx
@@ -1,7 +1,7 @@
 import { Link } from 'react-router-dom';
 import styled, { css } from 'styled-components';
 
-export const Container = styled.article<{ index: number }>`
+export const Container = styled.div<{ index: number }>`
   display: flex;
   gap: 1rem;
   border-radius: 0.375rem;

--- a/frontend/src/components/Review/ReviewCard/ReviewCard.tsx
+++ b/frontend/src/components/Review/ReviewCard/ReviewCard.tsx
@@ -17,6 +17,7 @@ type Props = {
   reviewData: Omit<Review, 'id'>;
   handleDelete?: (id: number) => void;
   handleEdit?: (reviewInput: ReviewInput, id: number) => Promise<void>;
+  handleFocus?: () => void;
   index?: number;
   userNameVisible?: boolean;
 };
@@ -25,6 +26,7 @@ function ReviewCard({
   reviewId,
   handleDelete,
   handleEdit,
+  handleFocus,
   reviewData,
   index = 0,
   userNameVisible = true,
@@ -52,6 +54,7 @@ function ReviewCard({
 
   const handleDeleteClick = () => {
     handleDelete(reviewId);
+    handleFocus();
   };
 
   return (

--- a/frontend/src/components/Review/ReviewForm/ReviewForm.style.tsx
+++ b/frontend/src/components/Review/ReviewForm/ReviewForm.style.tsx
@@ -63,3 +63,16 @@ export const SubmitButton = styled.button`
 export const ErrorMessage = styled.p`
   color: red;
 `;
+
+export const ReadableValue = styled.div`
+  position: absolute;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  top: 0;
+  left: 0;
+`;

--- a/frontend/src/components/Review/ReviewForm/ReviewForm.tsx
+++ b/frontend/src/components/Review/ReviewForm/ReviewForm.tsx
@@ -78,35 +78,40 @@ function ReviewForm({
   }, []);
 
   return (
-    <S.Container>
-      <S.Title tabIndex={0} ref={modalRef}>
-        {isEdit ? '리뷰 수정하기' : '리뷰 작성하기'}
-      </S.Title>
-      <S.Form onSubmit={submitForm} onChange={handleFormChange}>
-        <S.Label isInvalid={isFormInvalid && isRatingEmpty}>
-          <p>평점을 입력해주세요</p>
-          <RatingInput rating={rating} setRating={setRating} />
-        </S.Label>
-        <S.Label isInvalid={isFormInvalid && isContentEmpty}>
-          <S.LabelTop>
-            <p>총평을 입력해주세요</p>
-            <p>{content.length} / 1000</p>
-          </S.LabelTop>
-          <S.Textarea
-            value={content}
-            onChange={handleContentChange}
-            required
-            maxLength={1000}
-          />
-        </S.Label>
-        <S.Footer>
-          <S.SubmitButton>{isEdit ? '리뷰 수정' : '리뷰 추가'}</S.SubmitButton>
-          {isFormInvalid && (
-            <S.ErrorMessage>{VALIDATION_ERROR_MESSAGES.FORM_INCOMPLETE}</S.ErrorMessage>
-          )}
-        </S.Footer>
-      </S.Form>
-    </S.Container>
+    <>
+      <S.ReadableValue aria-live="assertive">
+        {content.length === 1000 && '리뷰는 1000자까지 입력 가능합니다'}
+      </S.ReadableValue>
+      <S.Container>
+        <S.Title tabIndex={0} ref={modalRef}>
+          {isEdit ? '리뷰 수정하기' : '리뷰 작성하기'}
+        </S.Title>
+        <S.Form onSubmit={submitForm} onChange={handleFormChange}>
+          <S.Label isInvalid={isFormInvalid && isRatingEmpty}>
+            <p>평점을 입력해주세요</p>
+            <RatingInput rating={rating} setRating={setRating} />
+          </S.Label>
+          <S.Label isInvalid={isFormInvalid && isContentEmpty}>
+            <S.LabelTop>
+              <p>총평을 입력해주세요</p>
+              <p aria-hidden="true">{content.length} / 1000</p>
+            </S.LabelTop>
+            <S.Textarea
+              value={content}
+              onChange={handleContentChange}
+              required
+              maxLength={1000}
+            />
+          </S.Label>
+          <S.Footer>
+            <S.SubmitButton>{isEdit ? '리뷰 수정' : '리뷰 추가'}</S.SubmitButton>
+            {isFormInvalid && (
+              <S.ErrorMessage>{VALIDATION_ERROR_MESSAGES.FORM_INCOMPLETE}</S.ErrorMessage>
+            )}
+          </S.Footer>
+        </S.Form>
+      </S.Container>
+    </>
   );
 }
 

--- a/frontend/src/components/Review/ReviewForm/ReviewForm.tsx
+++ b/frontend/src/components/Review/ReviewForm/ReviewForm.tsx
@@ -7,7 +7,6 @@ import * as S from '@/components/Review/ReviewForm/ReviewForm.style';
 import { VALIDATION_ERROR_MESSAGES } from '@/constants/messages';
 
 type Props = {
-  isSheetOpen: boolean;
   handleSubmit: (reviewInput: ReviewInput) => Promise<void>;
   isEdit: boolean;
   rating?: Review['rating'];
@@ -20,7 +19,6 @@ const initialState = {
 };
 
 function ReviewForm({
-  isSheetOpen,
   handleSubmit,
   isEdit,
   rating: savedRating,
@@ -73,21 +71,18 @@ function ReviewForm({
   const isRatingEmpty = rating === 0;
   const isContentEmpty = content.trim() === '';
 
-  const modalRef = useRef<HTMLFormElement>(null);
+  const modalRef = useRef<HTMLHeadingElement>(null);
 
   useEffect(() => {
-    if (isSheetOpen) modalRef.current.focus();
-  }, [isSheetOpen]);
+    modalRef.current.focus();
+  }, []);
 
   return (
     <S.Container>
-      <S.Title>{isEdit ? '리뷰 수정하기' : '리뷰 작성하기'}</S.Title>
-      <S.Form
-        tabIndex={0}
-        ref={modalRef}
-        onSubmit={submitForm}
-        onChange={handleFormChange}
-      >
+      <S.Title tabIndex={0} ref={modalRef}>
+        {isEdit ? '리뷰 수정하기' : '리뷰 작성하기'}
+      </S.Title>
+      <S.Form onSubmit={submitForm} onChange={handleFormChange}>
         <S.Label isInvalid={isFormInvalid && isRatingEmpty}>
           <p>평점을 입력해주세요</p>
           <RatingInput rating={rating} setRating={setRating} />

--- a/frontend/src/components/Review/ReviewForm/ReviewForm.tsx
+++ b/frontend/src/components/Review/ReviewForm/ReviewForm.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 import RatingInput from '@/components/common/RatingInput/RatingInput';
 
@@ -7,6 +7,7 @@ import * as S from '@/components/Review/ReviewForm/ReviewForm.style';
 import { VALIDATION_ERROR_MESSAGES } from '@/constants/messages';
 
 type Props = {
+  isSheetOpen: boolean;
   handleSubmit: (reviewInput: ReviewInput) => Promise<void>;
   isEdit: boolean;
   rating?: Review['rating'];
@@ -19,6 +20,7 @@ const initialState = {
 };
 
 function ReviewForm({
+  isSheetOpen,
   handleSubmit,
   isEdit,
   rating: savedRating,
@@ -71,10 +73,21 @@ function ReviewForm({
   const isRatingEmpty = rating === 0;
   const isContentEmpty = content.trim() === '';
 
+  const modalRef = useRef<HTMLFormElement>(null);
+
+  useEffect(() => {
+    if (isSheetOpen) modalRef.current.focus();
+  }, [isSheetOpen]);
+
   return (
     <S.Container>
       <S.Title>{isEdit ? '리뷰 수정하기' : '리뷰 작성하기'}</S.Title>
-      <S.Form onSubmit={submitForm} onChange={handleFormChange}>
+      <S.Form
+        tabIndex={0}
+        ref={modalRef}
+        onSubmit={submitForm}
+        onChange={handleFormChange}
+      >
         <S.Label isInvalid={isFormInvalid && isRatingEmpty}>
           <p>평점을 입력해주세요</p>
           <RatingInput rating={rating} setRating={setRating} />

--- a/frontend/src/components/Review/ReviewListSection/ReviewListSection.tsx
+++ b/frontend/src/components/Review/ReviewListSection/ReviewListSection.tsx
@@ -9,6 +9,7 @@ type Props = Omit<DataFetchStatus, 'isReady'> & {
   getNextPage: () => void;
   handleDelete?: (id: number) => void;
   handleEdit?: (reviewInput: ReviewInput, id: number) => Promise<void>;
+  handleFocus?: () => void;
   pageSize?: number;
   userNameVisible?: boolean;
 };
@@ -23,9 +24,10 @@ function ReviewListSection({
   isError,
   pageSize = 10,
   userNameVisible,
+  handleFocus,
 }: Props) {
   return (
-    <S.Container aria-label="최근 후기">
+    <>
       <InfiniteScroll
         handleContentLoad={getNextPage}
         isLoading={isLoading}
@@ -37,6 +39,7 @@ function ReviewListSection({
               key={id}
               reviewId={id}
               reviewData={reviewData}
+              handleFocus={handleFocus}
               handleDelete={handleDelete}
               handleEdit={handleEdit}
               index={index % pageSize}
@@ -45,7 +48,7 @@ function ReviewListSection({
           ))}
         </S.Wrapper>
       </InfiniteScroll>
-    </S.Container>
+    </>
   );
 }
 

--- a/frontend/src/components/common/BarGraph/BarGraph.style.tsx
+++ b/frontend/src/components/common/BarGraph/BarGraph.style.tsx
@@ -98,3 +98,16 @@ export const JobType = styled.div`
   width: calc(320px / 4);
   font-size: 1.1rem;
 `;
+
+export const UnreadableValue = styled.span``;
+
+export const ReadableValue = styled.span`
+  position: absolute;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+`;

--- a/frontend/src/components/common/BarGraph/BarGraph.style.tsx
+++ b/frontend/src/components/common/BarGraph/BarGraph.style.tsx
@@ -110,4 +110,6 @@ export const ReadableValue = styled.span`
   margin: -1px;
   padding: 0;
   border: 0;
+  top: 0;
+  left: 0;
 `;

--- a/frontend/src/components/common/BarGraph/BarGraph.tsx
+++ b/frontend/src/components/common/BarGraph/BarGraph.tsx
@@ -22,18 +22,22 @@ function BarGraph({ statistics }: Prop) {
     {
       color: theme.colors.primary,
       percent: Math.round((isJobType ? jobType.frontend : careerLevel.none) * 100),
+      label: isJobType ? jobTypeList[0] : careerLevelList[0],
     },
     {
       color: theme.colors.primaryDark,
       percent: Math.round((isJobType ? jobType.backend : careerLevel.junior) * 100),
+      label: isJobType ? jobTypeList[1] : careerLevelList[1],
     },
     {
       color: theme.colors.secondary,
       percent: Math.round((isJobType ? jobType.mobile : careerLevel.midlevel) * 100),
+      label: isJobType ? jobTypeList[2] : careerLevelList[2],
     },
     {
       color: theme.colors.black,
       percent: Math.round((isJobType ? jobType.etc : careerLevel.senior) * 100),
+      label: isJobType ? jobTypeList[3] : careerLevelList[3],
     },
   ];
 
@@ -43,19 +47,37 @@ function BarGraph({ statistics }: Prop) {
 
   return (
     <S.Container aria-label="통계 정보">
+      <S.BarGraphTitleWrapper>
+        <S.BarGraphTitle>{isJobType ? '직군별 통계' : '연차별 통계'}</S.BarGraphTitle>
+        <S.BarGraphToggleButton onClick={toggleGraph}>
+          <S.UnreadableValue aria-hidden="true">
+            {isJobType ? '연차별 통계 보기' : '직군별 통계 보기'}
+          </S.UnreadableValue>
+          <S.ReadableValue>
+            {isJobType
+              ? '연차별 통계 보기 버튼. 연차별 통계를 보려면 클릭하시고, 직군별 통계를 보려면 다음으로 탭 하세요.'
+              : '직군별 통계 보기 버튼. 직군별 통계를 보려면 클릭하시고, 연차별 통계를 보려면 다음으로 탭 하세요.'}
+          </S.ReadableValue>
+        </S.BarGraphToggleButton>
+      </S.BarGraphTitleWrapper>
       <S.DataWrapper>
         {statisticsData.map((data, index) => {
           return (
             <S.BarWrapper key={index}>
               <S.Bar key={Math.random()} color={data.color} height={data.percent} />
               <S.PercentWrapper>
-                <S.Percent>{data.percent}%</S.Percent>
+                <S.Percent aria-hidden="true">{`${data.percent}%`}</S.Percent>
+                <S.ReadableValue>{`전체 ${isJobType ? '직군' : '연차'} 중 ${
+                  data.percent
+                }%의 ${
+                  data.label
+                } 개발자가 이 제품을 사용하고 있습니다.`}</S.ReadableValue>
               </S.PercentWrapper>
             </S.BarWrapper>
           );
         })}
       </S.DataWrapper>
-      <S.JobTypeWrapper>
+      <S.JobTypeWrapper aria-hidden="true">
         {isJobType
           ? jobTypeList.map((title, index) => {
               return <S.JobType key={index}>{title}</S.JobType>;
@@ -64,12 +86,6 @@ function BarGraph({ statistics }: Prop) {
               return <S.JobType key={index}>{title}</S.JobType>;
             })}
       </S.JobTypeWrapper>
-      <S.BarGraphTitleWrapper>
-        <S.BarGraphTitle>{isJobType ? '직군별 통계' : '연차별 통계'}</S.BarGraphTitle>
-        <S.BarGraphToggleButton onClick={toggleGraph}>
-          {isJobType ? '연차별 통계 보기' : '직군별 통계 보기'}
-        </S.BarGraphToggleButton>
-      </S.BarGraphTitleWrapper>
     </S.Container>
   );
 }

--- a/frontend/src/components/common/BottomNavigation/BottomNavigation.style.tsx
+++ b/frontend/src/components/common/BottomNavigation/BottomNavigation.style.tsx
@@ -10,7 +10,9 @@ export const Container = styled.nav`
   background-color: ${({ theme }) => theme.colors.white};
   box-shadow: 0 0 20px rgba(0, 0, 0, 0.2);
   border-radius: 1.5rem;
+`;
 
+export const NavList = styled.ul`
   display: flex;
   justify-content: space-around;
   align-items: center;

--- a/frontend/src/components/common/BottomNavigation/BottomNavigation.tsx
+++ b/frontend/src/components/common/BottomNavigation/BottomNavigation.tsx
@@ -4,10 +4,18 @@ import ROUTES from '@/constants/routes';
 
 function BottomNavigation() {
   return (
-    <S.Container>
-      <S.NavButton to={ROUTES.PRODUCTS}>제품 검색</S.NavButton>
-      <S.NavButton to={ROUTES.HOME}>홈</S.NavButton>
-      <S.NavButton to={ROUTES.PROFILE_SEARCH}>프로필 검색</S.NavButton>
+    <S.Container aria-label={'하단 메뉴바'}>
+      <S.NavList>
+        <li>
+          <S.NavButton to={ROUTES.PRODUCTS}>제품 검색</S.NavButton>
+        </li>
+        <li>
+          <S.NavButton to={ROUTES.HOME}>홈</S.NavButton>
+        </li>
+        <li>
+          <S.NavButton to={ROUTES.PROFILE_SEARCH}>프로필 검색</S.NavButton>
+        </li>
+      </S.NavList>
     </S.Container>
   );
 }

--- a/frontend/src/components/common/BottomSheet/BottomSheet.tsx
+++ b/frontend/src/components/common/BottomSheet/BottomSheet.tsx
@@ -17,7 +17,11 @@ function BottomSheet({
   animationTrigger,
 }: PropsWithChildren<Props>) {
   return createPortal(
-    <S.Container onTransitionEnd={handleUnmount} animationTrigger={animationTrigger}>
+    <S.Container
+      role="dialog"
+      onTransitionEnd={handleUnmount}
+      animationTrigger={animationTrigger}
+    >
       <S.Backdrop onClick={handleClose} />
       <S.Content>{children}</S.Content>
     </S.Container>,

--- a/frontend/src/components/common/ChipFilter/ChipFilter.tsx
+++ b/frontend/src/components/common/ChipFilter/ChipFilter.tsx
@@ -9,12 +9,15 @@ type Props = {
 };
 
 function ChipFilter({ fontSize, value, children, filter, handleClick }: Props) {
+  const isChecked = filter === value;
   return (
     <S.Button
       fontSize={fontSize}
-      clicked={filter === value}
+      clicked={isChecked}
       value={value}
       onClick={handleClick}
+      role="radio"
+      aria-checked={filter === value}
     >
       {children}
     </S.Button>

--- a/frontend/src/components/common/ErrorPlaceholder/ErrorPlaceholder.tsx
+++ b/frontend/src/components/common/ErrorPlaceholder/ErrorPlaceholder.tsx
@@ -3,12 +3,19 @@ import errorWebp from '@/assets/error.webp';
 
 function ErrorPlaceholder() {
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        gap: '1rem',
+      }}
+    >
       <picture>
         <source srcSet={errorWebp} type="image/webP" />
         <img src={errorGif} alt="" width="150" />
       </picture>
-      <div>오류가 발생했어요..</div>
+      <div role="alert">오류가 발생했어요..</div>
     </div>
   );
 }

--- a/frontend/src/components/common/FloatingButton/FloatingButton.tsx
+++ b/frontend/src/components/common/FloatingButton/FloatingButton.tsx
@@ -7,7 +7,11 @@ type Props = {
 };
 
 function FloatingButton({ clickHandler, children }: PropsWithChildren<Props>) {
-  return <S.Button onClick={clickHandler}>{children}</S.Button>;
+  return (
+    <S.Button aria-label="리뷰 작성하기" onClick={clickHandler}>
+      {children}
+    </S.Button>
+  );
 }
 
 export default FloatingButton;

--- a/frontend/src/components/common/HeaderLogo/HeaderLogo.style.tsx
+++ b/frontend/src/components/common/HeaderLogo/HeaderLogo.style.tsx
@@ -1,46 +1,16 @@
 import { Link } from 'react-router-dom';
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 
 export const Container = styled.div`
+  height: max-content;
+
   display: flex;
   align-items: center;
+  justify-content: center;
+
+  position: relative;
+
   background-color: ${({ theme }) => theme.colors.white};
-
-  justify-content: space-between;
-  height: 4rem;
-
-  position: sticky;
-  top: 0;
-  left: 0;
-  z-index: 1;
-
-  &::after {
-    position: absolute;
-    top: 4rem;
-    content: '';
-    height: 0.3rem;
-    width: 100%;
-    background: linear-gradient(
-      180deg,
-      rgba(60, 60, 60, 0.1) 0%,
-      rgba(60, 60, 60, 0) 100%
-    );
-  }
-
-  ${({ theme: { device } }) => css`
-    @media screen and ${device.desktop} {
-      justify-content: center;
-      height: max-content;
-
-      position: relative;
-
-      &::after {
-        background: transparent;
-        height: 0;
-        width: 0;
-      }
-    }
-  `};
 `;
 
 export const LogoLink = styled(Link)`

--- a/frontend/src/components/common/HeaderLogo/HeaderLogo.tsx
+++ b/frontend/src/components/common/HeaderLogo/HeaderLogo.tsx
@@ -1,13 +1,8 @@
 import * as S from '@/components/common/HeaderLogo/HeaderLogo.style';
 
-import useAuth from '@/hooks/useAuth';
-
-import { GITHUB_AUTH_URL } from '@/constants/api';
 import ROUTES from '@/constants/routes';
 
 import HeaderLogoImage from '@/assets/HeaderLogo.svg';
-import HeaderLogoImageHorizontal from '@/assets/HeaderLogoHorizontal.svg';
-import Profile from '@/assets/profile.svg';
 
 function HeaderLogo() {
   return (
@@ -18,27 +13,5 @@ function HeaderLogo() {
     </S.Container>
   );
 }
-
-function Mobile() {
-  const { isLoggedIn } = useAuth();
-  return (
-    <S.Container>
-      <S.LogoLink to={ROUTES.HOME}>
-        <HeaderLogoImageHorizontal />
-      </S.LogoLink>
-      {isLoggedIn ? (
-        <S.CustomLink to={ROUTES.MY_PROFILE}>
-          <Profile />
-        </S.CustomLink>
-      ) : (
-        <S.CustomLink as={'a'} href={GITHUB_AUTH_URL}>
-          로그인
-        </S.CustomLink>
-      )}
-    </S.Container>
-  );
-}
-
-HeaderLogo.Mobile = Mobile;
 
 export default HeaderLogo;

--- a/frontend/src/components/common/HeaderLogo/HeaderLogo.tsx
+++ b/frontend/src/components/common/HeaderLogo/HeaderLogo.tsx
@@ -12,7 +12,7 @@ import Profile from '@/assets/profile.svg';
 function HeaderLogo() {
   return (
     <S.Container>
-      <S.LogoLink to={ROUTES.HOME}>
+      <S.LogoLink to={ROUTES.HOME} aria-label={'F12 홈으로'}>
         <HeaderLogoImage />
       </S.LogoLink>
     </S.Container>

--- a/frontend/src/components/common/HeaderNav/HeaderNav.style.tsx
+++ b/frontend/src/components/common/HeaderNav/HeaderNav.style.tsx
@@ -1,4 +1,5 @@
-import styled from 'styled-components';
+import { Link } from 'react-router-dom';
+import styled, { css } from 'styled-components';
 
 export const Wrapper = styled.div`
   max-width: 1320px;
@@ -8,10 +9,6 @@ export const Wrapper = styled.div`
 `;
 
 export const Nav = styled.nav`
-  width: 100%;
-  height: 3rem;
-  display: flex;
-
   position: sticky;
   top: 0;
   left: 0;
@@ -20,7 +17,7 @@ export const Nav = styled.nav`
 
   &::after {
     position: absolute;
-    top: 3rem;
+    top: 4rem;
     content: '';
     height: 0.3rem;
     width: 100%;
@@ -30,6 +27,21 @@ export const Nav = styled.nav`
       rgba(60, 60, 60, 0) 100%
     );
   }
+
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  height: 4rem;
+  ${({ theme: { device } }) => css`
+    @media screen and ${device.desktop} {
+      width: 100%;
+      height: 3rem;
+      &::after {
+        top: 3rem;
+      }
+    }
+  `}
 `;
 
 export const FlexLeftWrapper = styled.ul`
@@ -51,4 +63,20 @@ export const TransparentButton = styled.button`
   background-color: transparent;
   border: none;
   font-size: 1rem;
+`;
+
+export const LogoLink = styled(Link)`
+  padding: 1rem;
+  width: 11rem;
+`;
+
+export const CustomLink = styled(Link)`
+  padding: 1rem;
+  width: 5rem;
+
+  text-align: center;
+
+  svg {
+    width: 2em;
+  }
 `;

--- a/frontend/src/components/common/HeaderNav/HeaderNav.tsx
+++ b/frontend/src/components/common/HeaderNav/HeaderNav.tsx
@@ -9,7 +9,11 @@ import useAuth from '@/hooks/useAuth';
 
 import { GITHUB_AUTH_URL } from '@/constants/api';
 import ROUTES from '@/constants/routes';
+
 import { CustomNavLink } from '@/style/GlobalStyles';
+
+import HeaderLogoImageHorizontal from '@/assets/HeaderLogoHorizontal.svg';
+import ProfileImage from '@/assets/profile.svg';
 
 function HeaderNav() {
   const [categoryOpen, setCategoryOpen] = useState(false);
@@ -29,7 +33,7 @@ function HeaderNav() {
   }, [location.key]);
 
   return (
-    <S.Nav>
+    <S.Nav aria-label={'상단 메뉴바'}>
       <S.Wrapper>
         <S.FlexLeftWrapper>
           <S.TransparentButton onClick={handleCategoryToggle} aria-label="카테고리">
@@ -59,5 +63,27 @@ function HeaderNav() {
     </S.Nav>
   );
 }
+
+function Mobile() {
+  const { isLoggedIn } = useAuth();
+  return (
+    <S.Nav aria-label={'상단 메뉴바'}>
+      <S.LogoLink to={ROUTES.HOME}>
+        <HeaderLogoImageHorizontal />
+      </S.LogoLink>
+      {isLoggedIn ? (
+        <S.CustomLink to={ROUTES.MY_PROFILE} aria-label={'내 프로필 보기'}>
+          <ProfileImage />
+        </S.CustomLink>
+      ) : (
+        <S.CustomLink as={'a'} href={GITHUB_AUTH_URL}>
+          로그인
+        </S.CustomLink>
+      )}
+    </S.Nav>
+  );
+}
+
+HeaderNav.Mobile = Mobile;
 
 export default HeaderNav;

--- a/frontend/src/components/common/InfiniteScroll/InfiniteScroll.tsx
+++ b/frontend/src/components/common/InfiniteScroll/InfiniteScroll.tsx
@@ -34,11 +34,17 @@ function InfiniteScroll({
   }, [isError]);
 
   return (
-    <>
+    <section role={'feed'} aria-busy={!isLoading}>
       {children}
       {isLoading && <Loading />}
-      <section ref={endRef} aria-label="무한스크롤 목록 끝 지표" />
-    </>
+      <section
+        aria-hidden={'true'}
+        aria-label={'무한스크롤 목록 끝 지표'}
+        tabIndex={0}
+        ref={endRef}
+        style={{ transform: 'translateY(-200px)' }}
+      />
+    </section>
   );
 }
 

--- a/frontend/src/components/common/LazyImage/LazyImage.tsx
+++ b/frontend/src/components/common/LazyImage/LazyImage.tsx
@@ -6,10 +6,11 @@ import useLazyImage from '@/hooks/useLazyImage';
 
 type Props = {
   src: string;
+  alt: string;
 };
 
-function LazyImage({ src }: Props) {
+function LazyImage({ src, alt }: Props) {
   const { imageSrc, imageRef } = useLazyImage({ src });
-  return <S.Image ref={imageRef} src={imageSrc} loading="lazy" />;
+  return <S.Image ref={imageRef} src={imageSrc} alt={alt} loading="lazy" />;
 }
 export default memo(LazyImage);

--- a/frontend/src/components/common/Modal/Modal.tsx
+++ b/frontend/src/components/common/Modal/Modal.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren, useEffect, useState } from 'react';
+import { PropsWithChildren, useEffect, useState, useRef } from 'react';
 import { createPortal } from 'react-dom';
 
 import * as S from '@/components/common/Modal/Modal.style';
@@ -28,10 +28,16 @@ function Modal({
     };
   }, []);
 
+  const modalRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    modalRef.current.focus();
+  }, []);
+
   return createPortal(
     <S.Container scrollOffset={scrollOffset} onTransitionEnd={handleUnmount}>
       <S.Backdrop onClick={handleClose} animationTrigger={animationTrigger} />
-      <S.Content animationTrigger={animationTrigger}>
+      <S.Content tabIndex={0} ref={modalRef} animationTrigger={animationTrigger}>
         {children}
         <ActionButtons handleClose={handleClose} handleConfirm={handleConfirm} />
       </S.Content>

--- a/frontend/src/components/common/NoDataPlaceholder/NoDataPlaceholder.tsx
+++ b/frontend/src/components/common/NoDataPlaceholder/NoDataPlaceholder.tsx
@@ -4,7 +4,9 @@ function NoDataPlaceholder() {
   return (
     <div style={{ width: '200px' }}>
       <Empty />
-      <div style={{ width: '100%', textAlign: 'center' }}>아무것도 찾지 못했어요..</div>
+      <div style={{ width: '100%', textAlign: 'center', marginTop: '1rem' }} role="alert">
+        아무것도 찾지 못했어요..
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/common/Rating/Rating.style.tsx
+++ b/frontend/src/components/common/Rating/Rating.style.tsx
@@ -27,3 +27,16 @@ export const Unit = styled.div<{ size: 'small' | 'medium' | 'large' }>`
 export const Value = styled.div<{ size: 'small' | 'medium' | 'large' }>`
   font-size: ${({ size }) => sizeOptions[size].value}px;
 `;
+
+export const UnreadableValue = styled.span``;
+
+export const ReadableValue = styled.span`
+  position: absolute;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+`;

--- a/frontend/src/components/common/Rating/Rating.style.tsx
+++ b/frontend/src/components/common/Rating/Rating.style.tsx
@@ -39,4 +39,6 @@ export const ReadableValue = styled.span`
   margin: -1px;
   padding: 0;
   border: 0;
+  top: 0;
+  left: 0;
 `;

--- a/frontend/src/components/common/Rating/Rating.tsx
+++ b/frontend/src/components/common/Rating/Rating.tsx
@@ -24,7 +24,10 @@ function Rating({ rating, type = '일반', size = 'small' }: Props) {
       {type === '일반' ? (
         <>
           {RatingUnit}
-          <S.Value size={size}>{rating.toFixed(2)}</S.Value>
+          <S.Value size={size}>
+            <S.UnreadableValue aria-hidden="true">{rating.toFixed(2)}</S.UnreadableValue>
+            <S.ReadableValue>{`평점 ${rating.toFixed(2)}점`}</S.ReadableValue>
+          </S.Value>
         </>
       ) : (
         Array.from({ length: rating }).map((_, index) => (

--- a/frontend/src/components/common/Rating/Rating.tsx
+++ b/frontend/src/components/common/Rating/Rating.tsx
@@ -2,6 +2,7 @@ import { Fragment } from 'react';
 
 import * as S from '@/components/common/Rating/Rating.style';
 
+import { SROnly } from '@/style/GlobalStyles';
 import theme from '@/style/theme';
 
 import Heart from '@/assets/heart.svg';
@@ -14,27 +15,29 @@ export type Props = {
 
 function Rating({ rating, type = '일반', size = 'small' }: Props) {
   const RatingUnit = (
-    <S.Unit size={size}>
+    <S.Unit size={size} aria-hidden={'true'}>
       <Heart fill={theme.colors.primary} stroke={theme.colors.primaryDark} />
     </S.Unit>
   );
 
   return (
-    <S.Container>
-      <S.ReadableValue>{`평점 ${rating.toFixed(2)}점`}</S.ReadableValue>
-      {type === '일반' ? (
-        <>
-          {RatingUnit}
-          <S.Value size={size}>
-            <S.UnreadableValue aria-hidden="true">{rating.toFixed(2)}</S.UnreadableValue>
-          </S.Value>
-        </>
-      ) : (
-        Array.from({ length: rating }).map((_, index) => (
-          <Fragment key={index}>{RatingUnit}</Fragment>
-        ))
-      )}
-    </S.Container>
+    <>
+      <S.Container aria-hidden={true}>
+        {type === '일반' ? (
+          <>
+            {RatingUnit}
+            <S.Value size={size}>{rating.toFixed(2)}</S.Value>
+          </>
+        ) : (
+          <>
+            {Array.from({ length: rating }).map((_, index) => (
+              <Fragment key={index}>{RatingUnit}</Fragment>
+            ))}
+          </>
+        )}
+      </S.Container>
+      <SROnly>평점 {rating.toFixed(2)}점</SROnly>
+    </>
   );
 }
 

--- a/frontend/src/components/common/Rating/Rating.tsx
+++ b/frontend/src/components/common/Rating/Rating.tsx
@@ -21,12 +21,12 @@ function Rating({ rating, type = '일반', size = 'small' }: Props) {
 
   return (
     <S.Container>
+      <S.ReadableValue>{`평점 ${rating.toFixed(2)}점`}</S.ReadableValue>
       {type === '일반' ? (
         <>
           {RatingUnit}
           <S.Value size={size}>
             <S.UnreadableValue aria-hidden="true">{rating.toFixed(2)}</S.UnreadableValue>
-            <S.ReadableValue>{`평점 ${rating.toFixed(2)}점`}</S.ReadableValue>
           </S.Value>
         </>
       ) : (

--- a/frontend/src/components/common/RatingInput/RatingInput.tsx
+++ b/frontend/src/components/common/RatingInput/RatingInput.tsx
@@ -35,6 +35,7 @@ function RatingInput({ rating = null, setRating }: Props) {
         const ratingIndex = index + 1;
         return (
           <S.EmptyButton
+            aria-label={`평점 ${ratingIndex}점을 주려면 클릭하세요.`}
             key={ratingIndex}
             type={'button'}
             onMouseUp={handleClick(ratingIndex)}

--- a/frontend/src/components/common/ReviewCount/ReviewCount.style.tsx
+++ b/frontend/src/components/common/ReviewCount/ReviewCount.style.tsx
@@ -14,3 +14,16 @@ export const ReviewIconWrapper = styled.div<{ size: 'small' | 'large' }>`
 export const Value = styled.p<{ size: 'small' | 'large' }>`
   font-size: ${({ size }) => (size === 'small' ? '14px' : '24px')};
 `;
+
+export const UnreadableValue = styled.span``;
+
+export const ReadableValue = styled.span`
+  position: absolute;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+`;

--- a/frontend/src/components/common/ReviewCount/ReviewCount.style.tsx
+++ b/frontend/src/components/common/ReviewCount/ReviewCount.style.tsx
@@ -26,4 +26,6 @@ export const ReadableValue = styled.span`
   margin: -1px;
   padding: 0;
   border: 0;
+  top: 0;
+  left: 0;
 `;

--- a/frontend/src/components/common/ReviewCount/ReviewCount.tsx
+++ b/frontend/src/components/common/ReviewCount/ReviewCount.tsx
@@ -13,7 +13,10 @@ function ReviewCount({ reviewCount, size = 'small' }: Props) {
       <S.ReviewIconWrapper size={size}>
         <ReviewIcon />
       </S.ReviewIconWrapper>
-      <S.Value size={size}>{reviewCount}</S.Value>
+      <S.Value size={size}>
+        <S.UnreadableValue aria-hidden="true">{reviewCount}</S.UnreadableValue>
+        <S.ReadableValue>{`${reviewCount}개의 리뷰`}</S.ReadableValue>
+      </S.Value>
     </S.Container>
   );
 }

--- a/frontend/src/components/common/ReviewCount/ReviewCount.tsx
+++ b/frontend/src/components/common/ReviewCount/ReviewCount.tsx
@@ -1,5 +1,7 @@
 import * as S from '@/components/common/ReviewCount/ReviewCount.style';
 
+import { SROnly } from '@/style/GlobalStyles';
+
 import ReviewIcon from '@/assets/review.svg';
 
 type Props = {
@@ -9,15 +11,15 @@ type Props = {
 
 function ReviewCount({ reviewCount, size = 'small' }: Props) {
   return (
-    <S.Container>
-      <S.ReviewIconWrapper size={size}>
-        <ReviewIcon />
-      </S.ReviewIconWrapper>
-      <S.Value size={size}>
-        <S.UnreadableValue aria-hidden="true">{reviewCount}</S.UnreadableValue>
-        <S.ReadableValue>{`${reviewCount}개의 리뷰`}</S.ReadableValue>
-      </S.Value>
-    </S.Container>
+    <>
+      <S.Container aria-hidden={'true'}>
+        <S.ReviewIconWrapper size={size}>
+          <ReviewIcon />
+        </S.ReviewIconWrapper>
+        <S.Value size={size}>{reviewCount}</S.Value>
+      </S.Container>
+      <SROnly>리뷰 {reviewCount}개</SROnly>
+    </>
   );
 }
 

--- a/frontend/src/components/common/SearchBar/SearchBar.style.tsx
+++ b/frontend/src/components/common/SearchBar/SearchBar.style.tsx
@@ -32,7 +32,10 @@ export const Input = styled.input`
   }
 `;
 
-export const Button = styled.button`
+export const IconContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
   width: 3.5rem;
   height: 2.8rem;
   margin-left: -3.5rem;

--- a/frontend/src/components/common/SearchBar/SearchBar.tsx
+++ b/frontend/src/components/common/SearchBar/SearchBar.tsx
@@ -17,14 +17,15 @@ function SearchBar({ searchInput, setSearchInput }: Props) {
   return (
     <S.Container>
       <S.Input
+        placeholder={'검색어를 입력해주세요'}
         maxLength={100}
         type="text"
         value={searchInput || ''}
         onChange={handleInputChange}
       />
-      <S.Button>
+      <S.IconContainer aria-hidden={true}>
         <SearchImage />
-      </S.Button>
+      </S.IconContainer>
     </S.Container>
   );
 }

--- a/frontend/src/components/common/SearchFilter/SearchFilter.tsx
+++ b/frontend/src/components/common/SearchFilter/SearchFilter.tsx
@@ -20,8 +20,8 @@ function SearchFilter({ title, value, setValue, options }: Props) {
 
   return (
     <S.Container>
-      <S.Wrapper>
-        <S.FilterTitle>{title}</S.FilterTitle>
+      <S.Wrapper role={'radiogroup'} aria-label={'카테고리 선택하기'}>
+        <S.FilterTitle aria-hidden={true}>{title}</S.FilterTitle>
         {Object.entries(options).map(([key, content], index: number) => {
           return (
             <ChipFilter

--- a/frontend/src/components/common/SectionHeader/SectionHeader.style.tsx
+++ b/frontend/src/components/common/SectionHeader/SectionHeader.style.tsx
@@ -3,7 +3,7 @@ import styled, { css } from 'styled-components';
 export const Container = styled.header`
   display: flex;
   justify-content: space-between;
-  align-items: flex-end;
+  align-items: center;
 `;
 
 export const Title = styled.h1`

--- a/frontend/src/components/common/Select/Select.tsx
+++ b/frontend/src/components/common/Select/Select.tsx
@@ -26,7 +26,7 @@ function Select({ value, setValue, options }: Props) {
   );
 
   return (
-    <S.Container value={value} onChange={handleOptionChange}>
+    <S.Container value={value} onChange={handleOptionChange} aria-label={'정렬 기준'}>
       {optionComponents}
     </S.Container>
   );

--- a/frontend/src/contexts/ModalContextProvider.tsx
+++ b/frontend/src/contexts/ModalContextProvider.tsx
@@ -113,7 +113,9 @@ function ModalContextProvider({ children }: PropsWithChildren) {
               handleUnmount={handleAlertUnmount}
               animationTrigger={alertAnimationTrigger}
             >
-              <Modal.Body>{message}</Modal.Body>
+              <Modal.Body>
+                <p>{message}</p>
+              </Modal.Body>
             </Modal>
           )}
           {shouldRenderConfirm && (
@@ -123,7 +125,9 @@ function ModalContextProvider({ children }: PropsWithChildren) {
               handleUnmount={handleConfirmUnmount}
               animationTrigger={confirmAnimationTrigger}
             >
-              <Modal.Body>{message}</Modal.Body>
+              <Modal.Body>
+                <p>{message}</p>
+              </Modal.Body>
             </Modal>
           )}
           {shouldRenderReview && (
@@ -134,8 +138,8 @@ function ModalContextProvider({ children }: PropsWithChildren) {
             >
               <Modal.Body>
                 <Rating rating={review.rating} type={'정수'} size={'small'} />
-                <div>{dateFormatter(review.createdAt)}</div>
-                {review.content}
+                <p>{dateFormatter(review.createdAt)}</p>
+                <p>{review.content}</p>
               </Modal.Body>
             </Modal>
           )}

--- a/frontend/src/hooks/api/useGetMany.tsx
+++ b/frontend/src/hooks/api/useGetMany.tsx
@@ -28,6 +28,7 @@ type Return<T> = DataFetchStatus & {
   data: T[];
   getNextPage: () => void;
   refetch: () => void;
+  hasNextPage: boolean;
 };
 
 function useGetMany<T>({ url, params, body, headers }: Props): Return<T> {
@@ -115,6 +116,6 @@ function useGetMany<T>({ url, params, body, headers }: Props): Return<T> {
 
   const isReady = !!data;
 
-  return { data, getNextPage, refetch, isLoading, isReady, isError };
+  return { data, hasNextPage, getNextPage, refetch, isLoading, isReady, isError };
 }
 export default useGetMany;

--- a/frontend/src/hooks/useSearch.tsx
+++ b/frontend/src/hooks/useSearch.tsx
@@ -14,12 +14,14 @@ type Return<T> = DataFetchStatus & {
   result: T[];
   getNextPage: () => void;
   refetch: () => void;
+  hasNextPage: boolean;
 };
 
 function useSearch<T>({ url, query, filter, size, headers }: Props): Return<T> {
   const params = { query, ...filter, size };
   const {
     data: result,
+    hasNextPage,
     getNextPage,
     refetch,
     isLoading,
@@ -31,7 +33,7 @@ function useSearch<T>({ url, query, filter, size, headers }: Props): Return<T> {
     headers,
   });
 
-  return { result, refetch, getNextPage, isLoading, isReady, isError };
+  return { result, refetch, hasNextPage, getNextPage, isLoading, isReady, isError };
 }
 
 export default useSearch;

--- a/frontend/src/pages/Product/Product.style.tsx
+++ b/frontend/src/pages/Product/Product.style.tsx
@@ -47,3 +47,12 @@ export const ReviewListWrapper = styled.div`
     }
   `}
 `;
+
+export const ReviewListContainer = styled.section`
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  width: 100%;
+
+  min-height: 10rem;
+`;

--- a/frontend/src/pages/Product/Product.tsx
+++ b/frontend/src/pages/Product/Product.tsx
@@ -120,6 +120,7 @@ function Product() {
         </AsyncWrapper>
         {shouldSheetRender && (
           <ReviewBottomSheet
+            isSheetOpen={isSheetOpen}
             handleClose={toggleSheetOpen}
             handleSubmit={handleReviewSubmit}
             handleUnmount={handleSheetUnmount}

--- a/frontend/src/pages/Product/Product.tsx
+++ b/frontend/src/pages/Product/Product.tsx
@@ -1,4 +1,4 @@
-import { useReducer, useEffect } from 'react';
+import { useReducer, useEffect, useRef } from 'react';
 import { useParams } from 'react-router-dom';
 
 import * as S from '@/pages/Product/Product.style';
@@ -57,6 +57,12 @@ function Product() {
     },
   });
 
+  const reviewRef = useRef<HTMLDivElement>(null);
+
+  const handleFocus = () => {
+    reviewRef.current.focus();
+  };
+
   const [isSheetOpen, toggleSheetOpen] = useReducer((isSheetOpen: boolean) => {
     if (!isLoggedIn) return false;
 
@@ -95,7 +101,6 @@ function Product() {
       ) : (
         ProductDetails
       )}
-
       <S.ReviewListWrapper>
         {isLoggedIn && (
           <FloatingButton clickHandler={toggleSheetOpen}>
@@ -107,24 +112,27 @@ function Product() {
           isReady={isReviewReady}
           isError={isReviewError}
         >
-          <ReviewListSection
-            columns={1}
-            data={reviews}
-            getNextPage={getNextPage}
-            handleDelete={handleReviewDelete}
-            handleEdit={handleReviewEdit}
-            isLoading={isReviewLoading}
-            isError={isReviewError}
-            pageSize={PRODUCT_PAGE_REVIEW_SIZE}
-          />
+          <S.ReviewListContainer tabIndex={0} ref={reviewRef} aria-label="최근 후기">
+            <ReviewListSection
+              columns={1}
+              data={reviews}
+              getNextPage={getNextPage}
+              handleDelete={handleReviewDelete}
+              handleEdit={handleReviewEdit}
+              handleFocus={handleFocus}
+              isLoading={isReviewLoading}
+              isError={isReviewError}
+              pageSize={PRODUCT_PAGE_REVIEW_SIZE}
+            />
+          </S.ReviewListContainer>
         </AsyncWrapper>
         {shouldSheetRender && (
           <ReviewBottomSheet
-            isSheetOpen={isSheetOpen}
             handleClose={toggleSheetOpen}
             handleSubmit={handleReviewSubmit}
             handleUnmount={handleSheetUnmount}
             animationTrigger={sheetAnimationTrigger}
+            handleFocus={handleFocus}
             isEdit={false}
           />
         )}

--- a/frontend/src/pages/Products/Products.style.tsx
+++ b/frontend/src/pages/Products/Products.style.tsx
@@ -9,7 +9,7 @@ export const Main = styled.main`
   gap: 3rem;
 `;
 
-export const SearchBarWrapper = styled.div`
+export const SearchBarWrapper = styled.section`
   display: flex;
   align-items: center;
   flex-direction: column;

--- a/frontend/src/pages/Products/Products.tsx
+++ b/frontend/src/pages/Products/Products.tsx
@@ -52,6 +52,7 @@ function Products() {
   const {
     result: products,
     getNextPage,
+    hasNextPage,
     isLoading,
     isReady,
     isError,
@@ -78,7 +79,11 @@ function Products() {
   const createLoadedMessage = (dataLength: number, prevDataLength: number) =>
     `총 ${dataLength - prevDataLength}개의 제품이 ${
       currDataLength !== 0 ? '추가로' : ''
-    } 로딩되었습니다`;
+    } 로딩되었습니다. ${
+      currDataLength === 0 && hasNextPage
+        ? '추가로 로딩할 수 있습니다. 마지막까지 탐색하면 자동으로 로딩됩니다.'
+        : ''
+    }`;
 
   useEffect(() => {
     if (isReady) {

--- a/frontend/src/pages/common/PageLayout/PageLayout.tsx
+++ b/frontend/src/pages/common/PageLayout/PageLayout.tsx
@@ -47,7 +47,7 @@ function PageLayout() {
 
   return (
     <>
-      {device !== 'desktop' && <HeaderLogo.Mobile />}
+      {device !== 'desktop' && <HeaderNav.Mobile />}
 
       {device === 'desktop' && (
         <>

--- a/frontend/src/style/GlobalStyles.tsx
+++ b/frontend/src/style/GlobalStyles.tsx
@@ -50,4 +50,18 @@ export const CustomNavLink = styled(NavLink)`
   }
 `;
 
+export const SROnly = styled.div`
+  overflow: hidden;
+  white-space: no-wrap;
+  clip: rect(1px, 1px, 1px, 1px);
+  clip-path: inset(50%);
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  border: 0;
+  top: 0;
+  left: 0;
+`;
+
 export default GlobalStyles;

--- a/frontend/src/style/ResetCss.tsx
+++ b/frontend/src/style/ResetCss.tsx
@@ -27,6 +27,10 @@ ol, ul {
 	list-style: none;
 }
 
+li {
+	list-style-type: none;
+}
+
 table {
 	border-collapse: collapse;
 	border-spacing: 0;


### PR DESCRIPTION
# issue: #745 

# 작업 내용

- [x]  "제품 이미지"라고 읽어주는 것을 수정
- [x] 리뷰 갯수를 숫자만 읽어주는 것을 수정
- [x] 평점을 숫자만 읽어주는 것을 수정
- [x] 직군별 통계 읽어주는 방식을 수정
- [x] 리뷰 목록에서 평점 읽어주도록 수정
- [x] 플로팅 버튼 접근 순서를 앞쪽으로
- [x] 바텀 시트 표시될 경우 시트 내부로 포커스 이동
- [x] 리뷰 작성 (평점 입력, 텍스트 입력, 최대 글자 도달하면 글자 수 알림)
- [x] 리뷰 작성 완료 후 리로딩 된 리뷰 목록으로 포커스 이동
- [x] 모달이 띄워지는 경우 모달 내부로 포커스 이동


