### PR TITLE
[Feature/FE] 사용자 피드백을 반영해서 스크롤 유지, 제품 상세정보 우회 구현

### DIFF
--- a/frontend/cypress/e2e/spec.cy.ts
+++ b/frontend/cypress/e2e/spec.cy.ts
@@ -100,28 +100,19 @@ describe('비회원 사용자 기본 플로우', () => {
         .findAllByRole('link')
         .should('be.visible');
     });
+  });
+  it.only('제품 상세 페이지에 진입하면, 제품 사진과 리뷰와 통계정보를 볼 수 있다.', () => {
+    cy.visit('/product/1');
 
-    it('제품 상세 페이지에 진입하면, 제품 사진과 리뷰와 통계정보를 볼 수 있다.', () => {
-      cy.wait('@productsRequest');
+    // 후기는 없는 제품이 있을 수도 있기 때문에 삭제하거나 빈 데이터 이미지 표시 필요
+    // cy.findByRole('region', { name: '최근 후기' })
+    //   .findAllByRole('link')
+    //   .should('be.visible');
+    cy.wait('@productRequest');
 
-      cy.findByRole('region', { name: '인기 있는 제품' })
-        .findAllByRole('link')
-        .first()
-        // .findByRole('img')
-        .click({ force: true });
+    expect(cy.findByRole('region', { name: '제품 상세 정보' }).findByRole('img')).to
+      .exist;
 
-      // 후기는 없는 제품이 있을 수도 있기 때문에 삭제하거나 빈 데이터 이미지 표시 필요
-      // cy.findByRole('region', { name: '최근 후기' })
-      //   .findAllByRole('link')
-      //   .should('be.visible');
-      cy.wait('@productRequest');
-
-      expect(cy.findByRole('region', { name: '제품 상세 정보' }).findByRole('img')).to
-        .exist;
-
-      cy.findByRole('region', { name: '통계 정보' })
-        .scrollIntoView()
-        .should('be.visible');
-    });
+    cy.findByRole('region', { name: '통계 정보' }).scrollIntoView().should('be.visible');
   });
 });

--- a/frontend/src/components/Product/ProductDetail/ProductDetail.style.tsx
+++ b/frontend/src/components/Product/ProductDetail/ProductDetail.style.tsx
@@ -17,6 +17,7 @@ export const Wrapper = styled.div`
   flex-direction: column;
   justify-content: space-between;
   align-items: flex-end;
+  gap: 0.5rem;
 `;
 
 export const Name = styled.p`
@@ -29,4 +30,10 @@ export const Details = styled.div`
   display: flex;
   align-items: center;
   gap: 0.5rem;
+`;
+
+export const SearchLink = styled.a`
+  align-self: flex-start;
+  text-decoration: underline;
+  font-weight: 500;
 `;

--- a/frontend/src/components/Product/ProductDetail/ProductDetail.tsx
+++ b/frontend/src/components/Product/ProductDetail/ProductDetail.tsx
@@ -3,18 +3,26 @@ import ReviewCount from '@/components/common/ReviewCount/ReviewCount';
 
 import * as S from '@/components/Product/ProductDetail/ProductDetail.style';
 
+import { DANAWA_SEARCH_URL, GOOGLE_SEARCH_URL } from '@/constants/api';
+
 type Props = {
   product: Product;
 };
 
 function ProductDetail({ product }: Props) {
-  const { imageUrl, name, rating, reviewCount } = product;
+  const { imageUrl, name, category, rating, reviewCount } = product;
+  const isSoftware = category === 'software';
+  const searchUrlBase = isSoftware ? GOOGLE_SEARCH_URL : DANAWA_SEARCH_URL;
+  const searchUrl = `${searchUrlBase}${name}`;
 
   return (
     <S.Container aria-label="제품 상세 정보">
       <S.Image src={imageUrl} alt={''} />
       <S.Wrapper>
         <S.Name>{name}</S.Name>
+        <S.SearchLink href={searchUrl} target={'_blank'} rel={'noopener noreferrer'}>
+          {isSoftware ? '구글' : '다나와'}에서 검색하기
+        </S.SearchLink>
         <S.Details>
           <ReviewCount reviewCount={reviewCount} size="large" />
           <Rating size="large" rating={rating} />

--- a/frontend/src/components/Product/ProductListSection/ProductListSection.tsx
+++ b/frontend/src/components/Product/ProductListSection/ProductListSection.tsx
@@ -1,3 +1,5 @@
+import { Link } from 'react-router-dom';
+
 import InfiniteScroll from '@/components/common/InfiniteScroll/InfiniteScroll';
 import NoDataPlaceholder from '@/components/common/NoDataPlaceholder/NoDataPlaceholder';
 
@@ -40,7 +42,12 @@ function ProductListSection({
 
   const productList = data.map(({ id, imageUrl, name, rating, reviewCount }, index) => (
     <li key={id}>
-      <S.ProductLink to={`${ROUTES.PRODUCT}/${id}`}>
+      <Link
+        to={`${ROUTES.PRODUCT}/${id}`}
+        key={id}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
         <ProductCard
           imageUrl={imageUrl}
           name={name}
@@ -49,7 +56,7 @@ function ProductListSection({
           index={index % pageSize}
           size={cardSize}
         />
-      </S.ProductLink>
+      </Link>
     </li>
   ));
 

--- a/frontend/src/constants/api.ts
+++ b/frontend/src/constants/api.ts
@@ -4,6 +4,9 @@ const githubClientId = __GITHUB_CLIENT_ID__;
 
 export const GITHUB_AUTH_URL = `https://github.com/login/oauth/authorize?client_id=${githubClientId}`;
 
+export const DANAWA_SEARCH_URL = 'https://search.danawa.com/dsearch.php?k1=';
+export const GOOGLE_SEARCH_URL = 'https://www.google.com/search?q=';
+
 export const ENDPOINTS = {
   PRODUCTS: '/products',
   PRODUCT: (id: number | ':id') => `/products/${id}`,


### PR DESCRIPTION
# issue: closes #764, closes #766

# 작업 내용
피드백을 반영해서 스크롤 유지, 제품 상세 정보 문제를 해결한다.
- 스크롤 유지: 실제로 스크롤을 유지하는 대신 제품을 새 창에서 열어주는 것으로 해결한다.
- 제품 상세 정보: 실제로 정보를 추가하는 것은 어려우므로 다나와, 구글로 연결하는 링크를 만들어서 외부로 연결한다.