### PR TITLE
[Bugfix/FE] 깃헙 최대 유저네임 길이에 대응하도록 스타일 수정

### DIFF
--- a/frontend/src/components/Profile/UserInfo/UserInfo.tsx
+++ b/frontend/src/components/Profile/UserInfo/UserInfo.tsx
@@ -74,7 +74,6 @@ function UserInfo({ userData, isOwnProfile }: Props) {
             >
               {`@${gitHubId}`}
             </S.GitHubId>
-            {`의 데스크 셋업`}
           </S.UserNameWrapper>
           <S.FollowerCount>{followerCount}명이 팔로우함</S.FollowerCount>
           {isOwnProfile && (

--- a/frontend/src/components/Review/ReviewCard/ReviewCard.tsx
+++ b/frontend/src/components/Review/ReviewCard/ReviewCard.tsx
@@ -89,8 +89,10 @@ function ReviewCard({
               </S.ReviewModifyButtonWrapper>
             )}
           </S.UserWrapper>
-          <Rating type="정수" rating={rating} />
         </S.Wrapper>
+        <div style={{ alignSelf: 'flex-end' }}>
+          <Rating type="정수" rating={rating} />
+        </div>
         <S.CreatedAt>{formattedDate}</S.CreatedAt>
         <S.Content>{content}</S.Content>
       </S.ReviewArea>

--- a/frontend/src/pages/Profile/Profile.style.tsx
+++ b/frontend/src/pages/Profile/Profile.style.tsx
@@ -89,3 +89,8 @@ export const TabButton = styled.button<{ selected: boolean }>`
     }
   `}
 `;
+
+export const SectionHeaderWrapper = styled.div`
+  margin-left: -1rem;
+  align-self: flex-start;
+`;

--- a/frontend/src/pages/Profile/Profile.tsx
+++ b/frontend/src/pages/Profile/Profile.tsx
@@ -5,6 +5,7 @@ import * as S from '@/pages/Profile/Profile.style';
 
 import AsyncWrapper from '@/components/common/AsyncWrapper/AsyncWrapper';
 import Loading from '@/components/common/Loading/Loading';
+import SectionHeader from '@/components/common/SectionHeader/SectionHeader';
 
 import DeskSetup from '@/components/DeskSetup/DeskSetup';
 import InventoryProductList from '@/components/Profile/InventoryProductList/InventoryProductList';
@@ -72,6 +73,9 @@ function Profile() {
           <UserInfo userData={userInfo} isOwnProfile={isOwnProfile} />
         </AsyncWrapper>
       </S.ProfileSection>
+      <S.SectionHeaderWrapper>
+        <SectionHeader title={'데스크 셋업'} />
+      </S.SectionHeaderWrapper>
       <S.DeskSetupSection>
         <AsyncWrapper
           fallback={<Loading />}


### PR DESCRIPTION
# 작업 내용
깃헙 최대 유저네임 길이에 대응하도록 스타일 수정
- 리뷰 카드에서 이름과 평점 줄바꿈
- 프로필 페이지의 사용자 정보 레이아웃 수정
