### PR TITLE
[BE] 데이터 정합성을 맞추는 스케줄러 작성

### DIFF
--- a/backend/src/main/java/com/woowacourse/f12/application/batch/BatchService.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/batch/BatchService.java
@@ -1,0 +1,20 @@
+package com.woowacourse.f12.application.batch;
+
+import com.woowacourse.f12.domain.member.MemberRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class BatchService {
+
+    private final MemberRepository memberRepository;
+
+    public BatchService(final MemberRepository memberRepository) {
+        this.memberRepository = memberRepository;
+    }
+
+    @Transactional
+    public void updateFollowerCount() {
+        memberRepository.updateFollowerCountBatch();
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/application/batch/FollowerCountBatchScheduler.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/batch/FollowerCountBatchScheduler.java
@@ -1,0 +1,25 @@
+package com.woowacourse.f12.application.batch;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+
+@Slf4j
+public class FollowerCountBatchScheduler {
+
+    private static final String LOG_FORMAT = "Class : {}, Message : {}";
+
+    private final BatchService batchService;
+
+    public FollowerCountBatchScheduler(final BatchService batchService) {
+        this.batchService = batchService;
+    }
+
+    @Scheduled(cron = "0 0 0/1 1/1 * ? *")
+    public void execute() {
+        try {
+            batchService.updateFollowerCount();
+        } catch (Exception e) {
+            log.error(LOG_FORMAT, e.getClass().getSimpleName(), e.getMessage());
+        }
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/application/review/ReviewService.java
+++ b/backend/src/main/java/com/woowacourse/f12/application/review/ReviewService.java
@@ -113,7 +113,6 @@ public class ReviewService {
         final Review updateReview = updateRequest.toReview(target.getProduct(), target.getMember());
         int ratingGap = updateReview.getRating() - target.getRating();
         target.update(updateReview);
-        reviewRepository.flush();
         productRepository.updateProductStatisticsForReviewUpdate(target.getProduct().getId(), ratingGap);
     }
 
@@ -125,8 +124,6 @@ public class ReviewService {
                 .orElseThrow(InventoryProductNotFoundException::new);
         inventoryProductRepository.delete(inventoryProduct);
         reviewRepository.delete(review);
-//        inventoryProductRepository.flush();
-        reviewRepository.flush();
         productRepository.updateProductStatisticsForReviewDelete(review.getProduct().getId(), review.getRating());
     }
 

--- a/backend/src/main/java/com/woowacourse/f12/config/SchedulerConfig.java
+++ b/backend/src/main/java/com/woowacourse/f12/config/SchedulerConfig.java
@@ -1,0 +1,23 @@
+package com.woowacourse.f12.config;
+
+import com.woowacourse.f12.application.batch.BatchService;
+import com.woowacourse.f12.application.batch.FollowerCountBatchScheduler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@EnableScheduling
+@Configuration
+public class SchedulerConfig {
+
+    private final BatchService batchService;
+
+    public SchedulerConfig(final BatchService batchService) {
+        this.batchService = batchService;
+    }
+
+    @Bean(name = "followerCountBatchScheduler")
+    public FollowerCountBatchScheduler followerCountBatchScheduler() {
+        return new FollowerCountBatchScheduler(batchService);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/domain/member/MemberRepository.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/member/MemberRepository.java
@@ -2,8 +2,14 @@ package com.woowacourse.f12.domain.member;
 
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface MemberRepository extends JpaRepository<Member, Long>, MemberRepositoryCustom {
 
     Optional<Member> findByGitHubId(String gitHubId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query(value = "update Member m set m.followerCount = (select count(f) from Following f where f.followingId = m.id)")
+    void updateFollowerCountBatch();
 }

--- a/backend/src/main/java/com/woowacourse/f12/domain/product/ProductRepository.java
+++ b/backend/src/main/java/com/woowacourse/f12/domain/product/ProductRepository.java
@@ -9,7 +9,7 @@ public interface ProductRepository extends JpaRepository<Product, Long>, Product
 
     List<Product> findByReviewCountGreaterThanEqualAndRatingGreaterThanEqual(int reviewCount, double rating);
 
-    @Modifying(clearAutomatically = true)
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query(value = "update Product p "
             + "set p.rating = (p.totalRating + :reviewRating) / cast((p.reviewCount + 1) as double), "
             + "p.reviewCount = p.reviewCount + 1, "
@@ -17,7 +17,7 @@ public interface ProductRepository extends JpaRepository<Product, Long>, Product
             + "where p.id = :productId")
     void updateProductStatisticsForReviewInsert(Long productId, int reviewRating);
 
-    @Modifying(clearAutomatically = true)
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query(value = "update Product p "
             + "set p.rating = case p.reviewCount when 1 then 0 "
             + "else ((p.totalRating - :reviewRating) / cast((p.reviewCount - 1) as double)) end , "
@@ -26,7 +26,7 @@ public interface ProductRepository extends JpaRepository<Product, Long>, Product
             + "where p.id = :productId")
     void updateProductStatisticsForReviewDelete(Long productId, int reviewRating);
 
-    @Modifying(clearAutomatically = true)
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query(value = "update Product p "
             + "set p.rating = (p.totalRating + :ratingGap) / cast(p.reviewCount as double), "
             + "p.totalRating = p.totalRating + :ratingGap "

--- a/backend/src/test/java/com/woowacourse/f12/domain/member/MemberRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/domain/member/MemberRepositoryTest.java
@@ -315,4 +315,27 @@ class MemberRepositoryTest {
         assertThatThrownBy(() -> memberRepository.save(member2))
                 .isInstanceOf(DataIntegrityViolationException.class);
     }
+
+    @Test
+    void 회원의_팔로워_수의_정합성을_맞춘다() {
+        // given
+        Member member = CORINNE.생성();
+        Member follower = MINCHO.생성();
+        memberRepository.save(member);
+        memberRepository.save(follower);
+        Following following = Following.builder()
+                .followerId(follower.getId())
+                .followingId(member.getId())
+                .build();
+        followingRepository.save(following);
+
+        // when
+        memberRepository.updateFollowerCountBatch();
+
+        // then
+        Member actual = memberRepository.findById(member.getId())
+                .orElseThrow();
+
+        assertThat(actual.getFollowerCount()).isOne();
+    }
 }


### PR DESCRIPTION
# issue: #755 

# 작업 내용
- 사용자는 구체적으로 누가 팔로우 하고 있는지 확인하지 않고, 팔로워 수만 확인하도록 구현되어 있으므로, 팔로우 버튼을 눌렀을 때 팔로잉 수가 올라가거나 언팔로우 버튼을 눌렀을 때 팔로워 수가 내려가기만 하면 됨.
- 기존 더티 체킹 방식의 문제는 트랜잭션 시작부터 커밋 사이에 커밋된 다른 트랜잭션의 업데이트 정보가 유실된다는 점이 문제지, 최소한 본인이 누른 팔로우 / 언팔로우에 대해서는 적용이 되고 있음
  - 따라서 매 번 정합성을 맞출 필요는 없음
- 스프링부트의 스케줄러를 사용해서 배치 업데이트 쿼리를 매 시간마다 실행
