### PR TITLE
[Feature/BE] Github Actions 백엔드 CI 스크립트를 gradle-build-action을 통해 개선한다.

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -2,6 +2,9 @@ name: backend
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - issue887
   pull_request:
     branches:
       - main

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -33,7 +33,7 @@ jobs:
         uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
       
       - name: Build with Gradle
-        uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
+        uses: gradle/gradle-build-action@v2
         with:
           arguments: build
 #       - name: grant execute permission for gradlew

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -1,8 +1,6 @@
 name: backend
 
 on:
-  workflow_dispatch:
-
   pull_request:
     branches:
       - main

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -33,7 +33,9 @@ jobs:
         uses: gradle/wrapper-validation-action@v1
       
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2    
+        uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/release' && github.ref != 'refs/heads/issue887' }}
      
       - name: grant execute permission for gradlew
         run: chmod +x gradlew

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -30,18 +30,16 @@ jobs:
           distribution: 'temurin'
 
       - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
+        uses: gradle/wrapper-validation-action@v1
       
-      - name: Build with Gradle
-        uses: gradle/gradle-build-action@v2
-        with:
-          gradle-version: wrapper
-          arguments: build
-#       - name: grant execute permission for gradlew
-#         run: chmod +x gradlew
-
-#       - name: gradle build
-#         run: ./gradlew build
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2    
+     
+      - name: grant execute permission for gradlew
+        run: chmod +x gradlew
+      
+      - name: Execute Gradle build
+        run: ./gradlew build
 
       - name: add comments to a pull request
         uses: mikepenz/action-junit-report@v3

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -1,6 +1,7 @@
 name: backend
 
 on:
+  workflow_dispatch:
   pull_request:
     branches:
       - main

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -25,11 +25,18 @@ jobs:
           java-version: '11'
           distribution: 'temurin'
 
-      - name: grant execute permission for gradlew
-        run: chmod +x gradlew
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
+      
+      - name: Build with Gradle
+        uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
+        with:
+          arguments: build
+#       - name: grant execute permission for gradlew
+#         run: chmod +x gradlew
 
-      - name: gradle build
-        run: ./gradlew build
+#       - name: gradle build
+#         run: ./gradlew build
 
       - name: add comments to a pull request
         uses: mikepenz/action-junit-report@v3

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -1,6 +1,8 @@
 name: backend
 
 on:
+  workflow_dispatch:
+
   pull_request:
     branches:
       - main

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -2,9 +2,6 @@ name: backend
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - issue887
   pull_request:
     branches:
       - main
@@ -35,7 +32,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
         with:
-          cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/release' && github.ref != 'refs/heads/issue887' }}
+          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
      
       - name: grant execute permission for gradlew
         run: chmod +x gradlew

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2
         with:
+          gradle-version: wrapper
           arguments: build
 #       - name: grant execute permission for gradlew
 #         run: chmod +x gradlew


### PR DESCRIPTION
# issue: #887 

# 작업 내용
1. gradle-build-action 을 활용해서 의존성 등을 caching 하도록 설정
2. main 브랜치가 아닌 경우는 cach-readonly 되도록 설정 (Github Actions runner의 저장 메모리를 효율적으로 활용하기 위함)
3. 기존 속도보다 30초 가량 빨라진다. (1분 53초 -> 1분 21초)
4. 다만 처음 캐싱하는 경우는 속도가 기존보다 느렸다. (2분 20초 가량)