### PR TITLE
[Bugfix/FE] ts-loader, fork-ts-checker 플러그인을 devDeps => deps로 변경

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,10 +43,8 @@
     "eslint-plugin-prettier": "^4.1.0",
     "eslint-plugin-react": "^7.30.1",
     "eslint-plugin-react-hooks": "^4.6.0",
-    "fork-ts-checker-webpack-plugin": "^7.2.13",
     "msw": "^0.42.3",
     "prettier": "^2.7.1",
-    "ts-loader": "^9.4.1",
     "webpack-bundle-analyzer": "^4.6.1"
   },
   "dependencies": {
@@ -65,10 +63,12 @@
     "copy-webpack-plugin": "^11.0.0",
     "core-js": "^3.26.0",
     "html-webpack-plugin": "^5.5.0",
+    "fork-ts-checker-webpack-plugin": "^7.2.13",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.3.0",
     "styled-components": "^5.3.5",
+    "ts-loader": "^9.4.1",
     "typescript": "^4.7.4",
     "webpack": "^5.73.0",
     "webpack-cli": "^4.10.0",


### PR DESCRIPTION
# 오류 상황
jenkins에서 프론트엔드 빌드 실패

# 작업 내용
jenkins에서 build할 때 devDependency는 설치하지 않는 --production 옵션을 사용 중이기 때문에
devDependency에 위 두 플러그인이 있으면 설치되지 않아 성공적으로 build 할 수 없는 오류 발생