### PR TITLE
[FE] 바텀 시트가 리뷰 작성 버튼에 가려지는 문제 수정

### DIFF
--- a/frontend/src/components/common/BottomSheet/BottomSheet.style.tsx
+++ b/frontend/src/components/common/BottomSheet/BottomSheet.style.tsx
@@ -14,6 +14,8 @@ export const Container = styled.section<{
   right: 5%;
   bottom: 0;
 
+  z-index: 2;
+
   transition: 200ms;
 
   ${({ animationTrigger }) =>


### PR DESCRIPTION
# issue: close #826

# 작업 내용
[fix: BottomSheet container z-index 조정](https://github.com/woowacourse-teams/2022-f12/commit/d4aa5ee66e56b373e1c63783537b546fc1ae0b99)