### PR TITLE
[Refactor/BE] PresentationTest application context 통합으로 테스트 실행 속도 개선

### DIFF
--- a/backend/src/test/java/com/woowacourse/f12/presentation/CustomPageableArgumentResolverTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/CustomPageableArgumentResolverTest.java
@@ -10,29 +10,16 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.woowacourse.f12.application.product.ProductService;
 import com.woowacourse.f12.dto.request.product.ProductSearchRequest;
 import com.woowacourse.f12.dto.response.product.ProductPageResponse;
-import com.woowacourse.f12.presentation.product.ProductController;
 import java.util.List;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.domain.Sort;
-import org.springframework.test.web.servlet.MockMvc;
 
-@WebMvcTest(ProductController.class)
-public class CustomPageableArgumentResolverTest extends PresentationTest {
-
-    @Autowired
-    private MockMvc mockMvc;
-
-    @MockBean
-    private ProductService productService;
+class CustomPageableArgumentResolverTest extends PresentationTest {
 
     @Test
     void 페이징_실패_페이지_번호_숫자_형식_아님() throws Exception {

--- a/backend/src/test/java/com/woowacourse/f12/presentation/CustomPageableArgumentResolverTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/CustomPageableArgumentResolverTest.java
@@ -10,16 +10,25 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.woowacourse.f12.application.product.ProductService;
 import com.woowacourse.f12.dto.request.product.ProductSearchRequest;
 import com.woowacourse.f12.dto.response.product.ProductPageResponse;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.domain.Sort;
+import org.springframework.test.web.servlet.MockMvc;
 
 class CustomPageableArgumentResolverTest extends PresentationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ProductService productService;
 
     @Test
     void 페이징_실패_페이지_번호_숫자_형식_아님() throws Exception {

--- a/backend/src/test/java/com/woowacourse/f12/presentation/PresentationTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/PresentationTest.java
@@ -1,18 +1,62 @@
 package com.woowacourse.f12.presentation;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.woowacourse.f12.application.auth.AuthService;
 import com.woowacourse.f12.application.auth.token.JwtProvider;
+import com.woowacourse.f12.application.inventoryproduct.InventoryProductService;
+import com.woowacourse.f12.application.member.MemberService;
+import com.woowacourse.f12.application.product.ProductService;
+import com.woowacourse.f12.application.review.ReviewService;
 import com.woowacourse.f12.config.LoggingConfig;
 import com.woowacourse.f12.logging.ApiQueryCounter;
+import com.woowacourse.f12.presentation.auth.AuthController;
 import com.woowacourse.f12.presentation.auth.RefreshTokenCookieProvider;
+import com.woowacourse.f12.presentation.inventoryproduct.InventoryProductController;
+import com.woowacourse.f12.presentation.member.MemberController;
+import com.woowacourse.f12.presentation.product.ProductController;
+import com.woowacourse.f12.presentation.review.ReviewController;
 import com.woowacourse.f12.support.AuthTokenExtractor;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.test.web.servlet.MockMvc;
 
 @AutoConfigureRestDocs
 @ExtendWith(RestDocumentationExtension.class)
 @Import({AuthTokenExtractor.class, JwtProvider.class, RestDocsConfig.class, LoggingConfig.class, ApiQueryCounter.class,
         RefreshTokenCookieProvider.class})
+@WebMvcTest({AuthController.class, ReviewController.class, ProductController.class, InventoryProductController.class,
+        MemberController.class, ReviewController.class})
 public class PresentationTest {
+
+    @Autowired
+    protected MockMvc mockMvc;
+
+    @MockBean
+    protected AuthService authService;
+
+    @MockBean
+    protected ReviewService reviewService;
+
+    @MockBean
+    protected ProductService productService;
+
+    @MockBean
+    protected JwtProvider jwtProvider;
+
+    @MockBean
+    protected InventoryProductService inventoryProductService;
+
+    @MockBean
+    protected MemberService memberService;
+
+    protected final ObjectMapper objectMapper;
+
+    public PresentationTest() {
+        this.objectMapper = new ObjectMapper();
+    }
 }

--- a/backend/src/test/java/com/woowacourse/f12/presentation/PresentationTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/PresentationTest.java
@@ -17,13 +17,11 @@ import com.woowacourse.f12.presentation.product.ProductController;
 import com.woowacourse.f12.presentation.review.ReviewController;
 import com.woowacourse.f12.support.AuthTokenExtractor;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.restdocs.RestDocumentationExtension;
-import org.springframework.test.web.servlet.MockMvc;
 
 @AutoConfigureRestDocs
 @ExtendWith(RestDocumentationExtension.class)
@@ -32,9 +30,6 @@ import org.springframework.test.web.servlet.MockMvc;
 @WebMvcTest({AuthController.class, ReviewController.class, ProductController.class, InventoryProductController.class,
         MemberController.class, ReviewController.class})
 public class PresentationTest {
-
-    @Autowired
-    protected MockMvc mockMvc;
 
     @MockBean
     protected AuthService authService;

--- a/backend/src/test/java/com/woowacourse/f12/presentation/UrlLengthCheckInterceptorTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/UrlLengthCheckInterceptorTest.java
@@ -8,22 +8,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.woowacourse.f12.application.product.ProductService;
 import com.woowacourse.f12.exception.ErrorCode;
-import com.woowacourse.f12.presentation.product.ProductController;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.web.servlet.MockMvc;
 
-@WebMvcTest(ProductController.class)
 class UrlLengthCheckInterceptorTest extends PresentationTest {
-    @Autowired
-    private MockMvc mockMvc;
-
-    @MockBean
-    private ProductService productService;
 
     @Test
     void uri가_1000자_이상인_경우_예외가_발생() throws Exception {

--- a/backend/src/test/java/com/woowacourse/f12/presentation/UrlLengthCheckInterceptorTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/UrlLengthCheckInterceptorTest.java
@@ -8,11 +8,20 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.woowacourse.f12.application.product.ProductService;
 import com.woowacourse.f12.exception.ErrorCode;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.MockMvc;
 
 class UrlLengthCheckInterceptorTest extends PresentationTest {
 
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ProductService productService;
+    
     @Test
     void uri가_1000자_이상인_경우_예외가_발생() throws Exception {
         // given

--- a/backend/src/test/java/com/woowacourse/f12/presentation/auth/AuthControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/auth/AuthControllerTest.java
@@ -27,7 +27,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.woowacourse.f12.application.auth.AuthService;
 import com.woowacourse.f12.dto.response.auth.AdminLoginResponse;
 import com.woowacourse.f12.dto.response.auth.IssuedTokensResponse;
 import com.woowacourse.f12.dto.response.auth.LoginResponse;
@@ -43,21 +42,10 @@ import com.woowacourse.f12.presentation.PresentationTest;
 import com.woowacourse.f12.support.ErrorCodeSnippet;
 import javax.servlet.http.Cookie;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
-@WebMvcTest(AuthController.class)
 class AuthControllerTest extends PresentationTest {
-
-    @Autowired
-    private MockMvc mockMvc;
-
-    @MockBean
-    private AuthService authService;
 
     @Test
     void 로그인_성공() throws Exception {

--- a/backend/src/test/java/com/woowacourse/f12/presentation/auth/AuthControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/auth/AuthControllerTest.java
@@ -27,9 +27,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.woowacourse.f12.application.auth.AuthService;
 import com.woowacourse.f12.dto.response.auth.AdminLoginResponse;
 import com.woowacourse.f12.dto.response.auth.IssuedTokensResponse;
-import com.woowacourse.f12.dto.response.auth.LoginResponse;
 import com.woowacourse.f12.dto.result.LoginResult;
 import com.woowacourse.f12.exception.ErrorCode;
 import com.woowacourse.f12.exception.badrequest.InvalidGitHubLoginException;
@@ -42,10 +42,18 @@ import com.woowacourse.f12.presentation.PresentationTest;
 import com.woowacourse.f12.support.ErrorCodeSnippet;
 import javax.servlet.http.Cookie;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
 class AuthControllerTest extends PresentationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private AuthService authService;
 
     @Test
     void 로그인_성공() throws Exception {
@@ -54,7 +62,6 @@ class AuthControllerTest extends PresentationTest {
         String token = "token";
         String refreshToken = "refreshTokenValue";
         LoginResult loginResult = new LoginResult(refreshToken, token, CORINNE.생성(1L));
-        LoginResponse loginResponse = LoginResponse.from(loginResult);
 
         given(authService.login(code))
                 .willReturn(loginResult);

--- a/backend/src/test/java/com/woowacourse/f12/presentation/auth/AuthInterceptorTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/auth/AuthInterceptorTest.java
@@ -17,16 +17,29 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.woowacourse.f12.application.auth.token.JwtProvider;
 import com.woowacourse.f12.application.auth.token.MemberPayload;
+import com.woowacourse.f12.application.review.ReviewService;
 import com.woowacourse.f12.domain.member.Role;
 import com.woowacourse.f12.dto.request.product.ProductCreateRequest;
 import com.woowacourse.f12.dto.request.review.ReviewRequest;
 import com.woowacourse.f12.presentation.PresentationTest;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
 
 class AuthInterceptorTest extends PresentationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JwtProvider jwtProvider;
+
+    @Autowired
+    private ReviewService reviewService;
 
     @Test
     void 인증_인가를_검증_실패_유효하지_않은_액세스_토큰() throws Exception {

--- a/backend/src/test/java/com/woowacourse/f12/presentation/auth/AuthInterceptorTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/auth/AuthInterceptorTest.java
@@ -17,45 +17,16 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.woowacourse.f12.application.auth.token.JwtProvider;
 import com.woowacourse.f12.application.auth.token.MemberPayload;
-import com.woowacourse.f12.application.product.ProductService;
-import com.woowacourse.f12.application.review.ReviewService;
 import com.woowacourse.f12.domain.member.Role;
 import com.woowacourse.f12.dto.request.product.ProductCreateRequest;
 import com.woowacourse.f12.dto.request.review.ReviewRequest;
 import com.woowacourse.f12.presentation.PresentationTest;
-import com.woowacourse.f12.presentation.product.ProductController;
-import com.woowacourse.f12.presentation.review.ReviewController;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.test.web.servlet.MockMvc;
 
-@WebMvcTest({ReviewController.class, ProductController.class})
 class AuthInterceptorTest extends PresentationTest {
-
-    @Autowired
-    private MockMvc mockMvc;
-
-    @MockBean
-    private ReviewService reviewService;
-
-    @MockBean
-    private ProductService productService;
-
-    @MockBean
-    private JwtProvider jwtProvider;
-
-    private final ObjectMapper objectMapper;
-
-    public AuthInterceptorTest() {
-        this.objectMapper = new ObjectMapper();
-    }
 
     @Test
     void 인증_인가를_검증_실패_유효하지_않은_액세스_토큰() throws Exception {

--- a/backend/src/test/java/com/woowacourse/f12/presentation/inventoryproduct/InventoryProductControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/inventoryproduct/InventoryProductControllerTest.java
@@ -26,10 +26,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.woowacourse.f12.application.auth.token.JwtProvider;
 import com.woowacourse.f12.application.auth.token.MemberPayload;
-import com.woowacourse.f12.application.inventoryproduct.InventoryProductService;
 import com.woowacourse.f12.domain.inventoryproduct.InventoryProduct;
 import com.woowacourse.f12.domain.member.Member;
 import com.woowacourse.f12.domain.member.Role;
@@ -43,27 +40,11 @@ import com.woowacourse.f12.presentation.PresentationTest;
 import com.woowacourse.f12.support.ErrorCodeSnippet;
 import java.util.List;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
-@WebMvcTest(InventoryProductController.class)
 class InventoryProductControllerTest extends PresentationTest {
-
-    @Autowired
-    private MockMvc mockMvc;
-
-    @MockBean
-    private InventoryProductService inventoryProductService;
-
-    @MockBean
-    private JwtProvider jwtProvider;
-
-    private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Test
     void 대표_장비_등록_성공() throws Exception {

--- a/backend/src/test/java/com/woowacourse/f12/presentation/inventoryproduct/InventoryProductControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/inventoryproduct/InventoryProductControllerTest.java
@@ -26,7 +26,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.woowacourse.f12.application.auth.token.JwtProvider;
 import com.woowacourse.f12.application.auth.token.MemberPayload;
+import com.woowacourse.f12.application.inventoryproduct.InventoryProductService;
 import com.woowacourse.f12.domain.inventoryproduct.InventoryProduct;
 import com.woowacourse.f12.domain.member.Member;
 import com.woowacourse.f12.domain.member.Role;
@@ -40,11 +42,22 @@ import com.woowacourse.f12.presentation.PresentationTest;
 import com.woowacourse.f12.support.ErrorCodeSnippet;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
 class InventoryProductControllerTest extends PresentationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    
+    @Autowired
+    private JwtProvider jwtProvider;
+
+    @Autowired
+    private InventoryProductService inventoryProductService;
 
     @Test
     void 대표_장비_등록_성공() throws Exception {

--- a/backend/src/test/java/com/woowacourse/f12/presentation/member/MemberControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/member/MemberControllerTest.java
@@ -37,7 +37,9 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.woowacourse.f12.application.auth.token.JwtProvider;
 import com.woowacourse.f12.application.auth.token.MemberPayload;
+import com.woowacourse.f12.application.member.MemberService;
 import com.woowacourse.f12.domain.inventoryproduct.InventoryProduct;
 import com.woowacourse.f12.domain.member.Following;
 import com.woowacourse.f12.domain.member.Member;
@@ -57,6 +59,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -64,9 +67,19 @@ import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
 class MemberControllerTest extends PresentationTest {
+    
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JwtProvider jwtProvider;
+
+    @Autowired
+    private MemberService memberService;
 
     @Test
     void 로그인된_상태에서_나의_회원정보를_조회_성공() throws Exception {

--- a/backend/src/test/java/com/woowacourse/f12/presentation/member/MemberControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/member/MemberControllerTest.java
@@ -37,10 +37,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.woowacourse.f12.application.auth.token.JwtProvider;
 import com.woowacourse.f12.application.auth.token.MemberPayload;
-import com.woowacourse.f12.application.member.MemberService;
 import com.woowacourse.f12.domain.inventoryproduct.InventoryProduct;
 import com.woowacourse.f12.domain.member.Following;
 import com.woowacourse.f12.domain.member.Member;
@@ -60,9 +57,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -70,22 +64,9 @@ import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
-@WebMvcTest(MemberController.class)
 class MemberControllerTest extends PresentationTest {
-
-    @Autowired
-    private MockMvc mockMvc;
-
-    @MockBean
-    private MemberService memberService;
-
-    @MockBean
-    private JwtProvider jwtProvider;
-
-    private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Test
     void 로그인된_상태에서_나의_회원정보를_조회_성공() throws Exception {

--- a/backend/src/test/java/com/woowacourse/f12/presentation/product/ProductControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/product/ProductControllerTest.java
@@ -40,7 +40,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.woowacourse.f12.application.auth.token.JwtProvider;
 import com.woowacourse.f12.application.auth.token.MemberPayload;
+import com.woowacourse.f12.application.product.ProductService;
 import com.woowacourse.f12.domain.member.CareerLevel;
 import com.woowacourse.f12.domain.member.JobType;
 import com.woowacourse.f12.domain.member.Role;
@@ -58,15 +60,26 @@ import com.woowacourse.f12.support.ErrorCodeSnippet;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
 class ProductControllerTest extends PresentationTest {
+    
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JwtProvider jwtProvider;
+
+    @Autowired
+    private ProductService productService;
 
     @Test
     void 키보드_목록_페이지_조회_성공() throws Exception {

--- a/backend/src/test/java/com/woowacourse/f12/presentation/product/ProductControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/product/ProductControllerTest.java
@@ -40,10 +40,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.woowacourse.f12.application.auth.token.JwtProvider;
 import com.woowacourse.f12.application.auth.token.MemberPayload;
-import com.woowacourse.f12.application.product.ProductService;
 import com.woowacourse.f12.domain.member.CareerLevel;
 import com.woowacourse.f12.domain.member.JobType;
 import com.woowacourse.f12.domain.member.Role;
@@ -61,30 +58,15 @@ import com.woowacourse.f12.support.ErrorCodeSnippet;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
-@WebMvcTest(ProductController.class)
 class ProductControllerTest extends PresentationTest {
-
-    @Autowired
-    private MockMvc mockMvc;
-
-    @MockBean
-    private ProductService productService;
-
-    private final ObjectMapper objectMapper = new ObjectMapper();
-    @MockBean
-    private JwtProvider jwtProvider;
 
     @Test
     void 키보드_목록_페이지_조회_성공() throws Exception {

--- a/backend/src/test/java/com/woowacourse/f12/presentation/review/ReviewControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/review/ReviewControllerTest.java
@@ -39,7 +39,9 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.woowacourse.f12.application.auth.token.JwtProvider;
 import com.woowacourse.f12.application.auth.token.MemberPayload;
+import com.woowacourse.f12.application.review.ReviewService;
 import com.woowacourse.f12.domain.member.Member;
 import com.woowacourse.f12.domain.member.Role;
 import com.woowacourse.f12.domain.product.Product;
@@ -63,6 +65,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -70,9 +73,19 @@ import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
 class ReviewControllerTest extends PresentationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JwtProvider jwtProvider;
+
+    @Autowired
+    private ReviewService reviewService;
 
     private static final long PRODUCT_ID = 1L;
 

--- a/backend/src/test/java/com/woowacourse/f12/presentation/review/ReviewControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/presentation/review/ReviewControllerTest.java
@@ -39,10 +39,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.woowacourse.f12.application.auth.token.JwtProvider;
 import com.woowacourse.f12.application.auth.token.MemberPayload;
-import com.woowacourse.f12.application.review.ReviewService;
 import com.woowacourse.f12.domain.member.Member;
 import com.woowacourse.f12.domain.member.Role;
 import com.woowacourse.f12.domain.product.Product;
@@ -66,9 +63,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -76,28 +70,11 @@ import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
-@WebMvcTest(ReviewController.class)
 class ReviewControllerTest extends PresentationTest {
 
     private static final long PRODUCT_ID = 1L;
-
-    @Autowired
-    private MockMvc mockMvc;
-
-    private final ObjectMapper objectMapper;
-
-    @MockBean
-    private ReviewService reviewService;
-
-    @MockBean
-    private JwtProvider jwtProvider;
-
-    public ReviewControllerTest() {
-        this.objectMapper = new ObjectMapper();
-    }
 
     @Test
     void 리뷰_생성_성공() throws Exception {


### PR DESCRIPTION
# issue: #880 

# 작업 내용

### PresentationTest application context 통합으로 테스트 실행 속도 개선

각 Presentation 테스트에서 주입하는 `@MockBean` 의 구성이 매 테스트 클래스마다 달라지기 때문에 새롭게 application context를 새로 띄우는 현상이 발견되었다. 이를 개선하기 위해서 기존에 존재했던 Presentation 클래스를 활욤해서 Test에서 활용되는 각각의 `@MockBean`을 모두 구성한 후 application Context를 재활용해서 사용할 수 있도록 개선했다.

### 결과
**Application Context Load 횟수**
기존 12번 -> 개선 후  6번


**테스트 속도**
속도상으로 Intelij 에서 속도는 Application Context를 로딩하는 시간이 포함되어 나오지 않기 때문에 큰 변화는 없지만, 실제로 TEST를 실행하고 시간을 쟀을 때 유의미한 시간 차이가 있다.

(Mac Pro 2019 기준으로)
기존 평균적으로 41-42초 소요 -> 개선 후 평균적으로 36-37초로 개선
