### PR TITLE
[Bugfix/FE] babel/core-js 설치 및 설정을 통해 at 매서드 오류 해결

### DIFF
--- a/frontend/babel.config.json
+++ b/frontend/babel.config.json
@@ -1,6 +1,12 @@
 {
   "presets": [
-    "@babel/preset-env",
+    [
+      "@babel/preset-env",
+      {
+        "useBuiltIns": "entry",
+        "corejs": "3.22"
+      }
+    ],
     ["@babel/preset-react", { "runtime": "automatic" }],
     "@babel/preset-typescript"
   ],

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22,6 +22,7 @@
         "axios": "^0.27.2",
         "babel-loader": "^8.2.5",
         "copy-webpack-plugin": "^11.0.0",
+        "core-js": "^3.26.0",
         "html-webpack-plugin": "^5.5.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -13316,10 +13317,9 @@
       }
     },
     "node_modules/core-js": {
-      "version": "3.23.3",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.23.3.tgz",
-      "integrity": "sha512-oAKwkj9xcWNBAvGbT//WiCdOMpb9XQG92/Fe3ABFM/R16BsHgePG00mFOgKf7IsCtfj8tA1kHtf/VwErhriz5Q==",
-      "dev": true,
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.26.0.tgz",
+      "integrity": "sha512-+DkDrhoR4Y0PxDz6rurahuB+I45OsEUv8E1maPTB6OuHRohMMcznBq9TMpdpDMm/hUPob/mJJS3PqgbHpMTQgw==",
       "hasInstallScript": true,
       "funding": {
         "type": "opencollective",
@@ -36949,10 +36949,9 @@
       }
     },
     "core-js": {
-      "version": "3.23.3",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.23.3.tgz",
-      "integrity": "sha512-oAKwkj9xcWNBAvGbT//WiCdOMpb9XQG92/Fe3ABFM/R16BsHgePG00mFOgKf7IsCtfj8tA1kHtf/VwErhriz5Q==",
-      "dev": true
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.26.0.tgz",
+      "integrity": "sha512-+DkDrhoR4Y0PxDz6rurahuB+I45OsEUv8E1maPTB6OuHRohMMcznBq9TMpdpDMm/hUPob/mJJS3PqgbHpMTQgw=="
     },
     "core-js-compat": {
       "version": "3.23.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -61,6 +61,7 @@
     "axios": "^0.27.2",
     "babel-loader": "^8.2.5",
     "copy-webpack-plugin": "^11.0.0",
+    "core-js": "^3.26.0",
     "html-webpack-plugin": "^5.5.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,3 +1,4 @@
+import 'core-js/stable';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { ThemeProvider } from 'styled-components';


### PR DESCRIPTION
# issue: closes #858 

# 작업 내용
##문제 상황
홈화면에서 캐싱에 사용한 배열 내장 메서드인 `at`이 오래된 브라우저에서 지원이 되지 않아서 발생하는 오류
![image](https://user-images.githubusercontent.com/43166681/198175993-4e73165e-d550-4dd2-8fc1-b5f4a7ce430b.png)
![image](https://user-images.githubusercontent.com/43166681/198175558-f1061f1d-9faa-48cc-a325-c99ff92dc26c.png)
## 원인
- babel 설정 상으로 0.5% 이상의 점유율을 가진 브라우저에 지원하도록 설정해두었음 => 하지만 제대로 적용되지 않음
```json
"targets": "> 0.5%, not dead"
```
## 해결책
- 검색 결과 필요한 함수를 적절히 polyfill 하려면 core-js를 설치하고 설정해야함
- https://babeljs.io/docs/en/babel-preset-env#usebuiltins
- core-js를 설치하고 babel.confing.json에 설정 추가
- index.tsx에 core-js의 stable 버전을 import

