### PR TITLE
[Refactor/BE] 불필요한 ResponseEntity 제거

### DIFF
--- a/backend/src/main/java/com/woowacourse/f12/presentation/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/GlobalExceptionHandler.java
@@ -102,7 +102,7 @@ public class GlobalExceptionHandler {
         ExceptionResponse responseBody = ExceptionResponse.from(e);
         final Cookie cookie = WebUtils.getCookie(request, REFRESH_TOKEN);
         if (cookie != null) {
-            ResponseCookie responseCookie = refreshTokenCookieProvider.expireCookie(cookie);
+            ResponseCookie responseCookie = refreshTokenCookieProvider.createLogoutCookie();
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                     .header(HttpHeaders.SET_COOKIE, responseCookie.toString())
                     .body(responseBody);

--- a/backend/src/main/java/com/woowacourse/f12/presentation/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/GlobalExceptionHandler.java
@@ -19,11 +19,13 @@ import com.woowacourse.f12.exception.unauthorized.RefreshTokenNotFoundException;
 import com.woowacourse.f12.exception.unauthorized.TooManyRefreshTokenAffectedException;
 import com.woowacourse.f12.exception.unauthorized.UnauthorizedException;
 import com.woowacourse.f12.presentation.auth.RefreshTokenCookieProvider;
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.BindException;
@@ -31,11 +33,13 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.util.WebUtils;
 
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+    private static final String REFRESH_TOKEN = "refreshToken";
     private static final String REQUEST_DUPLICATED_MESSAGE = "요청이 중복될 수 없습니다";
     private static final String REQUEST_DATA_FORMAT_ERROR_MESSAGE = "요청으로 넘어온 값이 형식에 맞지 않습니다.";
     private static final String INTERNAL_SERVER_ERROR_MESSAGE = "서버 오류가 발생했습니다";
@@ -93,10 +97,18 @@ public class GlobalExceptionHandler {
     @ExceptionHandler({RefreshTokenNotFoundException.class, DuplicatedRefreshTokenSavedException.class,
             RefreshTokenExpiredException.class, TooManyRefreshTokenAffectedException.class})
     public ResponseEntity<ExceptionResponse> handleRefreshTokenException(final UnauthorizedException e,
-                                                                         final HttpServletRequest request,
-                                                                         final HttpServletResponse response) {
-        refreshTokenCookieProvider.removeCookie(request, response);
-        return handleUnauthorizedException(e);
+                                                                         final HttpServletRequest request) {
+        log.info(LOG_FORMAT, e.getClass().getSimpleName(), e.getErrorCode().getValue(), e.getMessage());
+        ExceptionResponse responseBody = ExceptionResponse.from(e);
+        final Cookie cookie = WebUtils.getCookie(request, REFRESH_TOKEN);
+        if (cookie != null) {
+            ResponseCookie responseCookie = refreshTokenCookieProvider.expireCookie(cookie);
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .header(HttpHeaders.SET_COOKIE, responseCookie.toString())
+                    .body(responseBody);
+        }
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(responseBody);
     }
 
     @ExceptionHandler(UnauthorizedException.class)

--- a/backend/src/main/java/com/woowacourse/f12/presentation/auth/AuthController.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/auth/AuthController.java
@@ -32,17 +32,16 @@ public class AuthController {
     }
 
     @GetMapping("/login")
-    public ResponseEntity<LoginResponse> login(final HttpServletResponse response, @RequestParam final String code) {
+    public LoginResponse login(final HttpServletResponse response, @RequestParam final String code) {
         final LoginResult loginResult = authService.login(code);
         final String refreshToken = loginResult.getRefreshToken();
         refreshTokenCookieProvider.setCookie(response, refreshToken);
-        return ResponseEntity.ok(LoginResponse.from(loginResult));
+        return LoginResponse.from(loginResult);
     }
 
     @GetMapping("/login/admin")
-    public ResponseEntity<AdminLoginResponse> loginAdmin(@RequestParam final String code) {
-        final AdminLoginResponse adminLoginResponse = authService.loginAdmin(code);
-        return ResponseEntity.ok(adminLoginResponse);
+    public AdminLoginResponse loginAdmin(@RequestParam final String code) {
+        return authService.loginAdmin(code);
     }
 
     @GetMapping("/logout")
@@ -52,14 +51,14 @@ public class AuthController {
     }
 
     @PostMapping("/accessToken")
-    public ResponseEntity<AccessTokenResponse> issueAccessToken(final HttpServletRequest request,
-                                                                final HttpServletResponse response,
-                                                                @CookieValue(value = REFRESH_TOKEN, required = false) final String refreshToken) {
+    public AccessTokenResponse issueAccessToken(final HttpServletRequest request,
+                                                final HttpServletResponse response,
+                                                @CookieValue(value = REFRESH_TOKEN, required = false) final String refreshToken) {
         if (refreshToken == null) {
             throw new RefreshTokenNotExistException();
         }
         final IssuedTokensResponse issuedTokensResponse = authService.issueAccessToken(refreshToken);
         refreshTokenCookieProvider.setCookie(response, issuedTokensResponse.getRefreshToken());
-        return ResponseEntity.ok(new AccessTokenResponse(issuedTokensResponse.getAccessToken()));
+        return new AccessTokenResponse(issuedTokensResponse.getAccessToken());
     }
 }

--- a/backend/src/main/java/com/woowacourse/f12/presentation/auth/RefreshTokenCookieProvider.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/auth/RefreshTokenCookieProvider.java
@@ -1,8 +1,6 @@
 package com.woowacourse.f12.presentation.auth;
 
-import com.woowacourse.f12.exception.unauthorized.RefreshTokenNotExistException;
 import java.time.Duration;
-import javax.servlet.http.Cookie;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.web.server.Cookie.SameSite;
 import org.springframework.http.ResponseCookie;
@@ -27,11 +25,8 @@ public class RefreshTokenCookieProvider {
                 .build();
     }
 
-    public ResponseCookie expireCookie(final Cookie cookie) {
-        if (cookie == null) {
-            throw new RefreshTokenNotExistException();
-        }
-        return createTokenCookieBuilder(cookie.getValue())
+    public ResponseCookie createLogoutCookie() {
+        return createTokenCookieBuilder("")
                 .maxAge(REMOVAL_MAX_AGE)
                 .build();
     }

--- a/backend/src/main/java/com/woowacourse/f12/presentation/auth/RefreshTokenCookieProvider.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/auth/RefreshTokenCookieProvider.java
@@ -3,15 +3,11 @@ package com.woowacourse.f12.presentation.auth;
 import com.woowacourse.f12.exception.unauthorized.RefreshTokenNotExistException;
 import java.time.Duration;
 import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.web.server.Cookie.SameSite;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseCookie.ResponseCookieBuilder;
 import org.springframework.stereotype.Component;
-import org.springframework.web.util.WebUtils;
 
 @Component
 public class RefreshTokenCookieProvider {
@@ -25,22 +21,19 @@ public class RefreshTokenCookieProvider {
         this.expiredTimeMillis = expiredTimeMillis;
     }
 
-    public void setCookie(final HttpServletResponse response, final String value) {
-        final ResponseCookie responseCookie = createTokenCookieBuilder(value)
+    public ResponseCookie createCookie(final String refreshToken) {
+        return createTokenCookieBuilder(refreshToken)
                 .maxAge(Duration.ofMillis(expiredTimeMillis))
                 .build();
-        response.addHeader(HttpHeaders.SET_COOKIE, responseCookie.toString());
     }
 
-    public void removeCookie(final HttpServletRequest request, final HttpServletResponse response) {
-        final Cookie cookie = WebUtils.getCookie(request, REFRESH_TOKEN);
+    public ResponseCookie expireCookie(final Cookie cookie) {
         if (cookie == null) {
             throw new RefreshTokenNotExistException();
         }
-        final ResponseCookie responseCookie = createTokenCookieBuilder(cookie.getValue())
+        return createTokenCookieBuilder(cookie.getValue())
                 .maxAge(REMOVAL_MAX_AGE)
                 .build();
-        response.addHeader(HttpHeaders.SET_COOKIE, responseCookie.toString());
     }
 
     private ResponseCookieBuilder createTokenCookieBuilder(final String value) {

--- a/backend/src/main/java/com/woowacourse/f12/presentation/inventoryproduct/InventoryProductController.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/inventoryproduct/InventoryProductController.java
@@ -36,16 +36,12 @@ public class InventoryProductController {
 
     @GetMapping("/members/inventoryProducts")
     @Login
-    public ResponseEntity<InventoryProductsResponse> showMyInventoryProducts(
-            @VerifiedMember final MemberPayload memberPayload) {
-        final InventoryProductsResponse inventoryProductsResponse = inventoryProductService.findByMemberId(
-                memberPayload.getId());
-        return ResponseEntity.ok(inventoryProductsResponse);
+    public InventoryProductsResponse showMyInventoryProducts(@VerifiedMember final MemberPayload memberPayload) {
+        return inventoryProductService.findByMemberId(memberPayload.getId());
     }
 
     @GetMapping("/members/{memberId}/inventoryProducts")
-    public ResponseEntity<InventoryProductsResponse> show(@PathVariable final Long memberId) {
-        final InventoryProductsResponse inventoryProductsResponse = inventoryProductService.findByMemberId(memberId);
-        return ResponseEntity.ok(inventoryProductsResponse);
+    public InventoryProductsResponse show(@PathVariable final Long memberId) {
+        return inventoryProductService.findByMemberId(memberId);
     }
 }

--- a/backend/src/main/java/com/woowacourse/f12/presentation/member/MemberController.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/member/MemberController.java
@@ -36,18 +36,16 @@ public class MemberController {
 
     @GetMapping("/me")
     @Login
-    public ResponseEntity<LoggedInMemberResponse> showLoggedIn(@VerifiedMember final MemberPayload memberPayload) {
-        final LoggedInMemberResponse loggedInMemberResponse = memberService.findLoggedInMember(memberPayload.getId());
-        return ResponseEntity.ok(loggedInMemberResponse);
+    public LoggedInMemberResponse showLoggedIn(@VerifiedMember final MemberPayload memberPayload) {
+        return memberService.findLoggedInMember(memberPayload.getId());
     }
 
     @GetMapping("/{memberId}")
     @Login(required = false)
-    public ResponseEntity<MemberResponse> show(@PathVariable final Long memberId,
-                                               @VerifiedMember @Nullable final MemberPayload loggedInMemberPayload) {
+    public MemberResponse show(@PathVariable final Long memberId,
+                               @VerifiedMember @Nullable final MemberPayload loggedInMemberPayload) {
         Long loggedInMemberId = MemberPayloadSupport.getLoggedInMemberId(loggedInMemberPayload);
-        final MemberResponse memberResponse = memberService.find(memberId, loggedInMemberId);
-        return ResponseEntity.ok(memberResponse);
+        return memberService.find(memberId, loggedInMemberId);
     }
 
     @PatchMapping("/me")
@@ -60,14 +58,11 @@ public class MemberController {
 
     @GetMapping
     @Login(required = false)
-    public ResponseEntity<MemberPageResponse> searchMembers(
-            @VerifiedMember @Nullable final MemberPayload loggedInMemberPayload,
-            @ModelAttribute final MemberSearchRequest memberSearchRequest,
-            final Pageable pageable) {
+    public MemberPageResponse searchMembers(@VerifiedMember @Nullable final MemberPayload loggedInMemberPayload,
+                                            @ModelAttribute final MemberSearchRequest memberSearchRequest,
+                                            final Pageable pageable) {
         Long loggedInMemberId = MemberPayloadSupport.getLoggedInMemberId(loggedInMemberPayload);
-        final MemberPageResponse memberPageResponse = memberService.findBySearchConditions(loggedInMemberId,
-                memberSearchRequest, pageable);
-        return ResponseEntity.ok(memberPageResponse);
+        return memberService.findBySearchConditions(loggedInMemberId, memberSearchRequest, pageable);
     }
 
     @PostMapping("/{memberId}/following")
@@ -90,11 +85,9 @@ public class MemberController {
 
     @GetMapping("/me/followings")
     @Login
-    public ResponseEntity<MemberPageResponse> searchFollowings(
-            @VerifiedMember final MemberPayload loggedInMemberPayload,
-            @ModelAttribute final MemberSearchRequest memberSearchRequest,
-            final Pageable pageable) {
-        return ResponseEntity.ok(
-                memberService.findFollowingsByConditions(loggedInMemberPayload.getId(), memberSearchRequest, pageable));
+    public MemberPageResponse searchFollowings(@VerifiedMember final MemberPayload loggedInMemberPayload,
+                                               @ModelAttribute final MemberSearchRequest memberSearchRequest,
+                                               final Pageable pageable) {
+        return memberService.findFollowingsByConditions(loggedInMemberPayload.getId(), memberSearchRequest, pageable);
     }
 }

--- a/backend/src/main/java/com/woowacourse/f12/presentation/product/ProductController.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/product/ProductController.java
@@ -34,9 +34,9 @@ public class ProductController {
     }
 
     @GetMapping
-    public ResponseEntity<ProductPageResponse> showPage(@ModelAttribute final ProductSearchRequest productSearchRequest,
-                                                        final Pageable pageable) {
-        return ResponseEntity.ok(productService.findBySearchConditions(productSearchRequest, pageable));
+    public ProductPageResponse showPage(@ModelAttribute final ProductSearchRequest productSearchRequest,
+                                        final Pageable pageable) {
+        return productService.findBySearchConditions(productSearchRequest, pageable);
     }
 
     @PostMapping
@@ -48,8 +48,8 @@ public class ProductController {
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<ProductResponse> show(@PathVariable final Long id) {
-        return ResponseEntity.ok(productService.findById(id));
+    public ProductResponse show(@PathVariable final Long id) {
+        return productService.findById(id);
     }
 
     @PatchMapping("/{id}")
@@ -70,12 +70,12 @@ public class ProductController {
     }
 
     @GetMapping("/{id}/statistics")
-    public ResponseEntity<ProductStatisticsResponse> showStatistics(@PathVariable final Long id) {
-        return ResponseEntity.ok(productService.calculateMemberStatisticsById(id));
+    public ProductStatisticsResponse showStatistics(@PathVariable final Long id) {
+        return productService.calculateMemberStatisticsById(id);
     }
 
     @GetMapping("/popular-list")
-    public ResponseEntity<PopularProductsResponse> showPopularProducts(@RequestParam final int size) {
-        return ResponseEntity.ok(productService.findPopularProducts(size));
+    public PopularProductsResponse showPopularProducts(@RequestParam final int size) {
+        return productService.findPopularProducts(size);
     }
 }

--- a/backend/src/main/java/com/woowacourse/f12/presentation/review/ReviewController.java
+++ b/backend/src/main/java/com/woowacourse/f12/presentation/review/ReviewController.java
@@ -46,20 +46,16 @@ public class ReviewController {
 
     @GetMapping("/products/{productId}/reviews")
     @Login(required = false)
-    public ResponseEntity<ReviewWithAuthorPageResponse> showPageByProductId(@PathVariable final Long productId,
-                                                                            @VerifiedMember @Nullable MemberPayload memberPayload,
-                                                                            final Pageable pageable) {
+    public ReviewWithAuthorPageResponse showPageByProductId(@PathVariable final Long productId,
+                                                            @VerifiedMember @Nullable MemberPayload memberPayload,
+                                                            final Pageable pageable) {
         final Long loggedInMemberId = MemberPayloadSupport.getLoggedInMemberId(memberPayload);
-        final ReviewWithAuthorPageResponse reviewPageResponse = reviewService.findPageByProductId(productId,
-                loggedInMemberId, pageable);
-        return ResponseEntity.ok(reviewPageResponse);
+        return reviewService.findPageByProductId(productId, loggedInMemberId, pageable);
     }
 
     @GetMapping("/reviews")
-    public ResponseEntity<ReviewWithAuthorAndProductPageResponse> showPage(final Pageable pageable) {
-        final ReviewWithAuthorAndProductPageResponse reviewWithAuthorAndProductPageResponse = reviewService.findPage(
-                pageable);
-        return ResponseEntity.ok(reviewWithAuthorAndProductPageResponse);
+    public ReviewWithAuthorAndProductPageResponse showPage(final Pageable pageable) {
+        return reviewService.findPage(pageable);
     }
 
     @PutMapping("/reviews/{reviewId}")
@@ -82,26 +78,20 @@ public class ReviewController {
     }
 
     @GetMapping("/members/{memberId}/reviews")
-    public ResponseEntity<ReviewWithProductPageResponse> showPageByMemberId(@PathVariable final Long memberId,
-                                                                            final Pageable pageable) {
-        final ReviewWithProductPageResponse reviewWithProductPageResponse = reviewService.findPageByMemberId(memberId,
-                pageable);
-        return ResponseEntity.ok(reviewWithProductPageResponse);
+    public ReviewWithProductPageResponse showPageByMemberId(@PathVariable final Long memberId,
+                                                            final Pageable pageable) {
+        return reviewService.findPageByMemberId(memberId, pageable);
     }
 
     @GetMapping("/members/me/reviews")
     @Login
-    public ResponseEntity<ReviewWithProductPageResponse> showMyReviewPage(
-            @VerifiedMember final MemberPayload memberPayload,
-            final Pageable pageable) {
-        final ReviewWithProductPageResponse reviewWithProductPageResponse = reviewService.findPageByMemberId(
-                memberPayload.getId(), pageable);
-        return ResponseEntity.ok(reviewWithProductPageResponse);
+    public ReviewWithProductPageResponse showMyReviewPage(@VerifiedMember final MemberPayload memberPayload,
+                                                          final Pageable pageable) {
+        return reviewService.findPageByMemberId(memberPayload.getId(), pageable);
     }
 
     @GetMapping("/inventoryProducts/{inventoryProductId}/reviews")
-    public ResponseEntity<ReviewWithProductResponse> showReview(@PathVariable final Long inventoryProductId) {
-        final ReviewWithProductResponse reviewResponse = reviewService.findByInventoryProductId(inventoryProductId);
-        return ResponseEntity.ok(reviewResponse);
+    public ReviewWithProductResponse showReview(@PathVariable final Long inventoryProductId) {
+        return reviewService.findByInventoryProductId(inventoryProductId);
     }
 }

--- a/backend/src/test/java/com/woowacourse/f12/presentation/auth/RefreshTokenCookieProviderTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/auth/RefreshTokenCookieProviderTest.java
@@ -2,25 +2,14 @@ package com.woowacourse.f12.presentation.auth;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
 
 import java.time.Duration;
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletRequest;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.ResponseCookie;
 
 class RefreshTokenCookieProviderTest {
 
-    private HttpServletRequest request;
     private RefreshTokenCookieProvider provider;
-
-    @BeforeEach
-    void setUp() {
-        request = mock(HttpServletRequest.class);
-    }
 
     @Test
     void 리프레시_토큰으로_쿠키를_생성한다() {
@@ -43,12 +32,9 @@ class RefreshTokenCookieProviderTest {
     void 생성된_쿠키를_받아서_만료시킨_뒤_반환한다() {
         // given
         provider = new RefreshTokenCookieProvider(1000L);
-        String refreshTokenValue = "refreshTokenValue";
-        Cookie cookie = new Cookie("refreshToken", refreshTokenValue);
-        given(request.getCookies()).willReturn(new Cookie[]{cookie});
 
         // when
-        ResponseCookie responseCookie = provider.expireCookie(cookie);
+        ResponseCookie responseCookie = provider.createLogoutCookie();
 
         // then
         assertThat(responseCookie.getMaxAge()).isZero();

--- a/backend/src/test/java/com/woowacourse/f12/presentation/auth/RefreshTokenCookieProviderTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/auth/RefreshTokenCookieProviderTest.java
@@ -1,56 +1,46 @@
 package com.woowacourse.f12.presentation.auth;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 
+import java.time.Duration;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 
 class RefreshTokenCookieProviderTest {
 
-    private static final int PER_SECOND = 1000;
     private HttpServletRequest request;
-    private HttpServletResponse response;
     private RefreshTokenCookieProvider provider;
 
     @BeforeEach
     void setUp() {
         request = mock(HttpServletRequest.class);
-        response = mock(HttpServletResponse.class);
     }
 
     @Test
-    void 쿠키를_응답헤더에_세팅한다() {
+    void 리프레시_토큰으로_쿠키를_생성한다() {
         // given
         final long expiredTimeMillis = 1000L;
         provider = new RefreshTokenCookieProvider(expiredTimeMillis);
         final String refreshTokenValue = "refreshTokenValue";
 
         // when
-        provider.setCookie(response, refreshTokenValue);
+        ResponseCookie responseCookie = provider.createCookie(refreshTokenValue);
 
         // then
-        verify(response)
-                .addHeader(eq(HttpHeaders.SET_COOKIE), argThat(
-                        argument -> argument.contains("refreshToken=" + refreshTokenValue)
-                                && argument.contains("Path=/")
-                                && argument.contains("Secure")
-                                && argument.contains("HttpOnly")
-                                && argument.contains("SameSite=None")
-                                && argument.contains("Max-Age=" + expiredTimeMillis / PER_SECOND))
-                );
+        assertAll(
+                () -> assertThat(responseCookie.getValue()).isEqualTo(refreshTokenValue),
+                () -> assertThat(responseCookie.getMaxAge()).isEqualTo(Duration.ofMillis(expiredTimeMillis))
+        );
     }
 
     @Test
-    void 쿠키_제거를_응답헤더에_세팅한다() {
+    void 생성된_쿠키를_받아서_만료시킨_뒤_반환한다() {
         // given
         provider = new RefreshTokenCookieProvider(1000L);
         String refreshTokenValue = "refreshTokenValue";
@@ -58,20 +48,9 @@ class RefreshTokenCookieProviderTest {
         given(request.getCookies()).willReturn(new Cookie[]{cookie});
 
         // when
-        provider.removeCookie(request, response);
+        ResponseCookie responseCookie = provider.expireCookie(cookie);
 
         // then
-        assertAll(
-                () -> verify(request).getCookies(),
-                () -> verify(response)
-                        .addHeader(eq(HttpHeaders.SET_COOKIE), argThat(
-                                argument -> argument.contains("refreshToken=" + refreshTokenValue)
-                                        && argument.contains("Path=/")
-                                        && argument.contains("Secure")
-                                        && argument.contains("HttpOnly")
-                                        && argument.contains("SameSite=None")
-                                        && argument.contains("Max-Age=0"))
-                        )
-        );
+        assertThat(responseCookie.getMaxAge()).isZero();
     }
 }


### PR DESCRIPTION
# issue: closes #863 

# 작업 내용
- 200 OK를 내려주는 응답에 대해서 스프링은 ResponseEntity<T>의 형태가 아니라 T의 반환값으로도 처리할 수 있음.
- 특별히 처리를 해주어야 하는 메서드가 없었기 때문에 모든 200 OK 응답들은 ResponseBody로 사용할 DTO를 그대로 리턴값으로 사용하도록 수정

# 의문점
- Cookie 값을 내려주는 컨트롤러 메서드에서 왜 굳이 HttpResponse를 파라미터로 받아서 처리했을까?
```java
return ResponseEntity.ok().header()...
```
으로도 처리할 수 있지 않았을까?