### PR TITLE
[Bugfix/FE] intersection observer 오류 수정

### DIFF
--- a/frontend/src/components/common/InfiniteScroll/InfiniteScroll.tsx
+++ b/frontend/src/components/common/InfiniteScroll/InfiniteScroll.tsx
@@ -30,8 +30,17 @@ function InfiniteScroll({
       endOfContentObserver.unobserve(endRef.current);
       return;
     }
-    endOfContentObserver.observe(endRef.current);
   }, [isError]);
+
+  useEffect(() => {
+    if (!endRef.current) return;
+    endOfContentObserver.observe(endRef.current);
+
+    return () => {
+      if (!endRef.current) return;
+      endOfContentObserver.unobserve(endRef.current);
+    };
+  }, [children]);
 
   return (
     <section role={'feed'} aria-busy={!isLoading}>

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -15,17 +15,17 @@ import theme from '@/style/theme';
 
 /* eslint-disable */
 
-// if (process.env.NODE_ENV === 'development' && !window.Cypress) {
-//   const { worker } = require('@/mocks/browser');
-//   worker.start({
-//     onUnhandledRequest(req) {
-//       const urlPath = req.url.pathname;
+if (process.env.NODE_ENV === 'development' && !window.Cypress) {
+  const { worker } = require('@/mocks/browser');
+  worker.start({
+    onUnhandledRequest(req) {
+      const urlPath = req.url.pathname;
 
-//       if (!urlPath.startsWith('http://localhost:8080')) return;
-//       console.warn('Found an unhandled %s request to %s', req.method, req.url.href);
-//     },
-//   });
-// }
+      if (!urlPath.startsWith('http://localhost:8080')) return;
+      console.warn('Found an unhandled %s request to %s', req.method, req.url.href);
+    },
+  });
+}
 
 /* eslint-enable */
 

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -15,17 +15,17 @@ import theme from '@/style/theme';
 
 /* eslint-disable */
 
-if (process.env.NODE_ENV === 'development' && !window.Cypress) {
-  const { worker } = require('@/mocks/browser');
-  worker.start({
-    onUnhandledRequest(req) {
-      const urlPath = req.url.pathname;
+// if (process.env.NODE_ENV === 'development' && !window.Cypress) {
+//   const { worker } = require('@/mocks/browser');
+//   worker.start({
+//     onUnhandledRequest(req) {
+//       const urlPath = req.url.pathname;
 
-      if (!urlPath.startsWith('http://localhost:8080')) return;
-      console.warn('Found an unhandled %s request to %s', req.method, req.url.href);
-    },
-  });
-}
+//       if (!urlPath.startsWith('http://localhost:8080')) return;
+//       console.warn('Found an unhandled %s request to %s', req.method, req.url.href);
+//     },
+//   });
+// }
 
 /* eslint-enable */
 


### PR DESCRIPTION
# issue: closes #856 

# 작업 내용
무한스크롤 오류 수정
- 첫 화면에서 두 페이지 (초기 + 그 다음)을 불러오면 발생
- intersection observer는 isIntersecting이 false에서 true로 변경될 때 콜백함수가 실행
- 위 엣지 케이스에서는 계속 화면에 intersecting이어서 그 다음 페이지를 불러오지 않음
- useEffect 훅을 사용해 children이 변경될 때 cleanup 콜백함수로 unobserve 한 뒤 다시 observe하도록 해서 화면에 존재하는 동안에는 새로운 데이터를 불러운 뒤 계속 콜백함수가 호출되도록 수정

```ts
useEffect(() => {
  if (!endRef.current) return;
  endOfContentObserver.observe(endRef.current);

  return () => {
    if (!endRef.current) return;
    endOfContentObserver.unobserve(endRef.current);
  };
}, [children]);
```
