### PR TITLE
[FE] API 캐시 타임 수정

### DIFF
--- a/frontend/src/constants/cache.ts
+++ b/frontend/src/constants/cache.ts
@@ -1,6 +1,7 @@
-const MINS = 60 * 100;
+const MINS = 60 * 1000;
 
 export const CACHE_TIME = {
   FIVE_MINS: 5 * MINS,
   THREE_MINS: 3 * MINS,
+  ONE_MINS: 1 * MINS,
 } as const;

--- a/frontend/src/contexts/CacheContextProvider.tsx
+++ b/frontend/src/contexts/CacheContextProvider.tsx
@@ -36,7 +36,7 @@ function CacheContextProvider({ children }: PropsWithChildren) {
   const addCache = (
     url: string,
     response: AxiosResponse<unknown>,
-    maxAge = CACHE_TIME.FIVE_MINS
+    maxAge = CACHE_TIME.ONE_MINS
   ) => {
     setCache((prev) => prev.set(url, { response, expires: Date.now() + maxAge }));
   };
@@ -45,7 +45,7 @@ function CacheContextProvider({ children }: PropsWithChildren) {
     url: string,
     page: number,
     response: AxiosResponse<unknown>,
-    maxAge = CACHE_TIME.FIVE_MINS
+    maxAge = CACHE_TIME.ONE_MINS
   ) => {
     setCache((prev) => {
       const prevCache = prev.get(url) || [];


### PR DESCRIPTION
# issue: closes #870 

# 작업 내용
- MINS 변수 오타 수정 (100ms -> 1000ms)
- 캐시 시간 1분으로 감소
- 현재 캐시 시간이 5분으로 설정되어 있는데 해당 시간 내에 데이터가 변경되는 경우, 사용자가 이전 데이터를 계속해서 보는 문제가 발생합니다. 서버로부터 캐싱을 하는 것이 가장 좋겠지만, 백엔드 크루들의 시간적 여력이 부족하고, 이미지도 자체적으로 관리하고 있는 상황이 아니기 때문에 현 상황에서는 클라이언트 측에서 캐싱 타임을 줄이는게 가장 현실적인 방안인 것 같습니다. 현재 서비스 규모에서 데이터가 1분 미만의 단위로 변경될 가능성은 크지 않다고 판단하여 1분으로 수정하였습니다. 
