### PR TITLE
[Feature/BE] replica db 서버를 1대 추가한다

### DIFF
--- a/backend/src/main/java/com/woowacourse/f12/config/DatasourceConfig.java
+++ b/backend/src/main/java/com/woowacourse/f12/config/DatasourceConfig.java
@@ -2,7 +2,10 @@ package com.woowacourse.f12.config;
 
 import static com.woowacourse.f12.support.DataSourceType.MASTER;
 import static com.woowacourse.f12.support.DataSourceType.SLAVE;
+import static com.woowacourse.f12.support.DataSourceType.SLAVE_SUB;
 
+import com.woowacourse.f12.support.DataSourceLoadBalancer;
+import com.woowacourse.f12.support.DataSourceType;
 import com.woowacourse.f12.support.ReplicationRoutingDataSource;
 import com.zaxxer.hikari.HikariDataSource;
 import java.util.Map;
@@ -41,11 +44,22 @@ public class DatasourceConfig {
                 .build();
     }
 
+    @Bean(name = "slaveSubDataSource")
+    @ConfigurationProperties(prefix = "spring.datasource.hikari.slave-sub")
+    public DataSource slaveSubDataSource() {
+        return DataSourceBuilder.create()
+                .type(HikariDataSource.class)
+                .build();
+    }
+
     @Bean(name = "routeDataSource")
     public DataSource routeDataSource(@Qualifier("masterDataSource") final DataSource masterDataSource,
-                                      @Qualifier("slaveDataSource") final DataSource slaveDataSource) {
-        final ReplicationRoutingDataSource replicationRoutingDataSource = new ReplicationRoutingDataSource();
-        final Map<Object, Object> dataSources = Map.of(MASTER, masterDataSource, SLAVE, slaveDataSource);
+                                      @Qualifier("slaveDataSource") final DataSource slaveDataSource,
+                                      @Qualifier("slaveSubDataSource") final DataSource slaveSubDataSource) {
+        final ReplicationRoutingDataSource replicationRoutingDataSource = new ReplicationRoutingDataSource(
+                new DataSourceLoadBalancer(DataSourceType.getSlaveDataSourcePool()));
+        final Map<Object, Object> dataSources = Map.of(MASTER, masterDataSource, SLAVE, slaveDataSource, SLAVE_SUB,
+                slaveSubDataSource);
         replicationRoutingDataSource.setTargetDataSources(dataSources);
         replicationRoutingDataSource.setDefaultTargetDataSource(masterDataSource);
         return replicationRoutingDataSource;

--- a/backend/src/main/java/com/woowacourse/f12/support/DataSourceLoadBalancer.java
+++ b/backend/src/main/java/com/woowacourse/f12/support/DataSourceLoadBalancer.java
@@ -1,0 +1,40 @@
+package com.woowacourse.f12.support;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.IntUnaryOperator;
+
+public class DataSourceLoadBalancer {
+
+    private static final int ROTATE_MIN_NUMBER = 0;
+
+    private final List<DataSourceType> dataSourcePool;
+    private final AtomicInteger atomicInteger = new AtomicInteger(ROTATE_MIN_NUMBER);
+    private final int rotateMaxNumber;
+    private final int rotateMinNumber;
+    private final int poolSize;
+
+    public DataSourceLoadBalancer(final List<DataSourceType> dataSourcePool) {
+        this.dataSourcePool = dataSourcePool;
+        this.poolSize = this.dataSourcePool.size();
+        this.rotateMaxNumber = this.poolSize - 1;
+        this.rotateMinNumber = ROTATE_MIN_NUMBER;
+    }
+
+    public DataSourceType getDataSource() {
+        return dataSourcePool.get(calculateIndex());
+    }
+
+    private int calculateIndex() {
+        return atomicInteger.getAndUpdate(rotateIncrement()) % (poolSize);
+    }
+
+    private IntUnaryOperator rotateIncrement() {
+        return (it) -> {
+            if (it == rotateMaxNumber) {
+                return rotateMinNumber;
+            }
+            return it + 1;
+        };
+    }
+}

--- a/backend/src/main/java/com/woowacourse/f12/support/DataSourceType.java
+++ b/backend/src/main/java/com/woowacourse/f12/support/DataSourceType.java
@@ -1,7 +1,38 @@
 package com.woowacourse.f12.support;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
 public enum DataSourceType {
 
-    MASTER,
-    SLAVE
+    MASTER(false, 1),
+    SLAVE(true, 1),
+    SLAVE_SUB(true, 1);
+
+    private final boolean isSlave;
+    private final int ratio;
+
+    DataSourceType(final boolean isSlave, final int ratio) {
+        this.isSlave = isSlave;
+        this.ratio = ratio;
+    }
+
+    public static List<DataSourceType> getSlaveDataSourcePool() {
+        final List<DataSourceType> dataSourceTypes = Arrays.stream(DataSourceType.values())
+                .filter(it -> it.isSlave)
+                .collect(Collectors.toList());
+        List<DataSourceType> dataSources = new ArrayList<>();
+        for (DataSourceType dataSourceType : dataSourceTypes) {
+            for (int i = 0; i < dataSourceType.getRatio(); i++) {
+                dataSources.add(dataSourceType);
+            }
+        }
+        return dataSources;
+    }
+
+    public int getRatio() {
+        return ratio;
+    }
 }

--- a/backend/src/test/java/com/woowacourse/f12/config/DataSourceLoadBalancerTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/config/DataSourceLoadBalancerTest.java
@@ -1,0 +1,68 @@
+package com.woowacourse.f12.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.woowacourse.f12.support.DataSourceLoadBalancer;
+import com.woowacourse.f12.support.DataSourceType;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+class DataSourceLoadBalancerTest {
+
+    @Test
+    void 요청에_대해서_비율_따라_부하_분산되는_동시성_테스트() throws InterruptedException {
+        int slaveRatio = 1;
+        int slaveSubRatio = 1;
+        List<DataSourceType> dataSourcePool = createDataSourcePool(slaveRatio, slaveSubRatio);
+        DataSourceLoadBalancer dataSourceLoadBalancer = new DataSourceLoadBalancer(dataSourcePool);
+
+        AtomicInteger slaveCount = new AtomicInteger(0);
+        AtomicInteger slaveSubCount = new AtomicInteger(0);
+        AtomicInteger errorCount = new AtomicInteger(0);
+
+        int numberOfThreads = 1000;
+        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+        CountDownLatch countDownLatch = new CountDownLatch(numberOfThreads);
+        for (int i = 0; i < numberOfThreads; i++) {
+            executorService.submit(() -> {
+                final DataSourceType dataSource = dataSourceLoadBalancer.getDataSource();
+                if (dataSource == DataSourceType.SLAVE) {
+                    slaveCount.getAndIncrement();
+                    countDownLatch.countDown();
+                    return;
+                }
+                if (dataSource == DataSourceType.SLAVE_SUB) {
+                    slaveSubCount.getAndIncrement();
+                    countDownLatch.countDown();
+                    return;
+                }
+                errorCount.getAndIncrement();
+                countDownLatch.countDown();
+            });
+        }
+        countDownLatch.await();
+
+        assertAll(
+                () -> assertThat(slaveCount.get()).isEqualTo(500),
+                () -> assertThat(slaveSubCount.get()).isEqualTo(500),
+                () -> assertThat(errorCount.get()).isEqualTo(0)
+        );
+    }
+
+    private static List<DataSourceType> createDataSourcePool(final int slaveRatio, final int slaveSubRatio) {
+        List<DataSourceType> dataSourcePool = new ArrayList<>();
+        for (int i = 0; i < slaveRatio; i++) {
+            dataSourcePool.add(DataSourceType.SLAVE);
+        }
+        for (int i = 0; i < slaveSubRatio; i++) {
+            dataSourcePool.add(DataSourceType.SLAVE_SUB);
+        }
+        return dataSourcePool;
+    }
+}

--- a/backend/src/test/java/com/woowacourse/f12/config/DatasourceConfigTest.java
+++ b/backend/src/test/java/com/woowacourse/f12/config/DatasourceConfigTest.java
@@ -19,7 +19,7 @@ class DatasourceConfigTest {
     void transaction이_readOnly라면_slave_datasource를_선택한다() throws SQLException {
         String url = transactionTestService.readOnly();
 
-        assertThat(url).isEqualTo("jdbc:h2:mem:slave");
+        assertThat(url).startsWith("jdbc:h2:mem:slave");
     }
 
     @Test


### PR DESCRIPTION
# issue: #882 

# 작업 내용
기존에 1대였던 replica를 1대 추가하여 2대로 구성한다.
사용한 쿼리는 제품을 키워드를 포함하여 페이지네이션으로 조회하는 요청이다.


### 개선 전(Replica 1대)
<img width="800" alt="스크린샷 2022-11-22 오후 5 11 50" src="https://user-images.githubusercontent.com/78459713/203505944-54597572-51c4-4224-819a-3718c022780a.png">

<img width="402" alt="스크린샷 2022-11-22 오후 5 12 54" src="https://user-images.githubusercontent.com/78459713/203505986-5a2d4845-74d7-41b1-ba6a-0589d2491e78.png">



### 개선 후(Replica 2대)
<img width="807" alt="스크린샷 2022-11-22 오후 4 57 22" src="https://user-images.githubusercontent.com/78459713/203506028-a07275b1-4ecd-4e45-859b-8496ae41b08e.png">

<img width="433" alt="스크린샷 2022-11-22 오후 4 58 34" src="https://user-images.githubusercontent.com/78459713/203506052-de700d1a-7aa2-4185-8c49-b045fa9a01e7.png">

### Pinpoint 그래프 비교(y축은 응답 속도, x축은 시간)
<img width="348" alt="스크린샷 2022-11-23 오후 4 29 03" src="https://user-images.githubusercontent.com/78459713/203506462-3dbd3fd6-ca2e-4df0-b93d-5993e2650b9f.png">


### 결론
DB Replication의 replica 개수를 1대에서 2대로 scale out으로 성능이 좋아짐
  - 약 15~20% 향상
  - 왜 2배가 아니라 15~20% 만 향상되었는가?
      - 실제 쿼리를 수행하는 excuteQuery는 시간이 줄어들지 않았지만, Connection을 점유할 때 사용할 수 있는 커넥션이 없어서 기다리는 getConnection의 시간이 절반으로 줄어들었다.
      - getConnection의 시간만 줄어든 것이기 때문에 이 비율에 따라서 성능이 향상된 것으로 보임
  - 최악의 경우에서는 replica 2대인 경우가 더 느린 응답속도를 보여줬다.
      - 그 이유는 성능이 향상되면서 더 많은 요청을 처리하기 때문에 excuteQuery 하는 과정이 시간이 더 늘어났다
      - 이유는 Context Switching 이라고 생각함
      - 또한 슬로우 쿼리 요청이 1대의 replica에 몰릴 수 있는 가능성이 있기 때문에 최악의 결과에서는 더 느린 응답 속도를 나타낸 것이라 보임
          - 이를 개선하기 위해서는 roundRobin 방식이 아니라, 응답 시간을 기준으로 트래픽을 로드 밸런싱 방법을 이용하면 될 것 같다.


### 주의사항
일반적으로 Connetor/J 를 사용해서 로드밸런싱을 구현할 수 있었지만, 기존에 있는 spirng boot 코드와 AtomicInteger를 사용해서 구현했다. 이유는 Connetor/J 의 장점이라고 할 수 있었던 failover에 대한 것이 실제로 상황을 구현했을 때 제대로 작동하지 않았다. (MariaDB Connector/J 를 활용해야만 가능하다고 하는 글이 있다. 그리고 mysql을 사용한다면, AWS aurora를 사용해야하는 것 같다.)
또한 Connector/J에서도 replicationProxy를 사용해서 로드밸런싱을 사용하는 것을 확인할 수 있었으나, 실제 내부적인 구현에 대한 파악이 어려웠으므로 직접 구현하는 방식을 선택했습니다.
직접 구현했을 때 단점은, 헬스 체크를 통한 failover 기능을 구현하기 어렵다는 것입니다.

