### PR TITLE
[HotFix] 어드민 페이지에 대해 CORS를 허용

### DIFF
--- a/backend/src/main/java/com/woowacourse/f12/config/WebConfig.java
+++ b/backend/src/main/java/com/woowacourse/f12/config/WebConfig.java
@@ -17,6 +17,7 @@ public class WebConfig implements WebMvcConfigurer {
     private static final String MAIN_SERVER_WWW_DOMAIN = "https://www.f12.app";
     private static final String TEST_SERVER_DOMAIN = "https://test.f12.app";
     private static final String FRONTEND_LOCALHOST = "http://localhost:3000";
+    private static final String ADMIN_PAGE = "https://admin.f12.app";
 
     private final List<HandlerInterceptor> interceptors;
     private final List<HandlerMethodArgumentResolver> resolvers;
@@ -35,7 +36,8 @@ public class WebConfig implements WebMvcConfigurer {
     public void addCorsMappings(final CorsRegistry registry) {
         registry.addMapping("/api/**")
                 .allowedMethods(CORS_ALLOWED_METHODS.split(","))
-                .allowedOrigins(MAIN_SERVER_DOMAIN, MAIN_SERVER_WWW_DOMAIN, TEST_SERVER_DOMAIN, FRONTEND_LOCALHOST)
+                .allowedOrigins(MAIN_SERVER_DOMAIN, MAIN_SERVER_WWW_DOMAIN, TEST_SERVER_DOMAIN, FRONTEND_LOCALHOST,
+                        ADMIN_PAGE)
                 .allowCredentials(true)
                 .exposedHeaders(HttpHeaders.LOCATION, HttpHeaders.SET_COOKIE);
     }

--- a/backend/src/test/java/com/woowacourse/f12/config/WebConfigTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/config/WebConfigTest.java
@@ -25,7 +25,8 @@ class WebConfigTest {
     private MockMvc mockMvc;
 
     @ParameterizedTest
-    @ValueSource(strings = {"https://f12.app", "https://www.f12.app", "https://test.f12.app", "http://localhost:3000"})
+    @ValueSource(strings = {"https://f12.app", "https://www.f12.app", "https://test.f12.app", "http://localhost:3000",
+            "https://admin.f12.app"})
     void 특정_Origin에_CORS가_허용되어있다(String origin) throws Exception {
         mockMvc.perform(
                         options("/api/v1/products")


### PR DESCRIPTION
# issue: closes #842 

# 작업 내용
- 어드민 페이지(https://admin.f12.app)에 대해 CORS가 허용되지 않아 어드민 페이지가 작동하지 않는 문제를 해결
