### PR TITLE
[FE] 불필요한 tsconfig 설정 제거

### DIFF
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -5,7 +5,6 @@
     "moduleResolution": "node",
     "jsx": "react-jsx",
     "esModuleInterop": true,
-    "removeComments": false,
     "strict": true,
     "strictNullChecks": false,
     "baseUrl": ".",


### PR DESCRIPTION
# issue: closes #872 

# 작업 내용
- removeComments는 기본값이 false인데 tsconfig에 명시되어 있어 제거했습니다.
- https://www.typescriptlang.org/tsconfig#removeComments
- `Strips all comments from TypeScript files when converting into JavaScript. Defaults to false.`
