### PR TITLE
[Hotfix/FE] 높이가 긴 이미지가 잘리는 오류 수정

### DIFF
--- a/frontend/src/components/common/LazyImage/LazyImage.style.tsx
+++ b/frontend/src/components/common/LazyImage/LazyImage.style.tsx
@@ -2,5 +2,6 @@ import styled from 'styled-components';
 
 export const Image = styled.img`
   width: 100%;
-  object-fit: cover;
+  height: 100%;
+  object-fit: contain;
 `;

--- a/frontend/src/mocks/data.ts
+++ b/frontend/src/mocks/data.ts
@@ -167,8 +167,7 @@ export const products: Product[] = [
   {
     id: 3,
     name: '레오폴드 FC900RBT PD 그레이 블루 한글 (저소음 적축)',
-    imageUrl:
-      'http://img.danawa.com/prod_img/500000/833/414/img/15414833_1.jpg?shrink=330:330&_v=20211013110445',
+    imageUrl: 'https://upload.wikimedia.org/wikipedia/commons/9/95/Homebrew_logo.svg',
     rating: 0.0,
     reviewCount: 3,
     category: 'keyboard',


### PR DESCRIPTION
# issue: closes # 844

# 작업 내용
높이가 긴 이미지가 잘리는 오류를 해결한다
- 이미지의 object-fit을 contain으로 수정
- 이미지에 높이 100% 설정