### PR TITLE
[Hotfix/BE] Tomcat maxThread 수 적용

### DIFF
--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -21,6 +21,10 @@ spring:
 
 server:
   port: 8080
+  tomcat:
+    threads:
+      max: 100
+    accept-count: 100
 
   servlet:
     session:


### PR DESCRIPTION
# issue: #852 

# 작업 내용
성능 테스트를 통해서 결론을 냈던 tomcat 설정을 적용하지 않았던 점 수정
- maxThread : 100
- acceptCount : 100 (default)
- max-connection: 10000 (default)